### PR TITLE
refactor: extract SidebarSelection and ServerStatusView

### DIFF
--- a/apps/mac-client/SuperPickyApp/ServerStatusView.swift
+++ b/apps/mac-client/SuperPickyApp/ServerStatusView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct ServerStatusView: View {
+    @Environment(ProcessManager.self) private var processManager
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(processManager.isReady ? .green : (processManager.isRunning ? .orange : .red))
+                .frame(width: 8, height: 8)
+
+            Text(statusText)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+        .accessibilityIdentifier("ServerStatus")
+    }
+
+    private var statusText: String {
+        if processManager.isReady {
+            return "Models ready"
+        } else if processManager.isRunning {
+            return "Loading models..."
+        } else {
+            return "Server offline"
+        }
+    }
+}

--- a/apps/mac-client/SuperPickyApp/SidebarSelection.swift
+++ b/apps/mac-client/SuperPickyApp/SidebarSelection.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum SidebarSelection: Hashable {
+    case folder(URL)
+    case rating(Int)
+    case flying
+    case picks
+    case species(String)
+    case burstGroup(UUID)
+}

--- a/apps/mac-client/SuperPickyApp/SourceListView.swift
+++ b/apps/mac-client/SuperPickyApp/SourceListView.swift
@@ -1,14 +1,5 @@
 import SwiftUI
 
-enum SidebarSelection: Hashable {
-    case folder(URL)
-    case rating(Int)
-    case flying
-    case picks
-    case species(String)
-    case burstGroup(UUID)
-}
-
 struct SourceListView: View {
     @Binding var selection: SidebarSelection?
     @Binding var folders: [URL]
@@ -18,7 +9,6 @@ struct SourceListView: View {
     let speciesEntries: [SpeciesEntry]
     let processingFolder: URL?
     let processingProgress: Double
-    @Environment(ProcessManager.self) private var processManager
 
     let onAddFolder: () -> Void
     let onRemoveFolder: (URL) -> Void
@@ -241,31 +231,3 @@ struct FolderRow: View {
     }
 }
 
-struct ServerStatusView: View {
-    @Environment(ProcessManager.self) private var processManager
-
-    var body: some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(processManager.isReady ? .green : (processManager.isRunning ? .orange : .red))
-                .frame(width: 8, height: 8)
-
-            Text(statusText)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-
-            Spacer()
-        }
-        .accessibilityIdentifier("ServerStatus")
-    }
-
-    private var statusText: String {
-        if processManager.isReady {
-            return "Models ready"
-        } else if processManager.isRunning {
-            return "Loading models..."
-        } else {
-            return "Server offline"
-        }
-    }
-}


### PR DESCRIPTION
## Summary
- Move `SidebarSelection` enum out of `SourceListView.swift` into its own `SidebarSelection.swift` file for discoverability (it is referenced from `MainView.swift` via `AppState`).
- Move `ServerStatusView` struct out of the bottom of `SourceListView.swift` into its own `ServerStatusView.swift` file. It is self-contained and only used from the sidebar's `safeAreaInset`.
- Drop a now-dead `@Environment(ProcessManager.self)` binding from `SourceListView` that was only relevant to the old in-file `ServerStatusView`.

Same Swift module, no import changes required at any call site. `SourceListView` is unchanged in name and call signature, so `MainView.swift` is untouched.

Note: instructions called for base branch `claude/refactor-codebase-kg8M6`, but that branch does not yet exist on the remote — targeting `main` instead.

## Verification
- Linux sandbox: no `swift` / `xcodebuild` available, so verification was source-review + grep only.
- `SidebarSelection` is referenced from `MainView.swift`, `SourceListView.swift`, and the new `SidebarSelection.swift` (3 files, as expected).
- `ServerStatusView` is referenced only from `SourceListView.swift` and the new `ServerStatusView.swift` (2 files, as expected).
- `Package.swift` auto-discovers `SuperPickyApp/*.swift`, so the new files are picked up automatically.
- `SuperPicky.xcodeproj` may need regeneration via `xcodegen` (`project.yml` is present in `apps/mac-client/`) so that the Xcode build sees the two new files. `xcodegen` is not available in this Linux sandbox.

## Test plan
- [ ] `cd apps/mac-client && swift build` succeeds on macOS.
- [ ] `cd apps/mac-client && swift test` passes.
- [ ] If using Xcode: regenerate the project (`cd apps/mac-client && xcodegen`) and confirm `SidebarSelection.swift` and `ServerStatusView.swift` are part of the `SuperPickyApp` target.
- [ ] Launch the app, confirm sidebar still renders folders / ratings / tags / species sections and the server-status footer at the bottom is unchanged.

https://claude.ai/code/session_01CNYDzahdBEWWLPGNToSSZf