### PR TITLE
refactor: extract ConfigurationStorage protocol from CullingConfig

### DIFF
--- a/apps/mac-client/SuperPickyApp/ConfigurationStorage.swift
+++ b/apps/mac-client/SuperPickyApp/ConfigurationStorage.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Abstraction over the key/value store used to persist `CullingConfig`.
+///
+/// The protocol surface intentionally mirrors only the accessors that
+/// `CullingConfig` needs today. When adding a new persisted property, extend
+/// this protocol (and `UserDefaultsStorage`) rather than reaching for
+/// `UserDefaults.standard` directly.
+protocol ConfigurationStorage: AnyObject, Sendable {
+    func bool(forKey key: String, default defaultValue: Bool) -> Bool
+    func float(forKey key: String, default defaultValue: Float) -> Float
+    func int(forKey key: String, default defaultValue: Int) -> Int
+    func string(forKey key: String, default defaultValue: String) -> String
+
+    func set(_ value: Bool, forKey key: String)
+    func set(_ value: Float, forKey key: String)
+    func set(_ value: Int, forKey key: String)
+    func set(_ value: String, forKey key: String)
+}
+
+/// Default `ConfigurationStorage` backed by `UserDefaults`.
+///
+/// `UserDefaults` is documented as thread-safe but is not annotated
+/// `Sendable`, so this conformance is `@unchecked`.
+final class UserDefaultsStorage: ConfigurationStorage, @unchecked Sendable {
+    private let defaults: UserDefaults
+
+    init(_ defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func bool(forKey key: String, default defaultValue: Bool) -> Bool {
+        defaults.object(forKey: key) as? Bool ?? defaultValue
+    }
+
+    func float(forKey key: String, default defaultValue: Float) -> Float {
+        defaults.object(forKey: key) as? Float ?? defaultValue
+    }
+
+    func int(forKey key: String, default defaultValue: Int) -> Int {
+        defaults.object(forKey: key) as? Int ?? defaultValue
+    }
+
+    func string(forKey key: String, default defaultValue: String) -> String {
+        defaults.string(forKey: key) ?? defaultValue
+    }
+
+    func set(_ value: Bool, forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    func set(_ value: Float, forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    func set(_ value: Int, forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    func set(_ value: String, forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+}

--- a/apps/mac-client/SuperPickyApp/CullingConfig.swift
+++ b/apps/mac-client/SuperPickyApp/CullingConfig.swift
@@ -55,6 +55,8 @@ enum RawFormat: String, CaseIterable, Sendable {
 
 @MainActor @Observable
 final class CullingConfig {
+    @ObservationIgnored private let storage: ConfigurationStorage
+
     var skillLevel: SkillLevel {
         didSet {
             sharpnessThreshold = skillLevel.sharpnessThreshold
@@ -73,34 +75,33 @@ final class CullingConfig {
     var keywordFormat: String { didSet { save() } }
     var appTheme: AppTheme { didSet { save() } }
 
-    init() {
-        let defaults = UserDefaults.standard
-        let level = SkillLevel(rawValue: defaults.string(forKey: "skillLevel") ?? "") ?? .intermediate
+    init(storage: ConfigurationStorage = UserDefaultsStorage()) {
+        self.storage = storage
+        let level = SkillLevel(rawValue: storage.string(forKey: "skillLevel", default: "")) ?? .intermediate
         self.skillLevel = level
-        self.sharpnessThreshold = defaults.object(forKey: "sharpnessThreshold") as? Float ?? level.sharpnessThreshold
-        self.aestheticsThreshold = defaults.object(forKey: "aestheticsThreshold") as? Float ?? level.aestheticsThreshold
-        self.exposureDetectionEnabled = defaults.object(forKey: "exposureDetectionEnabled") as? Bool ?? true
-        self.exposureThreshold = defaults.object(forKey: "exposureThreshold") as? Float ?? 0.10
-        self.burstDetectionEnabled = defaults.object(forKey: "burstDetectionEnabled") as? Bool ?? true
-        self.namingStandard = NamingStandard(rawValue: defaults.string(forKey: "namingStandard") ?? "") ?? .osea
-        self.backendPort = defaults.object(forKey: "backendPort") as? Int ?? 8420
-        self.writeKeywords = defaults.object(forKey: "writeKeywords") as? Bool ?? true
-        self.keywordFormat = defaults.string(forKey: "keywordFormat") ?? "{cn} {en} {pinyin}"
-        self.appTheme = AppTheme(rawValue: defaults.string(forKey: "appTheme") ?? "") ?? .dark
+        self.sharpnessThreshold = storage.float(forKey: "sharpnessThreshold", default: level.sharpnessThreshold)
+        self.aestheticsThreshold = storage.float(forKey: "aestheticsThreshold", default: level.aestheticsThreshold)
+        self.exposureDetectionEnabled = storage.bool(forKey: "exposureDetectionEnabled", default: true)
+        self.exposureThreshold = storage.float(forKey: "exposureThreshold", default: 0.10)
+        self.burstDetectionEnabled = storage.bool(forKey: "burstDetectionEnabled", default: true)
+        self.namingStandard = NamingStandard(rawValue: storage.string(forKey: "namingStandard", default: "")) ?? .osea
+        self.backendPort = storage.int(forKey: "backendPort", default: 8420)
+        self.writeKeywords = storage.bool(forKey: "writeKeywords", default: true)
+        self.keywordFormat = storage.string(forKey: "keywordFormat", default: "{cn} {en} {pinyin}")
+        self.appTheme = AppTheme(rawValue: storage.string(forKey: "appTheme", default: "")) ?? .dark
     }
 
     private func save() {
-        let defaults = UserDefaults.standard
-        defaults.set(skillLevel.rawValue, forKey: "skillLevel")
-        defaults.set(sharpnessThreshold, forKey: "sharpnessThreshold")
-        defaults.set(aestheticsThreshold, forKey: "aestheticsThreshold")
-        defaults.set(exposureDetectionEnabled, forKey: "exposureDetectionEnabled")
-        defaults.set(exposureThreshold, forKey: "exposureThreshold")
-        defaults.set(burstDetectionEnabled, forKey: "burstDetectionEnabled")
-        defaults.set(namingStandard.rawValue, forKey: "namingStandard")
-        defaults.set(backendPort, forKey: "backendPort")
-        defaults.set(writeKeywords, forKey: "writeKeywords")
-        defaults.set(keywordFormat, forKey: "keywordFormat")
-        defaults.set(appTheme.rawValue, forKey: "appTheme")
+        storage.set(skillLevel.rawValue, forKey: "skillLevel")
+        storage.set(sharpnessThreshold, forKey: "sharpnessThreshold")
+        storage.set(aestheticsThreshold, forKey: "aestheticsThreshold")
+        storage.set(exposureDetectionEnabled, forKey: "exposureDetectionEnabled")
+        storage.set(exposureThreshold, forKey: "exposureThreshold")
+        storage.set(burstDetectionEnabled, forKey: "burstDetectionEnabled")
+        storage.set(namingStandard.rawValue, forKey: "namingStandard")
+        storage.set(backendPort, forKey: "backendPort")
+        storage.set(writeKeywords, forKey: "writeKeywords")
+        storage.set(keywordFormat, forKey: "keywordFormat")
+        storage.set(appTheme.rawValue, forKey: "appTheme")
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `ConfigurationStorage` protocol (with `UserDefaultsStorage` default impl) so `CullingConfig` no longer reaches into `UserDefaults.standard` directly.
- `CullingConfig.init` now takes `storage: ConfigurationStorage = UserDefaultsStorage()`, so existing call sites (`CullingConfig()`) remain valid and tests can inject an in-memory fake.
- All persisted keys, types, and default values are preserved exactly; `@MainActor @Observable` and the synchronous `didSet` save behavior are unchanged.

## Notes
- New file is auto-discovered by `Package.swift` (`SuperPickyApp/*.swift`). `SuperPicky.xcodeproj` may need xcodegen regeneration to pick up `ConfigurationStorage.swift`.
- `UserDefaultsStorage` is `@unchecked Sendable` because `UserDefaults` is documented thread-safe but not annotated `Sendable`.
- Protocol surface is intentionally minimal (`bool`/`float`/`int`/`string` only — what `CullingConfig` actually persists). Float (not Double) accessors match the existing property types.
- No debouncing/async save loop added per task instructions.
- Targeting `main` because the requested base `claude/refactor-codebase-kg8M6` does not exist on the remote.

## Test plan
- [ ] `swift build` (Linux sandbox cannot run Swift toolchain — verified via source review + grep instead)
- [ ] `swift test` covering `CullingConfig` round-trip with an in-memory `ConfigurationStorage` fake
- [ ] Manual: launch app, change a setting, relaunch, confirm setting persisted (no key migration)

https://claude.ai/code/session_01CNYDzahdBEWWLPGNToSSZf