### PR TITLE
refactor: extract shared AsyncImageLoader

### DIFF
--- a/apps/mac-client/SuperPickyApp/AsyncImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/AsyncImageLoader.swift
@@ -1,0 +1,71 @@
+import Foundation
+import AppKit
+import ImageIO
+
+/// Shared async image-loading utility used by `PreviewView` and `FullscreenViewer`.
+///
+/// Both call sites previously duplicated the same `CGImageSource` thumbnail
+/// pipeline. This namespace preserves that exact pipeline and exposes it as a
+/// single entry point parameterized by the target pixel size.
+enum AsyncImageLoader {
+    /// Target size presets for the two existing call sites.
+    ///
+    /// - `preview`  : ~2000 px max, prefers the embedded preview when present
+    ///                (fast for RAW — avoids a full decode).
+    /// - `fullscreen`: ~4000 px max, always decodes from the image itself.
+    enum Size {
+        case preview
+        case fullscreen
+
+        fileprivate var maxPixelSize: Int {
+            switch self {
+            case .preview: return 2000
+            case .fullscreen: return 4000
+            }
+        }
+
+        /// Whether to force a thumbnail decode from the full image even if an
+        /// embedded preview is available. `fullscreen` always decodes so the
+        /// zoomed view gets full resolution; `preview` is allowed to use the
+        /// embedded thumbnail for speed.
+        fileprivate var alwaysFromImage: Bool {
+            switch self {
+            case .preview: return false
+            case .fullscreen: return true
+            }
+        }
+    }
+
+    /// Decodes the image at `filePath` to an `NSImage` sized for `size`.
+    ///
+    /// Returns `nil` if the file is missing or the image source cannot be
+    /// decoded. Runs the `CGImageSource` work on a background queue.
+    static func load(filePath: String, size: Size) async -> NSImage? {
+        let url = URL(fileURLWithPath: filePath)
+        guard FileManager.default.fileExists(atPath: filePath) else { return nil }
+
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                var options: [CFString: Any] = [
+                    kCGImageSourceThumbnailMaxPixelSize: size.maxPixelSize,
+                    kCGImageSourceCreateThumbnailWithTransform: true,
+                ]
+                if size.alwaysFromImage {
+                    options[kCGImageSourceCreateThumbnailFromImageAlways] = true
+                } else {
+                    options[kCGImageSourceCreateThumbnailFromImageIfAbsent] = true
+                }
+                guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+                continuation.resume(returning: nsImage)
+            }
+        }
+    }
+}

--- a/apps/mac-client/SuperPickyApp/FullscreenViewer.swift
+++ b/apps/mac-client/SuperPickyApp/FullscreenViewer.swift
@@ -41,7 +41,7 @@ struct FullscreenViewer: View {
             image = nil
             zoomState.reset()
             guard let photo = selectedPhoto else { return }
-            image = await loadFullscreenImage(path: photo.filePath)
+            image = await AsyncImageLoader.load(filePath: photo.filePath, size: .fullscreen)
         }
     }
 
@@ -61,30 +61,5 @@ struct FullscreenViewer: View {
     private func rateSelected(_ rating: Int) {
         guard let id = selectedPhotoID else { return }
         onRatePhoto?(id, rating)
-    }
-
-    private func loadFullscreenImage(path: String) async -> NSImage? {
-        let url = URL(fileURLWithPath: path)
-        guard FileManager.default.fileExists(atPath: path) else { return nil }
-        return await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                // Full resolution for fullscreen
-                let options: [CFString: Any] = [
-                    kCGImageSourceCreateThumbnailFromImageAlways: true,
-                    kCGImageSourceCreateThumbnailWithTransform: true,
-                    kCGImageSourceThumbnailMaxPixelSize: 4000,
-                ]
-                guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-                continuation.resume(returning: nsImage)
-            }
-        }
     }
 }

--- a/apps/mac-client/SuperPickyApp/PreviewView.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewView.swift
@@ -50,34 +50,8 @@ struct AsyncPreviewImage: View {
         }
         .task(id: filePath) {
             // Keep old image visible until new one loads (no white flash)
-            let newImage = await loadImage()
+            let newImage = await AsyncImageLoader.load(filePath: filePath, size: .preview)
             image = newImage
-        }
-    }
-
-    private func loadImage() async -> NSImage? {
-        let url = URL(fileURLWithPath: filePath)
-        guard FileManager.default.fileExists(atPath: filePath) else { return nil }
-
-        return await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                // Extract embedded preview (fast for RAW — no full decode)
-                let options: [CFString: Any] = [
-                    kCGImageSourceThumbnailMaxPixelSize: 2000,
-                    kCGImageSourceCreateThumbnailFromImageIfAbsent: true,
-                    kCGImageSourceCreateThumbnailWithTransform: true,
-                ]
-                guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-                continuation.resume(returning: nsImage)
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extract the duplicated `CGImageSource` async image loader from `PreviewView.swift` and `FullscreenViewer.swift` into a new `AsyncImageLoader` namespace.
- `AsyncImageLoader.Size` presets (`.preview` = 2000 px, prefer embedded preview; `.fullscreen` = 4000 px, always decode from image) preserve the exact pixel sizes and ImageIO option flags the two call sites used before.
- Decode pipeline (`CGImageSourceCreateWithURL` -> `CGImageSourceCreateThumbnailAtIndex` -> `NSImage(cgImage:size:)` on `DispatchQueue.global(qos: .userInitiated)` inside `withCheckedContinuation`) is preserved verbatim - only shared, not swapped.
- Pure utility: `Foundation` + `AppKit` + `ImageIO` only, no SwiftUI import. Implemented as a caseless `enum` namespace per the codebase convention.

Note: intended PR base was `claude/refactor-codebase-kg8M6` per the worker instructions, but that branch does not exist on origin - targeting `main` instead.

## Test plan
- [ ] `cd apps/mac-client && swift build` (Swift toolchain unavailable in Linux sandbox - needs verification on macOS)
- [ ] `cd apps/mac-client && swift test`
- [ ] Manual: open a folder, select a RAW and a JPEG, verify preview loads at ~2000 px and fullscreen (F) loads at ~4000 px with no regression in load speed or zoom quality
- [ ] If `SuperPicky.xcodeproj` was generated, regenerate with xcodegen so `AsyncImageLoader.swift` is picked up (Package.swift auto-discovers it)

https://claude.ai/code/session_01CNYDzahdBEWWLPGNToSSZf