### PR TITLE
refactor: extract ExifFormatters and FlowLayout from ExifPanelView

### DIFF
--- a/apps/mac-client/SuperPickyApp/ExifFormatters.swift
+++ b/apps/mac-client/SuperPickyApp/ExifFormatters.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Pure-string formatting helpers for displaying EXIF metadata.
+/// Kept free of SwiftUI so it can be unit-tested and reused outside views.
+enum ExifFormatters {
+    /// Renders a Double as an integer when whole, otherwise with one decimal place.
+    static func formatNumber(_ value: Double) -> String {
+        if value == value.rounded() {
+            return "\(Int(value))"
+        }
+        return String(format: "%.1f", value)
+    }
+
+    /// Combines shutter speed, aperture, and ISO Lightroom-style: "1/2000 at f/6.3, ISO 1600".
+    static func formatExposure(_ data: EXIFData) -> String {
+        var parts: [String] = []
+        if let shutter = data.exposure.shutterSpeed { parts.append(shutter) }
+        if let aperture = data.exposure.aperture { parts.append("f/\(formatNumber(aperture))") }
+        if let iso = data.exposure.iso { parts.append("ISO \(iso)") }
+        if parts.isEmpty { return "—" }
+        if data.exposure.shutterSpeed != nil, data.exposure.aperture != nil {
+            let shutter = parts.removeFirst()
+            let aperture = parts.removeFirst()
+            var result = "\(shutter) at \(aperture)"
+            if !parts.isEmpty { result += ", \(parts.joined(separator: ", "))" }
+            return result
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    /// Converts a raw EXIF date string ("2025:03:15 07:30:22") to "Mar 15, 2025  07:30".
+    static func formatDate(_ raw: String) -> String {
+        let parts = raw.split(separator: " ")
+        guard let datePart = parts.first else { return raw }
+        let dateComponents = datePart.split(separator: ":")
+        guard dateComponents.count == 3,
+              let year = Int(dateComponents[0]),
+              let month = Int(dateComponents[1]),
+              let day = Int(dateComponents[2]) else { return raw }
+
+        let months = ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+        let monthName = month >= 1 && month <= 12 ? months[month] : "\(month)"
+
+        var result = "\(monthName) \(day), \(year)"
+        if parts.count > 1 {
+            let timeParts = parts[1].split(separator: ":")
+            if timeParts.count >= 2 {
+                result += "  \(timeParts[0]):\(timeParts[1])"
+            }
+        }
+        return result
+    }
+
+    /// Joins city/state/country into a single comma-separated location string.
+    static func formatLocation(_ data: EXIFData) -> String? {
+        let parts = [data.location.city, data.location.state, data.location.country].compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+
+    /// Formats GPS coordinates with hemisphere suffixes: "37.7749° N, 122.4194° W".
+    static func formatCoordinates(_ data: EXIFData) -> String? {
+        guard let lat = data.location.latitude, let lon = data.location.longitude else { return nil }
+        let latDir = lat >= 0 ? "N" : "S"
+        let lonDir = lon >= 0 ? "E" : "W"
+        return String(format: "%.4f\u{00B0} %@, %.4f\u{00B0} %@",
+                      abs(lat), latDir, abs(lon), lonDir)
+    }
+}

--- a/apps/mac-client/SuperPickyApp/ExifPanelView.swift
+++ b/apps/mac-client/SuperPickyApp/ExifPanelView.swift
@@ -31,13 +31,13 @@ struct ExifPanelView: View {
                     if data.exposure.focalLength != nil || data.exposure.aperture != nil || data.exposure.shutterSpeed != nil || data.exposure.iso != nil {
                         sectionHeader("Exposure")
                         if let focal = data.exposure.focalLength {
-                            exifRow(label: "Focal Length", value: "\(formatNumber(focal)) mm")
+                            exifRow(label: "Focal Length", value: "\(ExifFormatters.formatNumber(focal)) mm")
                         }
                         // Combine exposure like Lightroom: "1/2000 at f/6.3, ISO 1600"
-                        exifRow(label: "Exposure", value: formatExposure(data))
+                        exifRow(label: "Exposure", value: ExifFormatters.formatExposure(data))
                         if let bias = data.exposure.exposureBias, bias != 0 {
                             let sign = bias >= 0 ? "+" : ""
-                            exifRow(label: "Exp Comp", value: "\(sign)\(formatNumber(bias)) EV")
+                            exifRow(label: "Exp Comp", value: "\(sign)\(ExifFormatters.formatNumber(bias)) EV")
                         }
                         if let metering = data.exposure.meteringMode {
                             exifRow(label: "Metering", value: metering)
@@ -51,7 +51,7 @@ struct ExifPanelView: View {
                     if data.image.width != nil || data.image.dateTimeOriginal != nil {
                         sectionHeader("Image")
                         if let date = data.image.dateTimeOriginal {
-                            exifRow(label: "Capture Date", value: formatDate(date))
+                            exifRow(label: "Capture Date", value: ExifFormatters.formatDate(date))
                         }
                         if let w = data.image.width, let h = data.image.height {
                             exifRow(label: "Dimensions", value: "\(w) \u{00D7} \(h)")
@@ -61,7 +61,7 @@ struct ExifPanelView: View {
                     // Location section
                     if data.location.latitude != nil || data.location.city != nil {
                         sectionHeader("Location")
-                        if let place = formatLocation(data) {
+                        if let place = ExifFormatters.formatLocation(data) {
                             exifRow(label: "Place", value: place)
                         }
                         if let lat = data.location.latitude, let lon = data.location.longitude {
@@ -71,12 +71,12 @@ struct ExifPanelView: View {
                                     .foregroundStyle(.secondary)
                                     .frame(width: labelWidth, alignment: .trailing)
                                     .lineLimit(1)
-                                Text(formatCoordinates(data) ?? "")
+                                Text(ExifFormatters.formatCoordinates(data) ?? "")
                                     .font(.system(size: 12))
                                     .foregroundStyle(.primary)
                                     .accessibilityIdentifier("Exif_GPS")
                                 Button {
-                                    let label = formatLocation(data) ?? "Photo Location"
+                                    let label = ExifFormatters.formatLocation(data) ?? "Photo Location"
                                     let url = URL(string: "https://maps.apple.com/?ll=\(lat),\(lon)&q=\(label.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "Photo")&z=14")!
                                     NSWorkspace.shared.open(url)
                                 } label: {
@@ -179,113 +179,5 @@ struct ExifPanelView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 3)
-    }
-
-    // MARK: - Formatters
-
-    private func formatNumber(_ value: Double) -> String {
-        if value == value.rounded() {
-            return "\(Int(value))"
-        }
-        return String(format: "%.1f", value)
-    }
-
-    private func formatExposure(_ data: EXIFData) -> String {
-        var parts: [String] = []
-        if let shutter = data.exposure.shutterSpeed { parts.append(shutter) }
-        if let aperture = data.exposure.aperture { parts.append("f/\(formatNumber(aperture))") }
-        if let iso = data.exposure.iso { parts.append("ISO \(iso)") }
-        if parts.isEmpty { return "—" }
-        // "1/2000 at f/6.3, ISO 1600"
-        if parts.count >= 2, data.exposure.shutterSpeed != nil, data.exposure.aperture != nil {
-            let shutter = parts.removeFirst()
-            let aperture = parts.removeFirst()
-            var result = "\(shutter) at \(aperture)"
-            if !parts.isEmpty { result += ", \(parts.joined(separator: ", "))" }
-            return result
-        }
-        return parts.joined(separator: ", ")
-    }
-
-    private func formatDate(_ raw: String) -> String {
-        // "2025:03:15 07:30:22" → "Mar 15, 2025  07:30"
-        let parts = raw.split(separator: " ")
-        guard let datePart = parts.first else { return raw }
-        let dateComponents = datePart.split(separator: ":")
-        guard dateComponents.count == 3,
-              let year = Int(dateComponents[0]),
-              let month = Int(dateComponents[1]),
-              let day = Int(dateComponents[2]) else { return raw }
-
-        let months = ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-        let monthName = month >= 1 && month <= 12 ? months[month] : "\(month)"
-
-        var result = "\(monthName) \(day), \(year)"
-        if parts.count > 1 {
-            let time = String(parts[1])
-            // Drop seconds: "07:30:22" → "07:30"
-            let timeParts = time.split(separator: ":")
-            if timeParts.count >= 2 {
-                result += "  \(timeParts[0]):\(timeParts[1])"
-            }
-        }
-        return result
-    }
-
-    private func formatLocation(_ data: EXIFData) -> String? {
-        let parts = [data.location.city, data.location.state, data.location.country].compactMap { $0 }
-        return parts.isEmpty ? nil : parts.joined(separator: ", ")
-    }
-
-    private func formatCoordinates(_ data: EXIFData) -> String? {
-        guard let lat = data.location.latitude, let lon = data.location.longitude else { return nil }
-        let latDir = lat >= 0 ? "N" : "S"
-        let lonDir = lon >= 0 ? "E" : "W"
-        return String(format: "%.4f\u{00B0} %@, %.4f\u{00B0} %@",
-                      abs(lat), latDir, abs(lon), lonDir)
-    }
-}
-
-// MARK: - FlowLayout for keyword tags
-
-struct FlowLayout: Layout {
-    var spacing: CGFloat = 4
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let result = arrange(proposal: proposal, subviews: subviews)
-        return result.size
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let result = arrange(proposal: proposal, subviews: subviews)
-        for (index, offset) in result.offsets.enumerated() {
-            subviews[index].place(at: CGPoint(x: bounds.minX + offset.x, y: bounds.minY + offset.y),
-                                   proposal: .unspecified)
-        }
-    }
-
-    private func arrange(proposal: ProposedViewSize, subviews: Subviews) -> (offsets: [CGPoint], size: CGSize) {
-        let maxWidth = proposal.width ?? .infinity
-        var offsets: [CGPoint] = []
-        var x: CGFloat = 0
-        var y: CGFloat = 0
-        var rowHeight: CGFloat = 0
-        var maxX: CGFloat = 0
-
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            if x + size.width > maxWidth && x > 0 {
-                x = 0
-                y += rowHeight + spacing
-                rowHeight = 0
-            }
-            offsets.append(CGPoint(x: x, y: y))
-            rowHeight = max(rowHeight, size.height)
-            x += size.width + spacing
-            maxX = max(maxX, x)
-        }
-
-        return (offsets, CGSize(width: maxX, height: y + rowHeight))
     }
 }

--- a/apps/mac-client/SuperPickyApp/FlowLayout.swift
+++ b/apps/mac-client/SuperPickyApp/FlowLayout.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Lays out subviews left-to-right, wrapping to a new row when the proposed width is exceeded.
+/// Used by `ExifPanelView` for keyword chips.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 4
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        return result.size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        for (index, offset) in result.offsets.enumerated() {
+            subviews[index].place(at: CGPoint(x: bounds.minX + offset.x, y: bounds.minY + offset.y),
+                                   proposal: .unspecified)
+        }
+    }
+
+    private func arrange(proposal: ProposedViewSize, subviews: Subviews) -> (offsets: [CGPoint], size: CGSize) {
+        let maxWidth = proposal.width ?? .infinity
+        var offsets: [CGPoint] = []
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var maxX: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth && x > 0 {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            offsets.append(CGPoint(x: x, y: y))
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + spacing
+            maxX = max(maxX, x)
+        }
+
+        return (offsets, CGSize(width: maxX, height: y + rowHeight))
+    }
+}

--- a/apps/mac-client/SuperPickyTests/Core/ExifFormattersTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/ExifFormattersTests.swift
@@ -1,0 +1,105 @@
+import Testing
+import Foundation
+@testable import SuperPicky
+
+@Suite struct ExifFormattersTests {
+
+    // MARK: - formatNumber
+
+    @Test func formatNumberRendersWholeValueAsInt() {
+        #expect(ExifFormatters.formatNumber(400.0) == "400")
+        #expect(ExifFormatters.formatNumber(0.0) == "0")
+        #expect(ExifFormatters.formatNumber(-3.0) == "-3")
+    }
+
+    @Test func formatNumberRendersFractionalWithOneDecimal() {
+        #expect(ExifFormatters.formatNumber(6.3) == "6.3")
+        #expect(ExifFormatters.formatNumber(1.75) == "1.8")
+    }
+
+    // MARK: - formatExposure
+
+    @Test func formatExposureCombinesShutterApertureAndIso() {
+        var data = EXIFData()
+        data.exposure.shutterSpeed = "1/2000"
+        data.exposure.aperture = 6.3
+        data.exposure.iso = 1600
+        #expect(ExifFormatters.formatExposure(data) == "1/2000 at f/6.3, ISO 1600")
+    }
+
+    @Test func formatExposureWithOnlyShutter() {
+        var data = EXIFData()
+        data.exposure.shutterSpeed = "1/500"
+        #expect(ExifFormatters.formatExposure(data) == "1/500")
+    }
+
+    @Test func formatExposureWithApertureAndIsoOnly() {
+        var data = EXIFData()
+        data.exposure.aperture = 2.8
+        data.exposure.iso = 100
+        #expect(ExifFormatters.formatExposure(data) == "f/2.8, ISO 100")
+    }
+
+    @Test func formatExposureFallsBackToEmDashWhenAllNil() {
+        let data = EXIFData()
+        #expect(ExifFormatters.formatExposure(data) == "—")
+    }
+
+    // MARK: - formatDate
+
+    @Test func formatDateConvertsExifFormatToHumanReadable() {
+        #expect(ExifFormatters.formatDate("2025:03:15 07:30:22") == "Mar 15, 2025  07:30")
+    }
+
+    @Test func formatDateHandlesDateOnly() {
+        #expect(ExifFormatters.formatDate("2024:12:01") == "Dec 1, 2024")
+    }
+
+    @Test func formatDateReturnsRawWhenUnparseable() {
+        #expect(ExifFormatters.formatDate("not a date") == "not a date")
+    }
+
+    // MARK: - formatLocation
+
+    @Test func formatLocationJoinsAvailableParts() {
+        var data = EXIFData()
+        data.location.city = "San Francisco"
+        data.location.state = "CA"
+        data.location.country = "USA"
+        #expect(ExifFormatters.formatLocation(data) == "San Francisco, CA, USA")
+    }
+
+    @Test func formatLocationSkipsMissingParts() {
+        var data = EXIFData()
+        data.location.city = "Tokyo"
+        data.location.country = "Japan"
+        #expect(ExifFormatters.formatLocation(data) == "Tokyo, Japan")
+    }
+
+    @Test func formatLocationReturnsNilWhenAllPartsMissing() {
+        let data = EXIFData()
+        #expect(ExifFormatters.formatLocation(data) == nil)
+    }
+
+    // MARK: - formatCoordinates
+
+    @Test func formatCoordinatesUsesNorthEastForPositive() {
+        var data = EXIFData()
+        data.location.latitude = 37.7749
+        data.location.longitude = 122.4194
+        #expect(ExifFormatters.formatCoordinates(data) == "37.7749\u{00B0} N, 122.4194\u{00B0} E")
+    }
+
+    @Test func formatCoordinatesUsesSouthWestForNegative() {
+        var data = EXIFData()
+        data.location.latitude = -33.8688
+        data.location.longitude = -151.2093
+        #expect(ExifFormatters.formatCoordinates(data) == "33.8688\u{00B0} S, 151.2093\u{00B0} W")
+    }
+
+    @Test func formatCoordinatesReturnsNilWithoutBothValues() {
+        var data = EXIFData()
+        data.location.latitude = 10.0
+        #expect(ExifFormatters.formatCoordinates(data) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

`ExifPanelView.swift` (291 lines) mixed three responsibilities — the SwiftUI view, a half-dozen string formatters, and a generic `FlowLayout`. This PR splits each into its own file so the formatters become unit-testable in isolation and `FlowLayout` can be reused without dragging the view along.

- **`ExifFormatters.swift`** — new `enum ExifFormatters` namespace (Foundation-only, no SwiftUI) holding `formatNumber`, `formatExposure`, `formatDate`, `formatLocation`, `formatCoordinates`. All call sites in `ExifPanelView` were updated to `ExifFormatters.formatX(...)`.
- **`FlowLayout.swift`** — the keyword-chip `Layout` struct, moved verbatim.
- **`ExifPanelView.swift`** — now just the view (`sectionHeader`, `exifRow`, `body`); shrinks from 291 to ~180 lines.
- **`ExifFormattersTests.swift`** — new Swift Testing suite covering all five formatters (whole/fractional numbers, full/partial exposure combinations, EXIF date parsing edge cases, location joining, GPS hemispheres).

While extracting, two trivial cleanups were applied to the formatters:
- `formatExposure`: dropped a redundant `parts.count >= 2` guard that's already implied by both `shutterSpeed != nil` and `aperture != nil`.
- `formatDate`: removed an unused intermediate `String(parts[1])` and a narrative comment.

Behavior is otherwise unchanged.

## Notes for reviewer

- `xcodegen` is not available in this Linux sandbox — **the new `.swift` files need to be added to `SuperPicky.xcodeproj` by re-running `xcodegen` locally** before the next Xcode build. Swift Package Manager (`Package.swift`) auto-discovers them and needs no changes.
- Swift toolchain is unavailable in this sandbox, so changes were verified by source review and grep (no bare `formatNumber/formatExposure/formatDate/formatLocation/formatCoordinates` references remain outside `ExifFormatters.swift`).

## Test plan

- [ ] `cd apps/mac-client && swift build`
- [ ] `cd apps/mac-client && swift test --filter ExifFormattersTests`
- [ ] Open the EXIF panel on a photo with full metadata (camera, lens, exposure, GPS, keywords) and confirm camera, exposure (`1/2000 at f/6.3, ISO 1600`-style), date (`Mar 15, 2025  07:30`), GPS (`37.7749° N, 122.4194° W`), and keyword chips render identically to before.
- [ ] Open the EXIF panel on a photo with partial metadata (e.g. no GPS, no keywords) and confirm sections collapse correctly.
- [ ] Re-run `xcodegen` so the new files appear in `SuperPicky.xcodeproj`.

https://claude.ai/code/session_01CNYDzahdBEWWLPGNToSSZf