### PR TITLE
refactor: split BurstDetector into named phases

### DIFF
--- a/apps/mac-client/SuperPickyApp/BurstDetectionPhases.swift
+++ b/apps/mac-client/SuperPickyApp/BurstDetectionPhases.swift
@@ -1,0 +1,178 @@
+import Foundation
+import CoreGraphics
+import ImageIO
+import Vision
+
+/// Pure, stateless implementations of the four phases of burst detection.
+///
+/// Each phase is exposed as a caseless enum with static methods so it can be
+/// exercised in isolation. `BurstDetector` composes these phases; the algorithm,
+/// thresholds, and ordering rules live here.
+enum BurstDetectionPhases {
+
+    // MARK: - Phase 1: EXIF timestamp reading
+
+    enum Timestamps {
+        /// Read `DateTimeOriginal` + `SubSecTimeOriginal` from EXIF for millisecond precision.
+        static func readPrecise(filePath: String) -> Double? {
+            let url = URL(fileURLWithPath: filePath)
+            guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+                  let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
+                  let exif = properties["{Exif}"] as? [String: Any],
+                  let dateStr = exif["DateTimeOriginal"] as? String else {
+                return nil
+            }
+
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy:MM:dd HH:mm:ss"
+            formatter.timeZone = TimeZone.current
+
+            guard let date = formatter.date(from: dateStr) else { return nil }
+            var timestamp = date.timeIntervalSince1970
+
+            // Add subsecond precision if available
+            if let subsec = (exif["SubsecTimeOriginal"] ?? exif["SubSecTimeOriginal"]) as? String,
+               let subsecFloat = Double("0.\(subsec)") {
+                timestamp += subsecFloat
+            }
+
+            return timestamp
+        }
+
+        /// Build a timestamp-sorted list of photos, dropping any without readable EXIF.
+        static func collect(photos: [Photo]) -> [(Photo, Double)] {
+            photos.compactMap { photo -> (Photo, Double)? in
+                guard let ts = readPrecise(filePath: photo.filePath) else { return nil }
+                return (photo, ts)
+            }.sorted { $0.1 < $1.1 }
+        }
+    }
+
+    // MARK: - Phase 2: Time-based grouping
+
+    enum TimeGrouping {
+        /// Split a timestamp-sorted list into burst candidates using the time threshold.
+        static func group(
+            timestamped: [(Photo, Double)],
+            timeThresholdMs: Double,
+            minBurstCount: Int
+        ) -> [BurstGroup] {
+            guard !timestamped.isEmpty else { return [] }
+
+            var groups: [BurstGroup] = []
+            var currentPhotos: [Photo] = [timestamped[0].0]
+            var currentTimestamps: [Double] = [timestamped[0].1]
+
+            for i in 1..<timestamped.count {
+                let timeDiffMs = (timestamped[i].1 - currentTimestamps.last!) * 1000
+
+                if timeDiffMs <= timeThresholdMs {
+                    currentPhotos.append(timestamped[i].0)
+                    currentTimestamps.append(timestamped[i].1)
+                } else {
+                    if currentPhotos.count >= minBurstCount {
+                        groups.append(BurstGroup(
+                            id: UUID(),
+                            photos: currentPhotos,
+                            bestPhotoID: nil
+                        ))
+                    }
+                    currentPhotos = [timestamped[i].0]
+                    currentTimestamps = [timestamped[i].1]
+                }
+            }
+
+            // Don't forget the last group
+            if currentPhotos.count >= minBurstCount {
+                groups.append(BurstGroup(
+                    id: UUID(),
+                    photos: currentPhotos,
+                    bestPhotoID: nil
+                ))
+            }
+
+            return groups
+        }
+    }
+
+    // MARK: - Phase 3: Similarity verification
+
+    enum Similarity {
+        /// Subdivide a time-based group using Vision feature-print distance.
+        static func verify(
+            group: BurstGroup,
+            similarityThreshold: Float,
+            minBurstCount: Int
+        ) -> [BurstGroup] {
+            let photos = group.photos
+            guard photos.count >= 2 else { return [group] }
+
+            // Generate feature prints for all photos
+            var featurePrints: [VNFeaturePrintObservation?] = []
+            for photo in photos {
+                featurePrints.append(generateFeaturePrint(filePath: photo.filePath))
+            }
+
+            // Split groups where similarity breaks
+            var subGroups: [BurstGroup] = []
+            var currentPhotos: [Photo] = [photos[0]]
+
+            for i in 1..<photos.count {
+                let similar: Bool
+                if let fp1 = featurePrints[i - 1], let fp2 = featurePrints[i] {
+                    var distance: Float = 0
+                    try? fp1.computeDistance(&distance, to: fp2)
+                    similar = distance <= similarityThreshold
+                } else {
+                    similar = true // If we can't compute, assume similar (time-based grouping already filtered)
+                }
+
+                if similar {
+                    currentPhotos.append(photos[i])
+                } else {
+                    if currentPhotos.count >= minBurstCount {
+                        subGroups.append(BurstGroup(id: UUID(), photos: currentPhotos, bestPhotoID: nil))
+                    }
+                    currentPhotos = [photos[i]]
+                }
+            }
+
+            if currentPhotos.count >= minBurstCount {
+                subGroups.append(BurstGroup(id: UUID(), photos: currentPhotos, bestPhotoID: nil))
+            }
+
+            return subGroups
+        }
+
+        static func generateFeaturePrint(filePath: String) -> VNFeaturePrintObservation? {
+            let url = URL(fileURLWithPath: filePath)
+            guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+                  let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, [
+                      kCGImageSourceThumbnailMaxPixelSize: 256,
+                      kCGImageSourceCreateThumbnailFromImageAlways: true,
+                  ] as CFDictionary) else {
+                return nil
+            }
+
+            let request = VNGenerateImageFeaturePrintRequest()
+            let handler = VNImageRequestHandler(cgImage: cgImage)
+            try? handler.perform([request])
+            return request.results?.first as? VNFeaturePrintObservation
+        }
+    }
+
+    // MARK: - Phase 4: Best photo selection
+
+    enum BestSelection {
+        /// Select the best photo by combined sharpness + aesthetics score.
+        static func selectBest(in photos: [Photo]) -> UUID? {
+            photos.max(by: { score($0) < score($1) })?.id
+        }
+
+        static func score(_ photo: Photo) -> Float {
+            let sharpness = photo.sharpnessScore ?? 0
+            let aesthetics = photo.aestheticsScore ?? 0
+            return sharpness * 0.5 + aesthetics * 0.5
+        }
+    }
+}

--- a/apps/mac-client/SuperPickyApp/BurstDetector.swift
+++ b/apps/mac-client/SuperPickyApp/BurstDetector.swift
@@ -4,6 +4,12 @@ import ImageIO
 import Vision
 
 /// Detects burst sequences: consecutive similar photos taken within a time threshold.
+///
+/// The algorithm runs in four phases, each implemented in `BurstDetectionPhases`:
+/// 1. Read precise EXIF timestamps.
+/// 2. Group photos by time proximity.
+/// 3. Verify groupings with Vision feature-print similarity.
+/// 4. Select the best photo within each verified group.
 struct BurstDetector: Sendable {
     /// Time threshold in milliseconds — photos closer than this are burst candidates.
     let timeThresholdMs: Double
@@ -20,168 +26,35 @@ struct BurstDetector: Sendable {
 
     /// Detect burst groups from a list of photos (must have filePath and dateCreated).
     func detect(photos: [Photo]) -> [BurstGroup] {
-        // 1. Read precise timestamps from EXIF
-        let timestamped = photos.compactMap { photo -> (Photo, Double)? in
-            guard let ts = readPreciseTimestamp(filePath: photo.filePath) else { return nil }
-            return (photo, ts)
-        }.sorted { $0.1 < $1.1 }
-
+        let timestamped = BurstDetectionPhases.Timestamps.collect(photos: photos)
         guard timestamped.count >= minBurstCount else { return [] }
 
-        // 2. Group by time proximity
-        var timeGroups = groupByTime(timestamped)
+        let timeGroups = BurstDetectionPhases.TimeGrouping.group(
+            timestamped: timestamped,
+            timeThresholdMs: timeThresholdMs,
+            minBurstCount: minBurstCount
+        )
 
-        // 3. Verify with image similarity (Vision feature prints)
         var verifiedGroups: [BurstGroup] = []
         for group in timeGroups {
-            let verified = verifyWithSimilarity(group)
+            let verified = BurstDetectionPhases.Similarity.verify(
+                group: group,
+                similarityThreshold: similarityThreshold,
+                minBurstCount: minBurstCount
+            )
             verifiedGroups.append(contentsOf: verified)
         }
 
-        // 4. Select best photo per group
         return verifiedGroups.map { group in
             var g = group
-            g.bestPhotoID = selectBest(in: g.photos)
+            g.bestPhotoID = BurstDetectionPhases.BestSelection.selectBest(in: g.photos)
             return g
         }
     }
 
-    // MARK: - Phase 1: EXIF timestamp reading
-
     /// Read DateTimeOriginal + SubSecTimeOriginal from EXIF for millisecond precision.
     func readPreciseTimestamp(filePath: String) -> Double? {
-        let url = URL(fileURLWithPath: filePath)
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
-              let exif = properties["{Exif}"] as? [String: Any],
-              let dateStr = exif["DateTimeOriginal"] as? String else {
-            return nil
-        }
-
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy:MM:dd HH:mm:ss"
-        formatter.timeZone = TimeZone.current
-
-        guard let date = formatter.date(from: dateStr) else { return nil }
-        var timestamp = date.timeIntervalSince1970
-
-        // Add subsecond precision if available
-        if let subsec = (exif["SubsecTimeOriginal"] ?? exif["SubSecTimeOriginal"]) as? String,
-           let subsecFloat = Double("0.\(subsec)") {
-            timestamp += subsecFloat
-        }
-
-        return timestamp
-    }
-
-    // MARK: - Phase 2: Time-based grouping
-
-    private func groupByTime(_ timestamped: [(Photo, Double)]) -> [BurstGroup] {
-        var groups: [BurstGroup] = []
-        var currentPhotos: [Photo] = [timestamped[0].0]
-        var currentTimestamps: [Double] = [timestamped[0].1]
-
-        for i in 1..<timestamped.count {
-            let timeDiffMs = (timestamped[i].1 - currentTimestamps.last!) * 1000
-
-            if timeDiffMs <= timeThresholdMs {
-                currentPhotos.append(timestamped[i].0)
-                currentTimestamps.append(timestamped[i].1)
-            } else {
-                if currentPhotos.count >= minBurstCount {
-                    groups.append(BurstGroup(
-                        id: UUID(),
-                        photos: currentPhotos,
-                        bestPhotoID: nil
-                    ))
-                }
-                currentPhotos = [timestamped[i].0]
-                currentTimestamps = [timestamped[i].1]
-            }
-        }
-
-        // Don't forget the last group
-        if currentPhotos.count >= minBurstCount {
-            groups.append(BurstGroup(
-                id: UUID(),
-                photos: currentPhotos,
-                bestPhotoID: nil
-            ))
-        }
-
-        return groups
-    }
-
-    // MARK: - Phase 3: Similarity verification
-
-    private func verifyWithSimilarity(_ group: BurstGroup) -> [BurstGroup] {
-        let photos = group.photos
-        guard photos.count >= 2 else { return [group] }
-
-        // Generate feature prints for all photos
-        var featurePrints: [VNFeaturePrintObservation?] = []
-        for photo in photos {
-            featurePrints.append(generateFeaturePrint(filePath: photo.filePath))
-        }
-
-        // Split groups where similarity breaks
-        var subGroups: [BurstGroup] = []
-        var currentPhotos: [Photo] = [photos[0]]
-
-        for i in 1..<photos.count {
-            let similar: Bool
-            if let fp1 = featurePrints[i - 1], let fp2 = featurePrints[i] {
-                var distance: Float = 0
-                try? fp1.computeDistance(&distance, to: fp2)
-                similar = distance <= similarityThreshold
-            } else {
-                similar = true // If we can't compute, assume similar (time-based grouping already filtered)
-            }
-
-            if similar {
-                currentPhotos.append(photos[i])
-            } else {
-                if currentPhotos.count >= minBurstCount {
-                    subGroups.append(BurstGroup(id: UUID(), photos: currentPhotos, bestPhotoID: nil))
-                }
-                currentPhotos = [photos[i]]
-            }
-        }
-
-        if currentPhotos.count >= minBurstCount {
-            subGroups.append(BurstGroup(id: UUID(), photos: currentPhotos, bestPhotoID: nil))
-        }
-
-        return subGroups
-    }
-
-    private func generateFeaturePrint(filePath: String) -> VNFeaturePrintObservation? {
-        let url = URL(fileURLWithPath: filePath)
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, [
-                  kCGImageSourceThumbnailMaxPixelSize: 256,
-                  kCGImageSourceCreateThumbnailFromImageAlways: true,
-              ] as CFDictionary) else {
-            return nil
-        }
-
-        let request = VNGenerateImageFeaturePrintRequest()
-        let handler = VNImageRequestHandler(cgImage: cgImage)
-        try? handler.perform([request])
-        return request.results?.first as? VNFeaturePrintObservation
-    }
-
-    // MARK: - Phase 4: Best photo selection
-
-    /// Select the best photo by combined sharpness + aesthetics score.
-    private func selectBest(in photos: [Photo]) -> UUID? {
-        photos.max(by: { score($0) < score($1) })?.id
-    }
-
-    private func score(_ photo: Photo) -> Float {
-        let sharpness = photo.sharpnessScore ?? 0
-        let aesthetics = photo.aestheticsScore ?? 0
-        return sharpness * 0.5 + aesthetics * 0.5
+        BurstDetectionPhases.Timestamps.readPrecise(filePath: filePath)
     }
 }
 


### PR DESCRIPTION
## Summary

- Extract `BurstDetector`'s four-phase algorithm into a new `BurstDetectionPhases` caseless enum so each phase can be exercised in isolation:
  - `Timestamps` — EXIF `DateTimeOriginal` + `SubSecTimeOriginal` extraction and timestamp-sorted collection.
  - `TimeGrouping` — time-proximity bucketing.
  - `Similarity` — Vision feature-print verification (with `generateFeaturePrint`).
  - `BestSelection` — sharpness + aesthetics scoring.
- `BurstDetector` now composes the phases. Public surface is unchanged: `init(timeThresholdMs:minBurstCount:similarityThreshold:)`, `detect(photos:)`, `readPreciseTimestamp(filePath:)`, and the `BurstGroup` struct.
- Pure structural refactor — thresholds, comparators, ordering, and the EXIF parsing path are bit-for-bit identical to the previous monolithic implementation.
- `PipelineCoordinator` and `BurstDetectorTests` are untouched and continue to compile against the same symbols.

Note: the assigned base branch `claude/refactor-codebase-kg8M6` does not exist on the remote, so this PR targets `main`.

## Test plan

- [ ] `cd apps/mac-client && swift build` (Swift toolchain unavailable in Linux sandbox)
- [ ] `cd apps/mac-client && swift test` — verify `BurstDetectorTests` still passes
- [ ] xcodegen regeneration of `SuperPicky.xcodeproj` may be needed since a new file was added under `SuperPickyApp/`

Verified via source review and grep: every symbol referenced by `BurstDetectorTests.swift` and `PipelineCoordinator.swift` still exists with the same signature.