### PR TITLE
refactor: add Size enum to StarRatingView

### DIFF
--- a/apps/mac-client/SuperPickyApp/StarRatingView.swift
+++ b/apps/mac-client/SuperPickyApp/StarRatingView.swift
@@ -1,13 +1,38 @@
 import SwiftUI
 
+/// Read-only 5-star rating display. Fills stars up to `rating`, uses
+/// primary color when rated and secondary when zero. Pick a `Size` preset
+/// instead of applying font/frame modifiers at the call site.
 struct StarRatingView: View {
+    /// Visual size preset controlling glyph point size and inter-star spacing.
+    enum Size {
+        case small, medium, large
+
+        var pointSize: CGFloat {
+            switch self {
+            case .small: 5
+            case .medium: 7
+            case .large: 12
+            }
+        }
+
+        var spacing: CGFloat {
+            switch self {
+            case .small: 1
+            case .medium: 1
+            case .large: 2
+            }
+        }
+    }
+
     let rating: Int
+    var size: Size = .medium
 
     var body: some View {
-        HStack(spacing: 1) {
+        HStack(spacing: size.spacing) {
             ForEach(1...5, id: \.self) { star in
                 Image(systemName: star <= rating ? "star.fill" : "star")
-                    .font(.system(size: 7))
+                    .font(.system(size: size.pointSize))
                     .foregroundStyle(color)
             }
         }


### PR DESCRIPTION
## Summary
- Add nested `Size` enum (`small`/`medium`/`large`) to `StarRatingView` with `pointSize` and `spacing` per case so callers no longer need to duplicate font/frame modifiers.
- Default `size: .medium` reproduces the prior rendering exactly (`pointSize 7`, `spacing 1`); existing callers in `PreviewView` and `ThumbnailStripView` are untouched.
- Add brief `///` doc comments on the struct and the `Size` enum.

## Test plan
- [ ] `cd apps/mac-client && swift build` (Linux sandbox can't run swift; verify on macOS)
- [ ] Visual smoke: `PreviewView` info bar and `ThumbnailStripView` overlay stars look identical to pre-refactor

https://claude.ai/code/session_01CNYDzahdBEWWLPGNToSSZf