### PR TITLE
refactor: extract ProcessConfiguration, drop hardcoded dev paths

### DIFF
--- a/apps/mac-client/SuperPickyApp/ProcessConfiguration.swift
+++ b/apps/mac-client/SuperPickyApp/ProcessConfiguration.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Resolves machine-specific filesystem paths needed to launch the Python
+/// inference server. Resolution priority for each value is:
+///   1. Environment variable override (useful for CI / packaged builds)
+///   2. Bundled resource directory (when shipped inside an .app)
+///   3. Developer fallback paths under `~/projects/...`
+///
+/// The struct is `Sendable` so it can be passed across actor boundaries.
+struct ProcessConfiguration: Sendable {
+    /// Directory containing `superpicky_server.py` and the Python `.venv`.
+    let serverDir: String
+    /// Directory containing model weights, exported to the child process as `MODELS_DIR`.
+    let modelsDir: String
+    /// Path to the Python interpreter to launch the server with.
+    /// May be either an absolute path to a binary or `/usr/bin/env python3`.
+    let pythonPath: String
+
+    init(serverDir: String, modelsDir: String, pythonPath: String) {
+        self.serverDir = serverDir
+        self.modelsDir = modelsDir
+        self.pythonPath = pythonPath
+    }
+
+    /// Resolves a configuration using env vars, bundle resources, and dev fallbacks.
+    static func resolve() -> ProcessConfiguration {
+        let env = ProcessInfo.processInfo.environment
+
+        let serverDir = env["SUPERPICKY_SERVER_DIR"]
+            ?? Bundle.main.resourceURL?.appendingPathComponent("python-server").path
+            ?? NSString("~/projects/SuperPickyMac/python-server").expandingTildeInPath
+
+        let modelsDir = env["SUPERPICKY_MODELS_DIR"]
+            ?? Bundle.main.resourceURL?.appendingPathComponent("models").path
+            ?? NSString("~/projects/SuperPicky/models").expandingTildeInPath
+
+        let pythonPath: String
+        if let override = env["SUPERPICKY_PYTHON"] {
+            pythonPath = override
+        } else {
+            let venvPython = serverDir + "/.venv/bin/python"
+            if FileManager.default.fileExists(atPath: venvPython) {
+                pythonPath = venvPython
+            } else {
+                pythonPath = "/usr/bin/env python3"
+            }
+        }
+
+        return ProcessConfiguration(
+            serverDir: serverDir,
+            modelsDir: modelsDir,
+            pythonPath: pythonPath
+        )
+    }
+}

--- a/apps/mac-client/SuperPickyApp/ProcessManager.swift
+++ b/apps/mac-client/SuperPickyApp/ProcessManager.swift
@@ -10,26 +10,11 @@ final class ProcessManager {
     private var healthCheckTask: Task<Void, Never>?
 
     let port: Int
-    private let serverDir: String
-    private let pythonPath: String
-    private let modelsDir: String
+    private let configuration: ProcessConfiguration
 
-    init(port: Int = 8420) {
+    init(port: Int = 8420, configuration: ProcessConfiguration = .resolve()) {
         self.port = port
-
-        // Dev mode: use project paths
-        let projectServerDir = NSString("~/projects/SuperPickyMac/python-server").expandingTildeInPath
-        let venvPython = projectServerDir + "/.venv/bin/python"
-        let modelsPath = NSString("~/projects/SuperPicky/models").expandingTildeInPath
-
-        if FileManager.default.fileExists(atPath: venvPython) {
-            self.pythonPath = venvPython
-        } else {
-            self.pythonPath = "/usr/bin/env python3"
-        }
-
-        self.serverDir = projectServerDir
-        self.modelsDir = modelsPath
+        self.configuration = configuration
     }
 
     func start() {
@@ -57,7 +42,7 @@ final class ProcessManager {
     }
 
     private func launchServer() async {
-        let serverScript = serverDir + "/superpicky_server.py"
+        let serverScript = configuration.serverDir + "/superpicky_server.py"
 
         guard FileManager.default.fileExists(atPath: serverScript) else {
             logger.error("Server script not found at \(serverScript)")
@@ -65,10 +50,10 @@ final class ProcessManager {
         }
 
         let proc = Process()
-        proc.currentDirectoryURL = URL(fileURLWithPath: serverDir)
+        proc.currentDirectoryURL = URL(fileURLWithPath: configuration.serverDir)
 
-        if FileManager.default.fileExists(atPath: pythonPath) {
-            proc.executableURL = URL(fileURLWithPath: pythonPath)
+        if FileManager.default.fileExists(atPath: configuration.pythonPath) {
+            proc.executableURL = URL(fileURLWithPath: configuration.pythonPath)
             proc.arguments = [serverScript, "--port", "\(port)"]
         } else {
             proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
@@ -76,7 +61,7 @@ final class ProcessManager {
         }
 
         var env = ProcessInfo.processInfo.environment
-        env["MODELS_DIR"] = modelsDir
+        env["MODELS_DIR"] = configuration.modelsDir
         proc.environment = env
 
         // Log stderr for debugging


### PR DESCRIPTION
## Summary

- Extracted machine-specific filesystem paths (python-server dir, models dir, interpreter) out of `ProcessManager` into a new `ProcessConfiguration` struct (`apps/mac-client/SuperPickyApp/ProcessConfiguration.swift`).
- `ProcessConfiguration.resolve()` picks each path in priority order: env var override (`SUPERPICKY_SERVER_DIR`, `SUPERPICKY_MODELS_DIR`, `SUPERPICKY_PYTHON`) -> `Bundle.main.resourceURL` for packaged builds -> the original `~/projects/...` dev fallbacks so the current dev loop keeps working unchanged.
- `ProcessManager.init(port:configuration:)` takes a defaulted `ProcessConfiguration = .resolve()`, so every existing call site (`ProcessManager()`, `ProcessManager(port: 19999)` in `SuperPickyApp` and the three `ProcessManagerTests` cases) continues to compile without modification.

## Why

The previous hardcoded `~/projects/SuperPickyMac/python-server` and `~/projects/SuperPicky/models` literals made the app non-distributable and tied it to one developer's machine layout. This refactor isolates that knowledge to a single, overridable resolver while preserving the public API.

## Test plan

- [ ] `cd apps/mac-client && swift build` (Swift toolchain unavailable in the Linux sandbox — verified by source review + grep instead)
- [ ] `cd apps/mac-client && swift test` to confirm `ProcessManagerTests` still compile and pass
- [ ] Launch dev app with no env vars set and confirm the Python server still starts from `~/projects/SuperPickyMac/python-server`
- [ ] Launch dev app with `SUPERPICKY_SERVER_DIR` / `SUPERPICKY_MODELS_DIR` / `SUPERPICKY_PYTHON` set and confirm the overrides are honored

## Notes

- `ProcessConfiguration.swift` imports only `Foundation`, no SwiftUI/AppKit.
- `Package.swift` auto-discovers `SuperPickyApp/*.swift`, so no package manifest changes are needed. The Xcode project (`SuperPicky.xcodeproj`) may need an `xcodegen` regeneration to pick up the new file.
- Port handling is untouched — port is still passed through `ProcessManager.init(port:)` per the existing convention (dev 8420 / L2 18420 / L3 28420).
- Intended base branch `claude/refactor-codebase-kg8M6` does not exist on the remote; targeting `main` instead.

https://claude.ai/code/session_01CNYDzahdBEWWLPGNToSSZf