### PR TITLE
refactor: name ExposureDetector thresholds

### DIFF
--- a/apps/mac-client/SuperPickyApp/ExposureDetector.swift
+++ b/apps/mac-client/SuperPickyApp/ExposureDetector.swift
@@ -9,7 +9,23 @@ struct ExposureResult: Sendable {
 }
 
 struct ExposureDetector: Sendable {
-    func detect(image: CGImage, threshold: Float = 0.10) -> ExposureResult {
+    /// Internal pixel-clipping thresholds. Independent of the user-adjustable
+    /// `CullingConfig.exposureThreshold`, which is passed through as `threshold`.
+    enum Thresholds {
+        /// Pixels >= 235/255 are treated as near-white clipping; the small margin
+        /// below pure white avoids flagging deliberately bright highlights.
+        static let overexposedPixelValue: UInt8 = 235
+
+        /// Pixels <= 15/255 are treated as near-black clipping; the small margin
+        /// above pure black avoids flagging recoverable shadow detail.
+        static let underexposedPixelValue: UInt8 = 15
+
+        /// Default fraction of clipped pixels (10%) that trips the over/under flag
+        /// when the caller doesn't supply its own threshold.
+        static let defaultClippingRatio: Float = 0.10
+    }
+
+    func detect(image: CGImage, threshold: Float = Thresholds.defaultClippingRatio) -> ExposureResult {
         let width = image.width
         let height = image.height
         let totalPixels = width * height
@@ -32,8 +48,8 @@ struct ExposureDetector: Sendable {
         var overCount = 0
         var underCount = 0
         for pixel in pixels {
-            if pixel >= 235 { overCount += 1 }
-            if pixel <= 15 { underCount += 1 }
+            if pixel >= Thresholds.overexposedPixelValue { overCount += 1 }
+            if pixel <= Thresholds.underexposedPixelValue { underCount += 1 }
         }
 
         let overRatio = Float(overCount) / Float(totalPixels)


### PR DESCRIPTION
## Summary
- Replace magic numbers (235, 15, 0.10) in `ExposureDetector.detect` with a nested `Thresholds` enum of named static constants.
- Add short `///` doc comments explaining why each cutoff exists (margin below pure white / above pure black, default clipping ratio).
- Public API is unchanged: `ExposureDetector()` still has a no-arg init and `detect(image:threshold:)` still defaults to `0.10` (now via `Thresholds.defaultClippingRatio`), so `PipelineCoordinator` and `ExposureDetectorTests` continue to compile against the same surface.

## Test plan
- [ ] `cd apps/mac-client && swift build`
- [ ] `cd apps/mac-client && swift test --filter ExposureDetectorTests` (normal / overexposed / underexposed cases unchanged)
- [ ] Spot-check `PipelineCoordinator` still calls `exposureDetector.detect(image:threshold:)` with the user-supplied `exposureThreshold`.

https://claude.ai/code/session_01CNYDzahdBEWWLPGNToSSZf