### PR TITLE
refactor: group EXIFData fields into Camera/Exposure/Image/Location sections

### DIFF
--- a/apps/mac-client/SuperPickyApp/EXIFReader.swift
+++ b/apps/mac-client/SuperPickyApp/EXIFReader.swift
@@ -3,41 +3,63 @@ import CoreGraphics
 import ImageIO
 
 /// Metadata extracted from an image file's EXIF, TIFF, and IPTC dictionaries.
+///
+/// Fields are grouped into nested sections by concern:
+/// - ``Camera`` — make, model, lens
+/// - ``Exposure`` — focal length, aperture, shutter speed, ISO, etc.
+/// - ``Image`` — pixel dimensions and capture date
+/// - ``Location`` — GPS coordinates and IPTC place names
+/// IPTC keywords stay at the top level since they are commonly accessed
+/// independently of any single section.
 struct EXIFData: Sendable {
-    var cameraMake: String?
-    var cameraModel: String?
-    var lensModel: String?
-    var focalLength: Double?       // mm
-    var aperture: Double?          // f-number
-    var shutterSpeed: String?      // formatted: "1/500" or "2.5s"
-    var iso: Int?
-    var dateTimeOriginal: String?  // raw EXIF string "2024:03:15 14:30:22"
-    var imageWidth: Int?
-    var imageHeight: Int?
-    var exposureBias: Double?
-    var meteringMode: String?
-    var whiteBalance: String?
-    var keywords: [String] = []    // IPTC keywords, empty if none
+    struct Camera: Sendable {
+        var make: String?
+        var model: String?
+        var lens: String?
+    }
 
-    // GPS
-    var latitude: Double?
-    var longitude: Double?
-    var altitude: Double?          // meters
+    struct Exposure: Sendable {
+        var focalLength: Double?       // mm
+        var aperture: Double?          // f-number
+        var shutterSpeed: String?      // formatted: "1/500" or "2.5s"
+        var iso: Int?
+        var exposureBias: Double?
+        var meteringMode: String?
+        var whiteBalance: String?
+    }
 
-    // IPTC location
-    var city: String?
-    var state: String?
-    var country: String?
+    struct Image: Sendable {
+        var width: Int?
+        var height: Int?
+        var dateTimeOriginal: String?  // raw EXIF string "2024:03:15 14:30:22"
+    }
+
+    struct Location: Sendable {
+        var latitude: Double?
+        var longitude: Double?
+        var altitude: Double?          // meters
+        var city: String?
+        var state: String?
+        var country: String?
+    }
+
+    var camera = Camera()
+    var exposure = Exposure()
+    var image = Image()
+    var location = Location()
+    var keywords: [String] = []        // IPTC keywords, empty if none
 
     /// True when no meaningful EXIF metadata is present.
-    /// Excludes imageWidth/imageHeight since those are always available from the image container.
+    /// Excludes image width/height since those are always available from the image container.
     var isEmpty: Bool {
-        cameraMake == nil && cameraModel == nil && lensModel == nil &&
-        focalLength == nil && aperture == nil && shutterSpeed == nil &&
-        iso == nil && dateTimeOriginal == nil && exposureBias == nil &&
-        meteringMode == nil && whiteBalance == nil && keywords.isEmpty &&
-        latitude == nil && longitude == nil && altitude == nil &&
-        city == nil && state == nil && country == nil
+        camera.make == nil && camera.model == nil && camera.lens == nil &&
+        exposure.focalLength == nil && exposure.aperture == nil && exposure.shutterSpeed == nil &&
+        exposure.iso == nil && exposure.exposureBias == nil &&
+        exposure.meteringMode == nil && exposure.whiteBalance == nil &&
+        image.dateTimeOriginal == nil &&
+        location.latitude == nil && location.longitude == nil && location.altitude == nil &&
+        location.city == nil && location.state == nil && location.country == nil &&
+        keywords.isEmpty
     }
 }
 
@@ -55,73 +77,89 @@ enum EXIFReader {
         let tiff = properties[kCGImagePropertyTIFFDictionary as String] as? [String: Any]
         let exifAux = properties[kCGImagePropertyExifAuxDictionary as String] as? [String: Any]
         let iptc = properties[kCGImagePropertyIPTCDictionary as String] as? [String: Any]
+        let gps = properties[kCGImagePropertyGPSDictionary as String] as? [String: Any]
 
-        var data = EXIFData()
+        return EXIFData(
+            camera: readCamera(tiff: tiff, exif: exif, exifAux: exifAux),
+            exposure: readExposure(exif: exif),
+            image: readImage(properties: properties, exif: exif),
+            location: readLocation(gps: gps, iptc: iptc),
+            keywords: (iptc?[kCGImagePropertyIPTCKeywords as String] as? [String]) ?? []
+        )
+    }
 
-        // TIFF
-        data.cameraMake = tiff?[kCGImagePropertyTIFFMake as String] as? String
-        data.cameraModel = tiff?[kCGImagePropertyTIFFModel as String] as? String
+    // MARK: - Section readers
 
+    private static func readCamera(
+        tiff: [String: Any]?,
+        exif: [String: Any]?,
+        exifAux: [String: Any]?
+    ) -> EXIFData.Camera {
+        var camera = EXIFData.Camera()
+        camera.make = tiff?[kCGImagePropertyTIFFMake as String] as? String
+        camera.model = tiff?[kCGImagePropertyTIFFModel as String] as? String
         // Lens: prefer ExifAux, fallback to Exif
-        data.lensModel = (exifAux?[kCGImagePropertyExifAuxLensModel as String] as? String)
+        camera.lens = (exifAux?[kCGImagePropertyExifAuxLensModel as String] as? String)
             ?? (exif?[kCGImagePropertyExifLensModel as String] as? String)
+        return camera
+    }
 
-        // Exif numerics
-        data.focalLength = doubleValue(exif, key: kCGImagePropertyExifFocalLength as String)
-        data.aperture = doubleValue(exif, key: kCGImagePropertyExifFNumber as String)
-        data.exposureBias = doubleValue(exif, key: kCGImagePropertyExifExposureBiasValue as String)
+    private static func readExposure(exif: [String: Any]?) -> EXIFData.Exposure {
+        var exposure = EXIFData.Exposure()
+        exposure.focalLength = doubleValue(exif, key: kCGImagePropertyExifFocalLength as String)
+        exposure.aperture = doubleValue(exif, key: kCGImagePropertyExifFNumber as String)
+        exposure.exposureBias = doubleValue(exif, key: kCGImagePropertyExifExposureBiasValue as String)
 
-        // ISO
         if let isoArray = exif?[kCGImagePropertyExifISOSpeedRatings as String] as? [Any],
            let first = isoArray.first {
-            data.iso = intValue(first)
+            exposure.iso = intValue(first)
         }
 
-        // Shutter speed (ExposureTime)
-        if let exposure = doubleValue(exif, key: kCGImagePropertyExifExposureTime as String) {
-            data.shutterSpeed = formatShutterSpeed(exposure)
+        if let exposureTime = doubleValue(exif, key: kCGImagePropertyExifExposureTime as String) {
+            exposure.shutterSpeed = formatShutterSpeed(exposureTime)
         }
 
-        // Date
-        data.dateTimeOriginal = exif?[kCGImagePropertyExifDateTimeOriginal as String] as? String
-
-        // Metering mode
         if let mode = exif?[kCGImagePropertyExifMeteringMode as String] {
-            data.meteringMode = describeMeteringMode(intValue(mode))
+            exposure.meteringMode = describeMeteringMode(intValue(mode))
         }
 
-        // White balance
         if let wb = exif?[kCGImagePropertyExifWhiteBalance as String] {
-            data.whiteBalance = intValue(wb) == 0 ? "Auto" : "Manual"
+            exposure.whiteBalance = intValue(wb) == 0 ? "Auto" : "Manual"
         }
 
-        // Dimensions (top-level)
-        data.imageWidth = properties[kCGImagePropertyPixelWidth as String] as? Int
-        data.imageHeight = properties[kCGImagePropertyPixelHeight as String] as? Int
+        return exposure
+    }
 
-        // IPTC keywords
-        if let kw = iptc?[kCGImagePropertyIPTCKeywords as String] as? [String] {
-            data.keywords = kw
-        }
+    private static func readImage(
+        properties: [String: Any],
+        exif: [String: Any]?
+    ) -> EXIFData.Image {
+        var image = EXIFData.Image()
+        image.width = properties[kCGImagePropertyPixelWidth as String] as? Int
+        image.height = properties[kCGImagePropertyPixelHeight as String] as? Int
+        image.dateTimeOriginal = exif?[kCGImagePropertyExifDateTimeOriginal as String] as? String
+        return image
+    }
 
-        // GPS
-        let gps = properties[kCGImagePropertyGPSDictionary as String] as? [String: Any]
+    private static func readLocation(
+        gps: [String: Any]?,
+        iptc: [String: Any]?
+    ) -> EXIFData.Location {
+        var location = EXIFData.Location()
         if let lat = doubleValue(gps, key: kCGImagePropertyGPSLatitude as String) {
             let ref = gps?[kCGImagePropertyGPSLatitudeRef as String] as? String
-            data.latitude = ref == "S" ? -lat : lat
+            location.latitude = ref == "S" ? -lat : lat
         }
         if let lon = doubleValue(gps, key: kCGImagePropertyGPSLongitude as String) {
             let ref = gps?[kCGImagePropertyGPSLongitudeRef as String] as? String
-            data.longitude = ref == "W" ? -lon : lon
+            location.longitude = ref == "W" ? -lon : lon
         }
-        data.altitude = doubleValue(gps, key: kCGImagePropertyGPSAltitude as String)
+        location.altitude = doubleValue(gps, key: kCGImagePropertyGPSAltitude as String)
 
-        // IPTC location
-        data.city = iptc?[kCGImagePropertyIPTCCity as String] as? String
-        data.state = iptc?[kCGImagePropertyIPTCProvinceState as String] as? String
-        data.country = iptc?[kCGImagePropertyIPTCCountryPrimaryLocationName as String] as? String
-
-        return data
+        location.city = iptc?[kCGImagePropertyIPTCCity as String] as? String
+        location.state = iptc?[kCGImagePropertyIPTCProvinceState as String] as? String
+        location.country = iptc?[kCGImagePropertyIPTCCountryPrimaryLocationName as String] as? String
+        return location
     }
 
     // MARK: - Private helpers

--- a/apps/mac-client/SuperPickyApp/ExifPanelView.swift
+++ b/apps/mac-client/SuperPickyApp/ExifPanelView.swift
@@ -13,58 +13,58 @@ struct ExifPanelView: View {
             if loaded, let data = exifData, !data.isEmpty {
                 VStack(alignment: .leading, spacing: 0) {
                     // Camera section
-                    if data.cameraMake != nil || data.cameraModel != nil || data.lensModel != nil {
+                    if data.camera.make != nil || data.camera.model != nil || data.camera.lens != nil {
                         sectionHeader("Camera", showDivider: false)
-                        if let make = data.cameraMake, let model = data.cameraModel {
+                        if let make = data.camera.make, let model = data.camera.model {
                             exifRow(label: "Camera", value: "\(make) \(model)")
-                        } else if let model = data.cameraModel {
+                        } else if let model = data.camera.model {
                             exifRow(label: "Camera", value: model)
-                        } else if let make = data.cameraMake {
+                        } else if let make = data.camera.make {
                             exifRow(label: "Camera", value: make)
                         }
-                        if let lens = data.lensModel {
+                        if let lens = data.camera.lens {
                             exifRow(label: "Lens", value: lens)
                         }
                     }
 
                     // Exposure section
-                    if data.focalLength != nil || data.aperture != nil || data.shutterSpeed != nil || data.iso != nil {
+                    if data.exposure.focalLength != nil || data.exposure.aperture != nil || data.exposure.shutterSpeed != nil || data.exposure.iso != nil {
                         sectionHeader("Exposure")
-                        if let focal = data.focalLength {
+                        if let focal = data.exposure.focalLength {
                             exifRow(label: "Focal Length", value: "\(formatNumber(focal)) mm")
                         }
                         // Combine exposure like Lightroom: "1/2000 at f/6.3, ISO 1600"
                         exifRow(label: "Exposure", value: formatExposure(data))
-                        if let bias = data.exposureBias, bias != 0 {
+                        if let bias = data.exposure.exposureBias, bias != 0 {
                             let sign = bias >= 0 ? "+" : ""
                             exifRow(label: "Exp Comp", value: "\(sign)\(formatNumber(bias)) EV")
                         }
-                        if let metering = data.meteringMode {
+                        if let metering = data.exposure.meteringMode {
                             exifRow(label: "Metering", value: metering)
                         }
-                        if let wb = data.whiteBalance {
+                        if let wb = data.exposure.whiteBalance {
                             exifRow(label: "White Balance", value: wb)
                         }
                     }
 
                     // Image section
-                    if data.imageWidth != nil || data.dateTimeOriginal != nil {
+                    if data.image.width != nil || data.image.dateTimeOriginal != nil {
                         sectionHeader("Image")
-                        if let date = data.dateTimeOriginal {
+                        if let date = data.image.dateTimeOriginal {
                             exifRow(label: "Capture Date", value: formatDate(date))
                         }
-                        if let w = data.imageWidth, let h = data.imageHeight {
+                        if let w = data.image.width, let h = data.image.height {
                             exifRow(label: "Dimensions", value: "\(w) \u{00D7} \(h)")
                         }
                     }
 
                     // Location section
-                    if data.latitude != nil || data.city != nil {
+                    if data.location.latitude != nil || data.location.city != nil {
                         sectionHeader("Location")
-                        if let location = formatLocation(data) {
-                            exifRow(label: "Place", value: location)
+                        if let place = formatLocation(data) {
+                            exifRow(label: "Place", value: place)
                         }
-                        if let lat = data.latitude, let lon = data.longitude {
+                        if let lat = data.location.latitude, let lon = data.location.longitude {
                             HStack(alignment: .firstTextBaseline, spacing: 8) {
                                 Text("GPS")
                                     .font(.system(size: 11))
@@ -93,7 +93,7 @@ struct ExifPanelView: View {
                             .padding(.horizontal, 12)
                             .padding(.vertical, 3)
                         }
-                        if let alt = data.altitude {
+                        if let alt = data.location.altitude {
                             exifRow(label: "Altitude", value: "\(Int(alt)) m")
                         }
                     }
@@ -192,12 +192,12 @@ struct ExifPanelView: View {
 
     private func formatExposure(_ data: EXIFData) -> String {
         var parts: [String] = []
-        if let shutter = data.shutterSpeed { parts.append(shutter) }
-        if let aperture = data.aperture { parts.append("f/\(formatNumber(aperture))") }
-        if let iso = data.iso { parts.append("ISO \(iso)") }
+        if let shutter = data.exposure.shutterSpeed { parts.append(shutter) }
+        if let aperture = data.exposure.aperture { parts.append("f/\(formatNumber(aperture))") }
+        if let iso = data.exposure.iso { parts.append("ISO \(iso)") }
         if parts.isEmpty { return "—" }
         // "1/2000 at f/6.3, ISO 1600"
-        if parts.count >= 2, data.shutterSpeed != nil, data.aperture != nil {
+        if parts.count >= 2, data.exposure.shutterSpeed != nil, data.exposure.aperture != nil {
             let shutter = parts.removeFirst()
             let aperture = parts.removeFirst()
             var result = "\(shutter) at \(aperture)"
@@ -234,12 +234,12 @@ struct ExifPanelView: View {
     }
 
     private func formatLocation(_ data: EXIFData) -> String? {
-        let parts = [data.city, data.state, data.country].compactMap { $0 }
+        let parts = [data.location.city, data.location.state, data.location.country].compactMap { $0 }
         return parts.isEmpty ? nil : parts.joined(separator: ", ")
     }
 
     private func formatCoordinates(_ data: EXIFData) -> String? {
-        guard let lat = data.latitude, let lon = data.longitude else { return nil }
+        guard let lat = data.location.latitude, let lon = data.location.longitude else { return nil }
         let latDir = lat >= 0 ? "N" : "S"
         let lonDir = lon >= 0 ? "E" : "W"
         return String(format: "%.4f\u{00B0} %@, %.4f\u{00B0} %@",

--- a/apps/mac-client/SuperPickyTests/BDD/ExifPanelTests.swift
+++ b/apps/mac-client/SuperPickyTests/BDD/ExifPanelTests.swift
@@ -118,16 +118,16 @@ import ImageIO
         let data = EXIFReader.read(from: photoURL.path)
         let exif = try #require(data)
 
-        #expect(exif.cameraMake == "Canon")
-        #expect(exif.cameraModel == "EOS R5")
-        #expect(exif.lensModel == "RF 100-500mm F4.5-7.1 L IS USM")
-        #expect(exif.focalLength == 500)
-        #expect(exif.aperture == 7.1)
-        #expect(exif.shutterSpeed == "1/3200")
-        #expect(exif.iso == 3200)
-        #expect(exif.dateTimeOriginal == "2025:04:02 06:15:10")
-        #expect(exif.imageWidth == 200)
-        #expect(exif.imageHeight == 150)
+        #expect(exif.camera.make == "Canon")
+        #expect(exif.camera.model == "EOS R5")
+        #expect(exif.camera.lens == "RF 100-500mm F4.5-7.1 L IS USM")
+        #expect(exif.exposure.focalLength == 500)
+        #expect(exif.exposure.aperture == 7.1)
+        #expect(exif.exposure.shutterSpeed == "1/3200")
+        #expect(exif.exposure.iso == 3200)
+        #expect(exif.image.dateTimeOriginal == "2025:04:02 06:15:10")
+        #expect(exif.image.width == 200)
+        #expect(exif.image.height == 150)
         #expect(!exif.isEmpty)
     }
 
@@ -174,7 +174,7 @@ import ImageIO
         let exif = try #require(data)
 
         #expect(exif.keywords.isEmpty)
-        #expect(exif.aperture == 4.0) // EXIF still present
+        #expect(exif.exposure.aperture == 4.0) // EXIF still present
     }
 
     // MARK: - Scenario: EXIF panel shows fallback for photo without any metadata
@@ -189,7 +189,7 @@ import ImageIO
 
         // All fields nil/empty — panel should show "No EXIF data available"
         #expect(exif.isEmpty)
-        #expect(exif.cameraMake == nil)
+        #expect(exif.camera.make == nil)
         #expect(exif.keywords.isEmpty)
     }
 
@@ -216,10 +216,10 @@ import ImageIO
         let data2 = try #require(EXIFReader.read(from: photo2URL.path))
 
         // Different photos produce different EXIF data
-        #expect(data1.cameraMake == "Nikon")
-        #expect(data2.cameraMake == "Canon")
-        #expect(data1.iso == 1600)
-        #expect(data2.iso == 3200)
+        #expect(data1.camera.make == "Nikon")
+        #expect(data2.camera.make == "Canon")
+        #expect(data1.exposure.iso == 1600)
+        #expect(data2.exposure.iso == 3200)
         #expect(data1.keywords == ["bird", "kingfisher"])
         #expect(data2.keywords == ["bird", "eagle"])
     }
@@ -233,13 +233,13 @@ import ImageIO
         let fastURL = dir.appendingPathComponent("fast.jpg")
         createJPEGWithEXIF(at: fastURL, exposureTime: 1.0 / 2000.0)
         let fast = try #require(EXIFReader.read(from: fastURL.path))
-        #expect(fast.shutterSpeed == "1/2000")
+        #expect(fast.exposure.shutterSpeed == "1/2000")
 
         // Slow shutter: 1s
         let slowURL = dir.appendingPathComponent("slow.jpg")
         createJPEGWithEXIF(at: slowURL, exposureTime: 1.0)
         let slow = try #require(EXIFReader.read(from: slowURL.path))
-        #expect(slow.shutterSpeed == "1s")
+        #expect(slow.exposure.shutterSpeed == "1s")
     }
 
     // MARK: - Scenario: EXIF panel shows GPS coordinates
@@ -251,9 +251,9 @@ import ImageIO
                            latitude: 35.6762, longitude: 139.6503, altitude: 40)
 
         let data = try #require(EXIFReader.read(from: photoURL.path))
-        #expect(data.latitude == 35.6762)
-        #expect(data.longitude == 139.6503)
-        #expect(data.altitude == 40)
+        #expect(data.location.latitude == 35.6762)
+        #expect(data.location.longitude == 139.6503)
+        #expect(data.location.altitude == 40)
     }
 
     // MARK: - Scenario: GPS handles southern/western hemisphere
@@ -266,10 +266,10 @@ import ImageIO
 
         let data = try #require(EXIFReader.read(from: photoURL.path))
         // Negative values for S/W
-        #expect(data.latitude! < 0)
-        #expect(data.longitude! < 0)
-        let latRounded = (data.latitude! * 10000).rounded() / 10000
-        let lonRounded = (data.longitude! * 10000).rounded() / 10000
+        #expect(data.location.latitude! < 0)
+        #expect(data.location.longitude! < 0)
+        let latRounded = (data.location.latitude! * 10000).rounded() / 10000
+        let lonRounded = (data.location.longitude! * 10000).rounded() / 10000
         #expect(latRounded == -33.8688)
         #expect(lonRounded == -151.2093)
     }
@@ -284,11 +284,11 @@ import ImageIO
                            city: "London", state: "England", country: "United Kingdom")
 
         let data = try #require(EXIFReader.read(from: photoURL.path))
-        #expect(data.city == "London")
-        #expect(data.state == "England")
-        #expect(data.country == "United Kingdom")
-        #expect(data.latitude != nil)
-        #expect(data.longitude != nil)
+        #expect(data.location.city == "London")
+        #expect(data.location.state == "England")
+        #expect(data.location.country == "United Kingdom")
+        #expect(data.location.latitude != nil)
+        #expect(data.location.longitude != nil)
     }
 
     // MARK: - Scenario: Photo without GPS has nil coordinates
@@ -299,12 +299,12 @@ import ImageIO
         createJPEGWithEXIF(at: photoURL) // No GPS params
 
         let data = try #require(EXIFReader.read(from: photoURL.path))
-        #expect(data.latitude == nil)
-        #expect(data.longitude == nil)
-        #expect(data.altitude == nil)
-        #expect(data.city == nil)
-        #expect(data.state == nil)
-        #expect(data.country == nil)
+        #expect(data.location.latitude == nil)
+        #expect(data.location.longitude == nil)
+        #expect(data.location.altitude == nil)
+        #expect(data.location.city == nil)
+        #expect(data.location.state == nil)
+        #expect(data.location.country == nil)
     }
 
     // MARK: - Scenario: Read EXIF from real test-photos directory
@@ -325,14 +325,14 @@ import ImageIO
         }
 
         let data = try #require(EXIFReader.read(from: kingfisher.path))
-        #expect(data.cameraMake == "Nikon")
-        #expect(data.cameraModel == "Z9")
+        #expect(data.camera.make == "Nikon")
+        #expect(data.camera.model == "Z9")
         #expect(!data.keywords.isEmpty)
         #expect(data.keywords.contains("kingfisher"))
         #expect(data.keywords.contains("bird"))
-        #expect(data.latitude != nil)
-        #expect(data.longitude != nil)
-        #expect(data.city != nil)
+        #expect(data.location.latitude != nil)
+        #expect(data.location.longitude != nil)
+        #expect(data.location.city != nil)
         #expect(!data.isEmpty)
     }
 }

--- a/apps/mac-client/SuperPickyTests/Core/EXIFReaderTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/EXIFReaderTests.swift
@@ -59,21 +59,21 @@ import ImageIO
         let result = EXIFReader.read(from: path)
         #expect(result != nil)
         let data = result!
-        #expect(data.cameraMake == nil)
-        #expect(data.cameraModel == nil)
-        #expect(data.lensModel == nil)
-        #expect(data.focalLength == nil)
-        #expect(data.aperture == nil)
-        #expect(data.shutterSpeed == nil)
-        #expect(data.iso == nil)
-        #expect(data.dateTimeOriginal == nil)
-        #expect(data.exposureBias == nil)
-        #expect(data.meteringMode == nil)
-        #expect(data.whiteBalance == nil)
+        #expect(data.camera.make == nil)
+        #expect(data.camera.model == nil)
+        #expect(data.camera.lens == nil)
+        #expect(data.exposure.focalLength == nil)
+        #expect(data.exposure.aperture == nil)
+        #expect(data.exposure.shutterSpeed == nil)
+        #expect(data.exposure.iso == nil)
+        #expect(data.image.dateTimeOriginal == nil)
+        #expect(data.exposure.exposureBias == nil)
+        #expect(data.exposure.meteringMode == nil)
+        #expect(data.exposure.whiteBalance == nil)
         #expect(data.keywords.isEmpty)
         // Dimensions should still be readable from the image itself
-        #expect(data.imageWidth == 100)
-        #expect(data.imageHeight == 80)
+        #expect(data.image.width == 100)
+        #expect(data.image.height == 80)
     }
 
     @Test func readExtractsFullEXIFData() {
@@ -107,17 +107,17 @@ import ImageIO
         let result = EXIFReader.read(from: path)
         #expect(result != nil)
         let data = result!
-        #expect(data.cameraMake == "Canon")
-        #expect(data.cameraModel == "EOS R5")
-        #expect(data.lensModel == "RF100-500mm F4.5-7.1 L IS USM")
-        #expect(data.focalLength == 200.0)
-        #expect(data.aperture == 2.8)
-        #expect(data.shutterSpeed == "1/500")
-        #expect(data.iso == 800)
-        #expect(data.dateTimeOriginal == "2024:03:15 14:30:22")
-        #expect(data.imageWidth == 8192)
-        #expect(data.imageHeight == 5464)
-        #expect(data.exposureBias == -0.3)
+        #expect(data.camera.make == "Canon")
+        #expect(data.camera.model == "EOS R5")
+        #expect(data.camera.lens == "RF100-500mm F4.5-7.1 L IS USM")
+        #expect(data.exposure.focalLength == 200.0)
+        #expect(data.exposure.aperture == 2.8)
+        #expect(data.exposure.shutterSpeed == "1/500")
+        #expect(data.exposure.iso == 800)
+        #expect(data.image.dateTimeOriginal == "2024:03:15 14:30:22")
+        #expect(data.image.width == 8192)
+        #expect(data.image.height == 5464)
+        #expect(data.exposure.exposureBias == -0.3)
         #expect(data.keywords == ["Bird", "Eagle", "Wildlife"])
     }
 
@@ -134,6 +134,6 @@ import ImageIO
 
         let result = EXIFReader.read(from: path)
         #expect(result != nil)
-        #expect(result!.shutterSpeed == "2.5s")
+        #expect(result!.exposure.shutterSpeed == "2.5s")
     }
 }


### PR DESCRIPTION
## Summary

- Nest `EXIFData`'s 20+ optional fields into four section structs (`Camera`, `Exposure`, `Image`, `Location`) so callers access related metadata through one logical group instead of a flat namespace. `keywords` stays top-level since it's commonly accessed independently of any single section.
- Split `EXIFReader.read` into per-section reader helpers (`readCamera`, `readExposure`, `readImage`, `readLocation`) and use the synthesized memberwise initializer for the final assembly.
- Update every consumer to the new accessor paths: `ExifPanelView`, `EXIFReaderTests`, and `ExifPanelTests`. (`KeywordWriterTests` only touches `.keywords` which is unchanged.)

### Field renaming

| Old | New |
|-----|-----|
| `cameraMake` | `camera.make` |
| `cameraModel` | `camera.model` |
| `lensModel` | `camera.lens` |
| `focalLength` | `exposure.focalLength` |
| `aperture` | `exposure.aperture` |
| `shutterSpeed` | `exposure.shutterSpeed` |
| `iso` | `exposure.iso` |
| `exposureBias` | `exposure.exposureBias` |
| `meteringMode` | `exposure.meteringMode` |
| `whiteBalance` | `exposure.whiteBalance` |
| `imageWidth` | `image.width` |
| `imageHeight` | `image.height` |
| `dateTimeOriginal` | `image.dateTimeOriginal` |
| `latitude`/`longitude`/`altitude` | `location.latitude`/`longitude`/`altitude` |
| `city`/`state`/`country` | `location.city`/`state`/`country` |
| `keywords` | unchanged (top level) |

### Conflict note

This PR touches `ExifPanelView.swift` to update field-access paths, and the parallel "ExifPanel decomposition" PR (Unit 1) is also editing the same file in a separate worktree. The two PRs will likely have merge conflicts in `ExifPanelView.swift` that will need to be resolved at merge time — that is expected and acceptable, since the field rename has to be atomic across consumers.

## Test plan

- [ ] Verify exhaustive grep shows zero references to old flat field names (`cameraMake`, `cameraModel`, `lensModel`, `imageWidth`, `imageHeight`, etc.) outside the rename diff itself.
- [ ] `swift build` (cannot run on Linux sandbox).
- [ ] `swift test` — `EXIFReaderTests`, `ExifPanelTests`, `KeywordWriterTests` should pass with updated accessor paths.
- [ ] Manual: open EXIF panel in the app, verify camera/exposure/image/location/keywords sections render as before.