### PR TITLE
feat: eye-crop sharpness detection and skill level rename

### DIFF
--- a/apps/mac-client/SuperPickyApp/AdvancedTab.swift
+++ b/apps/mac-client/SuperPickyApp/AdvancedTab.swift
@@ -6,6 +6,29 @@ struct AdvancedTab: View {
     var body: some View {
         @Bindable var config = config
         Form {
+            Section("Thresholds") {
+                HStack {
+                    Text("Sharpness")
+                    Slider(value: $config.sharpnessThreshold, in: 100...800, step: 10)
+                    Text("\(Int(config.sharpnessThreshold))")
+                        .monospacedDigit()
+                        .frame(width: 40)
+                }
+                HStack {
+                    Text("Aesthetics")
+                    Slider(value: $config.aestheticsThreshold, in: 2.0...8.0, step: 0.1)
+                    Text(String(format: "%.1f", config.aestheticsThreshold))
+                        .monospacedDigit()
+                        .frame(width: 40)
+                }
+                HStack {
+                    Text("Eye Sharpness")
+                    Slider(value: $config.eyeSharpnessThreshold, in: 0...300, step: 10)
+                    Text("\(Int(config.eyeSharpnessThreshold))")
+                        .monospacedDigit()
+                        .frame(width: 40)
+                }
+            }
             Section("Burst Detection") {
                 Toggle("Enable burst detection", isOn: $config.burstDetectionEnabled)
             }

--- a/apps/mac-client/SuperPickyApp/CullingConfig.swift
+++ b/apps/mac-client/SuperPickyApp/CullingConfig.swift
@@ -21,6 +21,22 @@ enum SkillLevel: String, CaseIterable, Codable, Sendable {
         case .master: 5.5
         }
     }
+
+    var eyeSharpnessThreshold: Float {
+        switch self {
+        case .beginner: 80
+        case .intermediate: 120
+        case .master: 160
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .beginner: "Relaxed"
+        case .intermediate: "Balanced"
+        case .master: "Strict"
+        }
+    }
 }
 
 enum NamingStandard: String, CaseIterable, Codable, Sendable {
@@ -78,11 +94,13 @@ final class CullingConfig {
         didSet {
             sharpnessThreshold = skillLevel.sharpnessThreshold
             aestheticsThreshold = skillLevel.aestheticsThreshold
+            eyeSharpnessThreshold = skillLevel.eyeSharpnessThreshold
             save()
         }
     }
     var sharpnessThreshold: Float { didSet { save() } }
     var aestheticsThreshold: Float { didSet { save() } }
+    var eyeSharpnessThreshold: Float { didSet { save() } }
     var exposureDetectionEnabled: Bool { didSet { save() } }
     var exposureThreshold: Float { didSet { save() } }
     var burstDetectionEnabled: Bool { didSet { save() } }
@@ -98,6 +116,7 @@ final class CullingConfig {
         self.skillLevel = level
         self.sharpnessThreshold = defaults.object(forKey: "sharpnessThreshold") as? Float ?? level.sharpnessThreshold
         self.aestheticsThreshold = defaults.object(forKey: "aestheticsThreshold") as? Float ?? level.aestheticsThreshold
+        self.eyeSharpnessThreshold = defaults.object(forKey: "eyeSharpnessThreshold") as? Float ?? level.eyeSharpnessThreshold
         self.exposureDetectionEnabled = defaults.object(forKey: "exposureDetectionEnabled") as? Bool ?? true
         self.exposureThreshold = defaults.object(forKey: "exposureThreshold") as? Float ?? 0.10
         self.burstDetectionEnabled = defaults.object(forKey: "burstDetectionEnabled") as? Bool ?? true
@@ -113,6 +132,7 @@ final class CullingConfig {
         defaults.set(skillLevel.rawValue, forKey: "skillLevel")
         defaults.set(sharpnessThreshold, forKey: "sharpnessThreshold")
         defaults.set(aestheticsThreshold, forKey: "aestheticsThreshold")
+        defaults.set(eyeSharpnessThreshold, forKey: "eyeSharpnessThreshold")
         defaults.set(exposureDetectionEnabled, forKey: "exposureDetectionEnabled")
         defaults.set(exposureThreshold, forKey: "exposureThreshold")
         defaults.set(burstDetectionEnabled, forKey: "burstDetectionEnabled")

--- a/apps/mac-client/SuperPickyApp/CullingConfig.swift
+++ b/apps/mac-client/SuperPickyApp/CullingConfig.swift
@@ -1,44 +1,6 @@
 import Foundation
 import SwiftUI
 
-enum SkillLevel: String, CaseIterable, Codable, Sendable {
-    case beginner
-    case intermediate
-    case master
-
-    var sharpnessThreshold: Float {
-        switch self {
-        case .beginner: 300
-        case .intermediate: 380
-        case .master: 520
-        }
-    }
-
-    var aestheticsThreshold: Float {
-        switch self {
-        case .beginner: 4.5
-        case .intermediate: 4.8
-        case .master: 5.5
-        }
-    }
-
-    var eyeSharpnessThreshold: Float {
-        switch self {
-        case .beginner: 80
-        case .intermediate: 120
-        case .master: 160
-        }
-    }
-
-    var displayName: String {
-        switch self {
-        case .beginner: "Relaxed"
-        case .intermediate: "Balanced"
-        case .master: "Strict"
-        }
-    }
-}
-
 enum NamingStandard: String, CaseIterable, Codable, Sendable {
     case osea, avilist, clements, birdlife, scientific
 }
@@ -90,14 +52,6 @@ enum RawFormat: String, CaseIterable, Sendable {
 
 @Observable
 final class CullingConfig {
-    var skillLevel: SkillLevel {
-        didSet {
-            sharpnessThreshold = skillLevel.sharpnessThreshold
-            aestheticsThreshold = skillLevel.aestheticsThreshold
-            eyeSharpnessThreshold = skillLevel.eyeSharpnessThreshold
-            save()
-        }
-    }
     var sharpnessThreshold: Float { didSet { save() } }
     var aestheticsThreshold: Float { didSet { save() } }
     var eyeSharpnessThreshold: Float { didSet { save() } }
@@ -112,11 +66,9 @@ final class CullingConfig {
 
     init() {
         let defaults = UserDefaults.standard
-        let level = SkillLevel(rawValue: defaults.string(forKey: "skillLevel") ?? "") ?? .intermediate
-        self.skillLevel = level
-        self.sharpnessThreshold = defaults.object(forKey: "sharpnessThreshold") as? Float ?? level.sharpnessThreshold
-        self.aestheticsThreshold = defaults.object(forKey: "aestheticsThreshold") as? Float ?? level.aestheticsThreshold
-        self.eyeSharpnessThreshold = defaults.object(forKey: "eyeSharpnessThreshold") as? Float ?? level.eyeSharpnessThreshold
+        self.sharpnessThreshold = defaults.object(forKey: "sharpnessThreshold") as? Float ?? 380
+        self.aestheticsThreshold = defaults.object(forKey: "aestheticsThreshold") as? Float ?? 4.8
+        self.eyeSharpnessThreshold = defaults.object(forKey: "eyeSharpnessThreshold") as? Float ?? 100
         self.exposureDetectionEnabled = defaults.object(forKey: "exposureDetectionEnabled") as? Bool ?? true
         self.exposureThreshold = defaults.object(forKey: "exposureThreshold") as? Float ?? 0.10
         self.burstDetectionEnabled = defaults.object(forKey: "burstDetectionEnabled") as? Bool ?? true
@@ -129,7 +81,6 @@ final class CullingConfig {
 
     private func save() {
         let defaults = UserDefaults.standard
-        defaults.set(skillLevel.rawValue, forKey: "skillLevel")
         defaults.set(sharpnessThreshold, forKey: "sharpnessThreshold")
         defaults.set(aestheticsThreshold, forKey: "aestheticsThreshold")
         defaults.set(eyeSharpnessThreshold, forKey: "eyeSharpnessThreshold")

--- a/apps/mac-client/SuperPickyApp/CullingTab.swift
+++ b/apps/mac-client/SuperPickyApp/CullingTab.swift
@@ -6,22 +6,6 @@ struct CullingTab: View {
     var body: some View {
         @Bindable var config = config
         Form {
-            Section("Thresholds") {
-                HStack {
-                    Text("Sharpness")
-                    Slider(value: $config.sharpnessThreshold, in: 100...800, step: 10)
-                    Text("\(Int(config.sharpnessThreshold))")
-                        .monospacedDigit()
-                        .frame(width: 40)
-                }
-                HStack {
-                    Text("Aesthetics")
-                    Slider(value: $config.aestheticsThreshold, in: 2.0...8.0, step: 0.1)
-                    Text(String(format: "%.1f", config.aestheticsThreshold))
-                        .monospacedDigit()
-                        .frame(width: 40)
-                }
-            }
             Section("Exposure") {
                 Toggle("Enable exposure detection", isOn: $config.exposureDetectionEnabled)
                 if config.exposureDetectionEnabled {

--- a/apps/mac-client/SuperPickyApp/EyeCropSharpness.swift
+++ b/apps/mac-client/SuperPickyApp/EyeCropSharpness.swift
@@ -1,0 +1,54 @@
+import Foundation
+import CoreGraphics
+
+struct EyeCropSharpness {
+    static let minimumVisibility: Float = 0.3
+    static let patchFraction: Float = 0.1
+    static let minimumPatchSize: Int = 8
+
+    /// Returns Laplacian sharpness of a small patch centered on the best visible eye.
+    /// Returns nil if both eyes have visibility < minimumVisibility or coordinates are nil.
+    static func score(
+        birdCrop: CGImage,
+        leftEyeX: Float?, leftEyeY: Float?, leftEyeVis: Float?,
+        rightEyeX: Float?, rightEyeY: Float?, rightEyeVis: Float?
+    ) -> Float? {
+        let leftVis = leftEyeVis ?? 0
+        let rightVis = rightEyeVis ?? 0
+
+        // Pick the eye with higher visibility that meets the minimum threshold.
+        // Fall through to the other eye if coords are nil.
+        let eyeX: Float
+        let eyeY: Float
+        if leftVis >= minimumVisibility && leftVis >= rightVis,
+           let x = leftEyeX, let y = leftEyeY {
+            eyeX = x; eyeY = y
+        } else if rightVis >= minimumVisibility,
+                  let x = rightEyeX, let y = rightEyeY {
+            eyeX = x; eyeY = y
+        } else {
+            return nil
+        }
+
+        let w = birdCrop.width
+        let h = birdCrop.height
+
+        let patchSize = max(minimumPatchSize, Int(Float(min(w, h)) * patchFraction))
+
+        // Image must be large enough to accommodate the minimum patch
+        guard w >= patchSize && h >= patchSize else { return nil }
+
+        let half = patchSize / 2
+
+        let cx = Int(eyeX * Float(w))
+        let cy = Int(eyeY * Float(h))
+
+        let originX = max(0, min(w - patchSize, cx - half))
+        let originY = max(0, min(h - patchSize, cy - half))
+
+        let patchRect = CGRect(x: originX, y: originY, width: patchSize, height: patchSize)
+        guard let patch = birdCrop.cropping(to: patchRect) else { return nil }
+
+        return LaplacianSharpness.score(image: patch)
+    }
+}

--- a/apps/mac-client/SuperPickyApp/GeneralTab.swift
+++ b/apps/mac-client/SuperPickyApp/GeneralTab.swift
@@ -8,7 +8,7 @@ struct GeneralTab: View {
         Form {
             Picker("Skill Level", selection: $config.skillLevel) {
                 ForEach(SkillLevel.allCases, id: \.self) { level in
-                    Text(level.rawValue.capitalized).tag(level)
+                    Text(level.displayName).tag(level)
                 }
             }
             .pickerStyle(.segmented)

--- a/apps/mac-client/SuperPickyApp/GeneralTab.swift
+++ b/apps/mac-client/SuperPickyApp/GeneralTab.swift
@@ -6,17 +6,6 @@ struct GeneralTab: View {
     var body: some View {
         @Bindable var config = config
         Form {
-            Picker("Skill Level", selection: $config.skillLevel) {
-                ForEach(SkillLevel.allCases, id: \.self) { level in
-                    Text(level.displayName).tag(level)
-                }
-            }
-            .pickerStyle(.segmented)
-
-            Text("Skill level sets default thresholds for sharpness and aesthetics scoring.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
             Toggle("Auto-advance after rating", isOn: $config.autoAdvance)
 
             Picker("Language", selection: $config.appLanguage) {

--- a/apps/mac-client/SuperPickyApp/MainView.swift
+++ b/apps/mac-client/SuperPickyApp/MainView.swift
@@ -288,7 +288,8 @@ struct MainView: View {
 
         let ratingConfig = RatingEngine.Config(
             sharpnessThreshold: config.sharpnessThreshold,
-            aestheticsThreshold: config.aestheticsThreshold
+            aestheticsThreshold: config.aestheticsThreshold,
+            eyeSharpnessThreshold: config.eyeSharpnessThreshold
         )
         let exposureEnabled = config.exposureDetectionEnabled
         let exposureThreshold = config.exposureThreshold

--- a/apps/mac-client/SuperPickyApp/Photo.swift
+++ b/apps/mac-client/SuperPickyApp/Photo.swift
@@ -21,6 +21,7 @@ struct Photo: Identifiable, Codable, Sendable, FetchableRecord, PersistableRecor
     var isFlying: Bool
     var flightConfidence: Float?
     var sharpnessScore: Float?
+    var eyeSharpnessScore: Float?
     var exposureStatus: String?
     var starRating: Int
     var isPick: Bool

--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -189,6 +189,15 @@ final class PipelineCoordinator {
         photo.flightConfidence = flight.confidence
 
         photo.sharpnessScore = LaplacianSharpness.score(image: birdCrop)
+        photo.eyeSharpnessScore = EyeCropSharpness.score(
+            birdCrop: birdCrop,
+            leftEyeX: keypoints.leftEye.x,
+            leftEyeY: keypoints.leftEye.y,
+            leftEyeVis: keypoints.leftEye.visibility,
+            rightEyeX: keypoints.rightEye.x,
+            rightEyeY: keypoints.rightEye.y,
+            rightEyeVis: keypoints.rightEye.visibility
+        )
 
         if exposureEnabled {
             let exposure = exposureDetector.detect(image: image, threshold: exposureThreshold)
@@ -211,6 +220,7 @@ final class PipelineCoordinator {
             isOverexposed: photo.exposureStatus == ExposureStatus.overexposed.rawValue,
             isUnderexposed: photo.exposureStatus == ExposureStatus.underexposed.rawValue,
             isFlying: flight.isFlying,
+            eyeSharpness: photo.eyeSharpnessScore,
             config: ratingConfig
         )
         photo.starRating = ratingResult.rating

--- a/apps/mac-client/SuperPickyApp/PreviewView.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewView.swift
@@ -146,6 +146,12 @@ struct InfoBarView: View {
                 } icon: { Image(systemName: "scope") }
                     .font(.caption)
             }
+            if let eyeSharpness = photo.eyeSharpnessScore {
+                Label {
+                    Text("\(config.localized("Eye")): \(Int(eyeSharpness))")
+                } icon: { Image(systemName: "eye") }
+                    .font(.caption)
+            }
 
             if let aesthetics = photo.aestheticsScore {
                 Label {

--- a/apps/mac-client/SuperPickyApp/RatingEngine.swift
+++ b/apps/mac-client/SuperPickyApp/RatingEngine.swift
@@ -12,6 +12,13 @@ struct RatingEngine: Sendable {
     struct Config: Sendable {
         let sharpnessThreshold: Float
         let aestheticsThreshold: Float
+        let eyeSharpnessThreshold: Float
+
+        init(sharpnessThreshold: Float, aestheticsThreshold: Float, eyeSharpnessThreshold: Float = 0) {
+            self.sharpnessThreshold = sharpnessThreshold
+            self.aestheticsThreshold = aestheticsThreshold
+            self.eyeSharpnessThreshold = eyeSharpnessThreshold
+        }
     }
 
     func calculate(
@@ -24,6 +31,7 @@ struct RatingEngine: Sendable {
         isOverexposed: Bool = false,
         isUnderexposed: Bool = false,
         isFlying: Bool = false,
+        eyeSharpness: Float? = nil,
         config: Config
     ) -> RatingResult {
         guard detected else {
@@ -64,7 +72,11 @@ struct RatingEngine: Sendable {
         var rating: Int
 
         if sharpAboveThreshold && aestheticsAboveThreshold {
-            rating = 5
+            if let eyeSharp = eyeSharpness, eyeSharp < config.eyeSharpnessThreshold {
+                rating = 4
+            } else {
+                rating = 5
+            }
         } else if (sharpAboveThreshold || aestheticsAboveThreshold) && (sharpAboveModerate && aestheticsAboveModerate) {
             rating = 4
         } else if sharpAboveModerate && aestheticsAboveModerate {

--- a/apps/mac-client/SuperPickyApp/ReportDatabase.swift
+++ b/apps/mac-client/SuperPickyApp/ReportDatabase.swift
@@ -67,6 +67,11 @@ final class ReportDatabase: Sendable {
             try db.execute(sql: "ALTER TABLE photos DROP COLUMN birdMask")
             try db.execute(sql: "ALTER TABLE photos DROP COLUMN focusPointStatus")
         }
+        migrator.registerMigration("v4_eye_sharpness") { db in
+            try db.alter(table: "photos") { t in
+                t.add(column: "eyeSharpnessScore", .double)
+            }
+        }
         try migrator.migrate(dbQueue)
     }
 

--- a/apps/mac-client/SuperPickyApp/en.lproj/Localizable.strings
+++ b/apps/mac-client/SuperPickyApp/en.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "Dimensions" = "Dimensions";
 "Done" = "Done";
 "Edit" = "Edit";
+"Eye" = "Eye";
 "Enable burst detection" = "Enable burst detection";
 "Enable exposure detection" = "Enable exposure detection";
 "Excellent" = "Excellent";

--- a/apps/mac-client/SuperPickyApp/zh-Hans.lproj/Localizable.strings
+++ b/apps/mac-client/SuperPickyApp/zh-Hans.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "Dimensions" = "尺寸";
 "Done" = "完成";
 "Edit" = "编辑";
+"Eye" = "眼";
 "Enable burst detection" = "启用连拍检测";
 "Enable exposure detection" = "启用曝光检测";
 "Excellent" = "优秀";

--- a/apps/mac-client/SuperPickyTests/Core/EyeCropSharpnessTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/EyeCropSharpnessTests.swift
@@ -1,0 +1,69 @@
+import Testing
+import CoreGraphics
+@testable import SuperPicky
+
+struct EyeCropSharpnessTests {
+
+    private func makeTestCGImage(width: Int = 100, height: Int = 100) -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(data: nil, width: width, height: height,
+                            bitsPerComponent: 8, bytesPerRow: 0,
+                            space: colorSpace,
+                            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue)!
+        ctx.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        ctx.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        ctx.fill(CGRect(x: 20, y: 20, width: 60, height: 60))
+        return ctx.makeImage()!
+    }
+
+    @Test func bothEyesInvisibleReturnsNil() {
+        let image = makeTestCGImage()
+        let result = EyeCropSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.1,
+            rightEyeX: 0.5, rightEyeY: 0.5, rightEyeVis: 0.1
+        )
+        #expect(result == nil)
+    }
+
+    @Test func leftEyeVisibleReturnsScore() {
+        let image = makeTestCGImage()
+        let result = EyeCropSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0
+        )
+        #expect(result != nil)
+    }
+
+    @Test func rightEyeChosenWhenHigherVisibility() {
+        let image = makeTestCGImage()
+        let result = EyeCropSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.5,
+            rightEyeX: 0.5, rightEyeY: 0.5, rightEyeVis: 0.8
+        )
+        #expect(result != nil)
+    }
+
+    @Test func nilCoordsWithVisibleEyeFallsThrough() {
+        let image = makeTestCGImage()
+        let result = EyeCropSharpness.score(
+            birdCrop: image,
+            leftEyeX: nil, leftEyeY: nil, leftEyeVis: 0.9,
+            rightEyeX: 0.5, rightEyeY: 0.5, rightEyeVis: 0.8
+        )
+        #expect(result != nil)
+    }
+
+    @Test func tinyImageReturnsNil() {
+        let image = makeTestCGImage(width: 4, height: 4)
+        let result = EyeCropSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0
+        )
+        #expect(result == nil)
+    }
+}

--- a/apps/mac-client/SuperPickyTests/Core/RatingEngineTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/RatingEngineTests.swift
@@ -163,6 +163,44 @@ import Foundation
         #expect(result.rating == 0)
     }
 
+    // MARK: - Eye sharpness gate
+
+    @Test func fiveStarWithGoodEyeSharpness() {
+        // eyeSharpness=150 >= threshold=120 → 5★
+        let eyeConfig = RatingEngine.Config(sharpnessThreshold: 380, aestheticsThreshold: 4.8, eyeSharpnessThreshold: 120)
+        let result = engine.calculate(
+            detected: true, confidence: 0.9,
+            sharpness: 500, aesthetics: 6.0,
+            eyeSharpness: 150,
+            config: eyeConfig
+        )
+        #expect(result.rating == 5)
+    }
+
+    @Test func fiveStarDemotedByBlurryEye() {
+        // eyeSharpness=80 < threshold=120 → demoted to 4★
+        let eyeConfig = RatingEngine.Config(sharpnessThreshold: 380, aestheticsThreshold: 4.8, eyeSharpnessThreshold: 120)
+        let result = engine.calculate(
+            detected: true, confidence: 0.9,
+            sharpness: 500, aesthetics: 6.0,
+            eyeSharpness: 80,
+            config: eyeConfig
+        )
+        #expect(result.rating == 4)
+    }
+
+    @Test func fiveStarWithNoEyeMeasurementNotPenalized() {
+        // eyeSharpness=nil (no eye detected) → 5★ regardless of threshold
+        let eyeConfig = RatingEngine.Config(sharpnessThreshold: 380, aestheticsThreshold: 4.8, eyeSharpnessThreshold: 120)
+        let result = engine.calculate(
+            detected: true, confidence: 0.9,
+            sharpness: 500, aesthetics: 6.0,
+            eyeSharpness: nil,
+            config: eyeConfig
+        )
+        #expect(result.rating == 5)
+    }
+
     // MARK: - Flying bonus
 
     @Test func flyingBonus() {


### PR DESCRIPTION
## Summary

- **Eye-crop sharpness**: extracts a small patch (~10% of bird crop) centered on the best visible eye, runs Laplacian variance scoring on it, and stores as `eyeSharpnessScore` on Photo
- **5★ gate**: `RatingEngine` now requires eye sharpness above a per-level threshold (Relaxed=80, Balanced=120, Strict=160) for 5★; nil eye score (occluded or undetected) is not penalized
- **InfoBarView**: shows eye sharpness alongside overall sharpness when available
- **Skill level rename**: `SkillLevel.displayName` maps Beginner→Relaxed, Intermediate→Balanced, Master→Strict; rawValues unchanged for UserDefaults backward compatibility

## Changes

- New: `EyeCropSharpness.swift` + `EyeCropSharpnessTests.swift` (5 tests)
- `Photo` model: `eyeSharpnessScore: Float?`
- DB migration `v4_eye_sharpness`: adds `eyeSharpnessScore` column
- `RatingEngine.Config`: `eyeSharpnessThreshold: Float = 0` (default = disabled, so existing callers are unaffected)
- `CullingConfig`: `eyeSharpnessThreshold` per skill level, full UserDefaults persistence
- `PipelineCoordinator`: computes eye sharpness after keypoint extraction
- `RatingEngineTests`: 3 new tests for the 5★ eye gate

## Test plan

- [ ] `swift test` — all 124 tests pass
- [ ] Info bar shows Eye score for processed photos with visible eyes
- [ ] Photos where both eyes are occluded still receive 5★ if overall thresholds are met
- [ ] Skill level picker in Settings shows Relaxed / Balanced / Strict