### PR TITLE
feat(ui): species edit panel with multi-species assignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,32 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "### Swift Build failure" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          grep -nE 'error:|warning:' /tmp/swift-build.log | head -80 >> "$GITHUB_STEP_SUMMARY" || true
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # Extract only hard errors (strip warnings which dominate the log).
+          grep -nE ': error:' /tmp/swift-build.log | head -200 > /tmp/swift-errors.log || true
+          # Also capture context around the final "Compiling" step that broke.
+          tail -200 /tmp/swift-build.log > /tmp/swift-build-tail.log || true
+          {
+            echo "### Swift Build failure — errors"
+            echo '```'
+            cat /tmp/swift-errors.log
+            echo '```'
+            echo '### Tail of build log (last 200 lines)'
+            echo '```'
+            cat /tmp/swift-build-tail.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
           if [ -n "$PR_NUMBER" ]; then
             {
-              echo "**Swift Build failure — first 80 error/warning lines**"
+              echo "**Swift Build failure — errors only**"
               echo ''
               echo '```'
-              grep -nE 'error:|warning:' /tmp/swift-build.log | head -80 || true
+              cat /tmp/swift-errors.log
+              echo '```'
+              echo ''
+              echo '**Last 200 lines of build log**'
+              echo ''
+              echo '```'
+              cat /tmp/swift-build-tail.log
               echo '```'
             } > /tmp/swift-build-comment.md
             gh pr comment "$PR_NUMBER" --body-file /tmp/swift-build-comment.md \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,20 @@ jobs:
 
       - name: Swift Build
         working-directory: apps/mac-client
-        run: swift build
+        run: |
+          set -o pipefail
+          swift build 2>&1 | tee /tmp/swift-build.log
+        shell: bash
+
+      - name: Dump Swift Build errors on failure
+        if: failure()
+        working-directory: apps/mac-client
+        shell: bash
+        run: |
+          echo "### Swift Build failure" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          grep -nE 'error:|warning:' /tmp/swift-build.log | head -80 >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Swift Test (L1 Unit)
         working-directory: apps/mac-client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   swift-build-test:
     name: Swift Build & Test (L1)
     runs-on: macos-15
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ jobs:
   swift-build-test:
     name: Swift Build & Test (L1)
     runs-on: macos-15
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -21,50 +18,7 @@ jobs:
 
       - name: Swift Build
         working-directory: apps/mac-client
-        run: |
-          set -o pipefail
-          swift build 2>&1 | tee /tmp/swift-build.log
-        shell: bash
-
-      - name: Dump Swift Build errors on failure
-        if: failure()
-        working-directory: apps/mac-client
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          # Extract only hard errors (strip warnings which dominate the log).
-          grep -nE ': error:' /tmp/swift-build.log | head -200 > /tmp/swift-errors.log || true
-          # Also capture context around the final "Compiling" step that broke.
-          tail -200 /tmp/swift-build.log > /tmp/swift-build-tail.log || true
-          {
-            echo "### Swift Build failure — errors"
-            echo '```'
-            cat /tmp/swift-errors.log
-            echo '```'
-            echo '### Tail of build log (last 200 lines)'
-            echo '```'
-            cat /tmp/swift-build-tail.log
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          if [ -n "$PR_NUMBER" ]; then
-            {
-              echo "**Swift Build failure — errors only**"
-              echo ''
-              echo '```'
-              cat /tmp/swift-errors.log
-              echo '```'
-              echo ''
-              echo '**Last 200 lines of build log**'
-              echo ''
-              echo '```'
-              cat /tmp/swift-build-tail.log
-              echo '```'
-            } > /tmp/swift-build-comment.md
-            gh pr comment "$PR_NUMBER" --body-file /tmp/swift-build-comment.md \
-              --repo "${{ github.repository }}" || true
-          fi
+        run: swift build
 
       - name: Swift Test (L1 Unit)
         working-directory: apps/mac-client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,25 @@ jobs:
             -scheme SuperPicky \
             -destination 'platform=macOS' \
             -only-testing:SuperPickyUITests/ProcessingFlowUITests
+
+      - name: SpeciesEditPanelUITests (mock mode)
+        working-directory: apps/mac-client
+        run: |
+          xcodebuild test \
+            -scheme SuperPicky \
+            -destination 'platform=macOS' \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test40_SpeciesEditToggleExists \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test41_ToggleOpensPanelWithAssignedSpecies \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test42_KeyboardShortcutSToggles \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test43_CandidatesListShowsNonAssignedTop5 \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test44_AddCandidateMovesToAssigned \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test45_RemoveSecondarySpecies \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test46_SearchFieldAcceptsInput \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test47_UnmatchedSearchReturnIsIgnored \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test48_EmptyAssignedStateShown \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test49_PhotoChangeClearsSearch \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test50_RemovePrimaryPromotesNext \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test51_MakePrimaryReordersAssigned \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test52_CandidateRowsShowLevelAndConfidence \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test53_SpeciesEditWritesToXMPSidecar \
+            -only-testing:SuperPickyUITests/CullingWorkflowUITests/test54_InfoPanelRefreshesKeywordsOnSpeciesEdit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,25 @@ jobs:
         if: failure()
         working-directory: apps/mac-client
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "### Swift Build failure" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           grep -nE 'error:|warning:' /tmp/swift-build.log | head -80 >> "$GITHUB_STEP_SUMMARY" || true
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$PR_NUMBER" ]; then
+            {
+              echo "**Swift Build failure — first 80 error/warning lines**"
+              echo ''
+              echo '```'
+              grep -nE 'error:|warning:' /tmp/swift-build.log | head -80 || true
+              echo '```'
+            } > /tmp/swift-build-comment.md
+            gh pr comment "$PR_NUMBER" --body-file /tmp/swift-build-comment.md \
+              --repo "${{ github.repository }}" || true
+          fi
 
       - name: Swift Test (L1 Unit)
         working-directory: apps/mac-client

--- a/apps/mac-client/SuperPickyApp/AppState.swift
+++ b/apps/mac-client/SuperPickyApp/AppState.swift
@@ -6,20 +6,30 @@ enum SidebarSelection: Hashable {
     case rating(Int)
     case flying
     case picks
-    case species(String)
+    /// Species bucket keyed by stable `SpeciesMatch.speciesID` (eBird code
+    /// or scientific-name fallback). `nil` selects the Unidentified bucket.
+    case species(String?)
     case burstGroup(UUID)
-    case singles(String) // species name
+    /// Singles under a species, keyed by the same stable ID as `.species`.
+    case singles(String?)
 }
 
 /// Species with its burst groups for the sidebar hierarchy.
+///
+/// `speciesID` is the stable identity (eBird code or scientific name); all
+/// filter / selection comparisons go through it. `name` is the English
+/// common name used as both the default display label and the input to
+/// `CullingConfig.localizedName(en:cn:)` for runtime-localized rendering.
 struct SpeciesEntry: Identifiable {
+    let speciesID: String?
+    let scientificName: String?
     let name: String
     let cnName: String?
     let count: Int
     let burstGroups: [BurstGroupEntry]
     let singlePhotos: Int
     let isUnidentified: Bool
-    var id: String { name }
+    var id: String { speciesID ?? "__unidentified__" }
 }
 
 struct BurstGroupEntry: Identifiable {
@@ -45,6 +55,12 @@ final class AppState {
     /// Locale used for alphabetical comparison — drives ICU collation
     /// (e.g. pinyin for `zh-Hans`, gojūon for `ja`).
     var speciesSortLocale: Locale = .current
+
+    /// Autocomplete backend used by the species edit panel. MainView wires
+    /// this to `SpeciesDatabase.search(query:limit:)` once at startup so the
+    /// UI never depends directly on `SuperPickyInference` types.
+    /// Default returns no matches, which keeps unit tests self-contained.
+    @ObservationIgnored var speciesSearch: (_ query: String) -> [SpeciesMatch] = { _ in [] }
 
     var ratingCounts: [Int: Int] {
         var counts: [Int: Int] = [:]
@@ -209,8 +225,9 @@ final class AppState {
     }
 
     /// Incremental species-hierarchy update. Touches only the bucket(s)
-    /// affected by this single photo — adding 1 row to an existing entry
-    /// is constant work, not a full `SpeciesHierarchyBuilder.build` pass.
+    /// affected by this single photo in the single-species fast path; a
+    /// multi-species assignedList, or a change that flips which species
+    /// appear, falls through to the debounced full rebuild.
     private func updateSpeciesHierarchy(removing old: Photo?, adding photo: Photo) {
         // Burst reassignment across species is too subtle to get right
         // incrementally (dominant species can flip). Fall back to a full
@@ -218,6 +235,22 @@ final class AppState {
         // burst photo during a large-folder ingest stalls the main
         // thread with O(n) work and throughput collapses to O(n²).
         if (old?.burstGroupID != nil) || (photo.burstGroupID != nil) {
+            scheduleAsyncHierarchyRebuild()
+            return
+        }
+
+        // Multi-species photos touch multiple buckets, and a single-species
+        // edit that changes the primary ID (user correction) moves the
+        // photo between buckets in non-obvious ways. The incremental
+        // add/remove helpers only know how to handle one bucket per call,
+        // so fall back to a debounced full rebuild whenever the assigned
+        // list has more than one entry or differs between old and new.
+        let oldAssigned = old?.assignedSpecies ?? []
+        let newAssigned = photo.assignedSpecies
+        let needsRebuild = oldAssigned.count > 1
+            || newAssigned.count > 1
+            || oldAssigned.map(\.speciesID) != newAssigned.map(\.speciesID)
+        if needsRebuild {
             scheduleAsyncHierarchyRebuild()
             return
         }
@@ -261,14 +294,21 @@ final class AppState {
         }
     }
 
+    /// Single-species fast-path add. Only called when `updateSpeciesHierarchy`
+    /// confirmed the photo has exactly one assigned species (or zero).
     private func add(_ photo: Photo) {
-        let hasSpecies = photo.speciesScientificName != nil
-        let name = photo.speciesCommonName ?? photo.speciesScientificName ?? String(localized: "Unidentified")
-        if let idx = speciesEntries.firstIndex(where: { $0.name == name }) {
+        let primary = photo.assignedSpecies.first
+        let hasSpecies = primary != nil
+        let id = primary?.speciesID
+        let name = primary?.commonName ?? primary?.scientificName ?? String(localized: "Unidentified")
+        let key: String = id ?? "__unidentified__"
+        if let idx = speciesEntries.firstIndex(where: { ($0.speciesID ?? "__unidentified__") == key }) {
             let existing = speciesEntries[idx]
             speciesEntries[idx] = SpeciesEntry(
+                speciesID: existing.speciesID,
+                scientificName: existing.scientificName ?? primary?.scientificName,
                 name: existing.name,
-                cnName: existing.cnName ?? photo.speciesCnName,
+                cnName: existing.cnName ?? primary?.cnName,
                 count: existing.count + 1,
                 burstGroups: existing.burstGroups,
                 singlePhotos: existing.singlePhotos + 1,
@@ -276,8 +316,10 @@ final class AppState {
             )
         } else {
             speciesEntries.append(SpeciesEntry(
+                speciesID: id,
+                scientificName: primary?.scientificName,
                 name: name,
-                cnName: photo.speciesCnName,
+                cnName: primary?.cnName,
                 count: 1,
                 burstGroups: [],
                 singlePhotos: 1,
@@ -287,14 +329,17 @@ final class AppState {
     }
 
     private func remove(_ photo: Photo) {
-        let name = photo.speciesCommonName ?? photo.speciesScientificName ?? String(localized: "Unidentified")
-        guard let idx = speciesEntries.firstIndex(where: { $0.name == name }) else { return }
+        let primary = photo.assignedSpecies.first
+        let key: String = primary?.speciesID ?? "__unidentified__"
+        guard let idx = speciesEntries.firstIndex(where: { ($0.speciesID ?? "__unidentified__") == key }) else { return }
         let existing = speciesEntries[idx]
         if existing.count <= 1 && existing.burstGroups.isEmpty {
             speciesEntries.remove(at: idx)
             return
         }
         speciesEntries[idx] = SpeciesEntry(
+            speciesID: existing.speciesID,
+            scientificName: existing.scientificName,
             name: existing.name,
             cnName: existing.cnName,
             count: max(0, existing.count - 1),
@@ -314,22 +359,22 @@ final class AppState {
             return photo.isFlying
         case .picks:
             return photo.isPick
-        case .species(let name):
-            let isUnidentified = speciesEntries.first { $0.name == name }?.isUnidentified ?? false
-            if isUnidentified {
-                return photo.speciesScientificName == nil
-            }
-            return photo.speciesCommonName == name || photo.speciesScientificName == name
+        case .species(let speciesID):
+            return photoHasSpeciesID(photo, speciesID: speciesID)
         case .burstGroup(let groupID):
             return photo.burstGroupID == groupID
-        case .singles(let speciesName):
+        case .singles(let speciesID):
             guard photo.burstGroupID == nil else { return false }
-            let isUnidentified = speciesEntries.first { $0.name == speciesName }?.isUnidentified ?? false
-            if isUnidentified {
-                return photo.speciesScientificName == nil
-            }
-            return photo.speciesCommonName == speciesName || photo.speciesScientificName == speciesName
+            return photoHasSpeciesID(photo, speciesID: speciesID)
         }
+    }
+
+    /// Multi-species-aware membership check. `nil` matches photos with an
+    /// empty `assignedSpecies` list (Unidentified bucket).
+    private func photoHasSpeciesID(_ photo: Photo, speciesID: String?) -> Bool {
+        let assigned = photo.assignedSpecies
+        if speciesID == nil { return assigned.isEmpty }
+        return assigned.contains { $0.speciesID == speciesID }
     }
 
     /// Clear all photo data (when folder is removed).
@@ -414,11 +459,53 @@ final class AppState {
         logger.info("Deleted photo: \(photo.filename)")
     }
 
-    /// Override the species name for a photo. Persists to DB and XMP sidecar.
+    /// Inline-rename hook for the info bar: rewrite the primary (first)
+    /// entry's common name without touching its stable `speciesID`. This
+    /// preserves sidebar bucketing — a cosmetic rename doesn't jump the
+    /// photo between buckets. Persists to DB and XMP sidecar.
     func correctSpecies(id: UUID, commonName: String) {
         let trimmed = commonName.trimmingCharacters(in: .whitespaces)
         mutatePhoto(id: id) { photo in
-            photo.speciesCommonName = trimmed.isEmpty ? nil : trimmed
+            var list = photo.assignedSpecies
+            guard var first = list.first else {
+                // No existing species — treat the rename as assigning a
+                // new custom entry with `trimmed` as both scientific and
+                // common name, so the photo leaves the Unidentified bucket.
+                if !trimmed.isEmpty {
+                    photo.assignedSpecies = [SpeciesMatch(
+                        scientificName: trimmed,
+                        commonName: trimmed,
+                        confidence: 0,
+                        cnName: nil,
+                        pinyin: nil,
+                        thresholdUsed: "manual",
+                        ebirdCode: nil
+                    )]
+                }
+                return
+            }
+            first = SpeciesMatch(
+                scientificName: first.scientificName,
+                commonName: trimmed.isEmpty ? nil : trimmed,
+                confidence: first.confidence,
+                cnName: first.cnName,
+                pinyin: first.pinyin,
+                thresholdUsed: first.thresholdUsed,
+                ebirdCode: first.ebirdCode
+            )
+            list[0] = first
+            photo.assignedSpecies = list
+        }
+        buildSpeciesHierarchy()
+    }
+
+    /// Replace the full assigned-species list for a photo. Used by the
+    /// species edit panel. `species.first` becomes the primary (which the
+    /// accessor mirrors into the scalar columns), every entry appears in
+    /// the sidebar hierarchy, and the XMP sidecar picks up all of them.
+    func setAssignedSpecies(id: UUID, species: [SpeciesMatch]) {
+        mutatePhoto(id: id) { photo in
+            photo.assignedSpecies = species
         }
         buildSpeciesHierarchy()
     }
@@ -472,24 +559,13 @@ final class AppState {
             photos = allPhotos.filter { $0.isFlying }
         case .picks:
             photos = allPhotos.filter { $0.isPick }
-        case .species(let name):
-            // Find the entry to check if it's the unidentified group
-            let isUnidentified = speciesEntries.first { $0.name == name }?.isUnidentified ?? false
-            if isUnidentified {
-                photos = allPhotos.filter { $0.speciesScientificName == nil }
-            } else {
-                photos = allPhotos.filter {
-                    $0.speciesCommonName == name || $0.speciesScientificName == name
-                }
-            }
+        case .species(let speciesID):
+            photos = allPhotos.filter { photoHasSpeciesID($0, speciesID: speciesID) }
         case .burstGroup(let groupID):
             photos = allPhotos.filter { $0.burstGroupID == groupID }
-        case .singles(let speciesName):
-            let isUnidentified = speciesEntries.first { $0.name == speciesName }?.isUnidentified ?? false
+        case .singles(let speciesID):
             photos = allPhotos.filter { photo in
-                photo.burstGroupID == nil && (isUnidentified
-                    ? photo.speciesScientificName == nil
-                    : (photo.speciesCommonName == speciesName || photo.speciesScientificName == speciesName))
+                photo.burstGroupID == nil && photoHasSpeciesID(photo, speciesID: speciesID)
             }
         case nil:
             photos = allPhotos

--- a/apps/mac-client/SuperPickyApp/ContentView.swift
+++ b/apps/mac-client/SuperPickyApp/ContentView.swift
@@ -22,6 +22,8 @@ struct ContentView: View {
     var onExportAllVisible: (([Photo]) -> Void)?
     var onDeletePhoto: ((UUID) -> Void)?
     var onCorrectSpecies: ((UUID, String) -> Void)?
+    var onAssignedSpeciesChanged: ((UUID, [SpeciesMatch]) -> Void)?
+    var searchSpecies: ((String) -> [SpeciesMatch])?
     @Environment(CullingConfig.self) private var config
     @State private var minimumStars: Int = 0
     @State private var topBurstOnly: Bool = false
@@ -29,6 +31,7 @@ struct ContentView: View {
     @State private var sortOrder: SortOrder = .filename
     @State private var sortAscending: Bool = true
     @State private var showExifPanel = true
+    @State private var showSpeciesEditPanel = false
     @State private var showFullscreen = false
     @State private var zoomState = ZoomState()
     @State private var fullscreenZoomState = ZoomState()
@@ -79,9 +82,22 @@ struct ContentView: View {
                             mouseInView: $mouseInPreview, viewSize: $previewSize,
                             onCorrectSpecies: onCorrectSpecies)
 
-                if showExifPanel, let photo = selectedPhoto {
-                    ExifPanelView(photo: photo)
+                HStack(alignment: .top, spacing: 0) {
+                    Spacer(minLength: 0)
+                    if showSpeciesEditPanel, let photo = selectedPhoto {
+                        SpeciesEditPanelView(
+                            photo: photo,
+                            onAssignedChanged: { species in
+                                onAssignedSpeciesChanged?(photo.id, species)
+                            },
+                            searchSpecies: searchSpecies ?? { _ in [] }
+                        )
                         .transition(.move(edge: .trailing))
+                    }
+                    if showExifPanel, let photo = selectedPhoto {
+                        ExifPanelView(photo: photo)
+                            .transition(.move(edge: .trailing))
+                    }
                 }
             }
             .frame(minHeight: 300)
@@ -271,6 +287,17 @@ struct ContentView: View {
                 .accessibilityIdentifier("ExifToggle")
                 .help(config.localized("Toggle EXIF Info (I)"))
             }
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showSpeciesEditPanel.toggle()
+                    }
+                } label: {
+                    Image(systemName: showSpeciesEditPanel ? "bird.fill" : "bird")
+                }
+                .accessibilityIdentifier("SpeciesEditToggle")
+                .help(config.localized("Edit species (S)"))
+            }
         }
         .alert(config.localized("No Photos"), isPresented: $showNoPhotosAlert) {
             Button(config.localized("OK"), role: .cancel) {}
@@ -324,6 +351,9 @@ struct ContentView: View {
         switch key.characters {
         case "i":
             withAnimation(.easeInOut(duration: 0.2)) { showExifPanel.toggle() }
+            return true
+        case "s":
+            withAnimation(.easeInOut(duration: 0.2)) { showSpeciesEditPanel.toggle() }
             return true
         case "f":
             showFullscreen.toggle()

--- a/apps/mac-client/SuperPickyApp/CoreMLInferenceClient.swift
+++ b/apps/mac-client/SuperPickyApp/CoreMLInferenceClient.swift
@@ -197,14 +197,18 @@ final class CoreMLInferenceClient: InferenceClient, @unchecked Sendable {
             let logits = try osea.logits(image: crop, isYOLOCropped: true, useTTA: true)
             let validLogits = Array(logits.prefix(OSEAClassifier.numClasses))
 
-            // 5. Walk the filter cascade. For each level compute softmax
-            //    (masked for gps/country, unmasked for global) and accept
-            //    the first level whose top-1 clears that level's
-            //    threshold. Matches `preen/detector.py` exactly.
+            // 5. Walk the full filter cascade, softmaxing at every level
+            //    (gps, country, global) regardless of whether an earlier
+            //    level already accepted. This lets us surface near-miss
+            //    candidates from each tier in the edit panel — a species
+            //    that just missed the regional threshold but would have
+            //    passed globally still shows up as an option. Top-1
+            //    acceptance logic is unchanged: we still stop *tracking
+            //    acceptance* at the first level whose max clears its gate.
             var acceptedProbs: [Float]?
             var acceptedLevel: SpeciesFilterLevel.Kind = .global
-            var lastProbs: [Float] = []
-            var lastLevel: SpeciesFilterLevel.Kind = .global
+            var perLevelProbs: [(kind: SpeciesFilterLevel.Kind, probs: [Float])] = []
+            perLevelProbs.reserveCapacity(filterChain.count)
             for level in filterChain {
                 let probs: [Float]
                 if let allowed = level.classIDs, !allowed.isEmpty {
@@ -215,49 +219,70 @@ final class CoreMLInferenceClient: InferenceClient, @unchecked Sendable {
                 } else {
                     probs = Self.softmax(logits: validLogits, temperature: Self.oseaTemperature)
                 }
-                lastProbs = probs
-                lastLevel = level.kind
-                let threshold = Self.top1ConfidenceThreshold(level: level.kind)
-                if (probs.max() ?? 0) >= threshold {
-                    acceptedProbs = probs
-                    acceptedLevel = level.kind
-                    break
+                perLevelProbs.append((level.kind, probs))
+                if acceptedProbs == nil {
+                    let threshold = Self.top1ConfidenceThreshold(level: level.kind)
+                    if (probs.max() ?? 0) >= threshold {
+                        acceptedProbs = probs
+                        acceptedLevel = level.kind
+                    }
                 }
             }
 
-            // 6. Build top-5 from the accepted level (or the last level
-            //    tried, for debugging parity). If no level cleared, the
-            //    top-1 is NOT appended — photo stays unidentified, but
-            //    top-5 still surfaces the best guesses for the parity
-            //    harness + diagnostics.
-            let probs = acceptedProbs ?? lastProbs
-            let topLevel = acceptedProbs != nil ? acceptedLevel : lastLevel
-            let topFive = probs.enumerated()
-                .sorted { $0.element > $1.element }
-                .prefix(max(5, topK))
-
-            var thisCropTop5: [SpeciesMatch] = []
-            var top1AppendedForThisCrop = false
-            for (classID, prob) in topFive {
-                guard prob >= Self.oseaFloorProbability else { break }
-                guard let entry = db.lookup(classID: classID) else { continue }
-                let match = SpeciesMatch(
+            // 6a. Primary species (top-1) still comes from the accepted
+            //     level only. If no level cleared, the photo stays
+            //     unidentified — nothing is appended to `speciesMatches`.
+            if let accepted = acceptedProbs,
+               let top1 = accepted.enumerated().max(by: { $0.element < $1.element }),
+               top1.element >= Self.oseaFloorProbability,
+               let entry = db.lookup(classID: top1.offset) {
+                speciesMatches.append(SpeciesMatch(
                     scientificName: entry.scientificName,
                     commonName: entry.englishName,
-                    confidence: prob,
+                    confidence: top1.element,
                     cnName: entry.chineseName,
                     pinyin: entry.pinyin,
-                    thresholdUsed: topLevel.rawValue
-                )
-                if !top1AppendedForThisCrop && acceptedProbs != nil {
-                    speciesMatches.append(match)
-                    top1AppendedForThisCrop = true
-                }
-                thisCropTop5.append(match)
-                if thisCropTop5.count >= 5 { break }
+                    thresholdUsed: acceptedLevel.rawValue,
+                    ebirdCode: entry.ebirdCode
+                ))
             }
-            if bestTop5 == nil && !thisCropTop5.isEmpty {
-                bestTop5 = thisCropTop5
+
+            // 6b. Candidate union across every level. For each (level, probs)
+            //     pair pull the top-5 above floor, then merge into a single
+            //     by-classID map keeping the highest-confidence entry (with
+            //     that level recorded as `thresholdUsed`). Cap final output
+            //     at 10 so the edit panel UI stays digestible.
+            var byClassID: [Int: SpeciesMatch] = [:]
+            for (kind, probs) in perLevelProbs {
+                let top = probs.enumerated()
+                    .sorted { $0.element > $1.element }
+                    .prefix(5)
+                for (classID, prob) in top {
+                    guard prob >= Self.oseaFloorProbability else { break }
+                    guard let entry = db.lookup(classID: classID) else { continue }
+                    let newMatch = SpeciesMatch(
+                        scientificName: entry.scientificName,
+                        commonName: entry.englishName,
+                        confidence: prob,
+                        cnName: entry.chineseName,
+                        pinyin: entry.pinyin,
+                        thresholdUsed: kind.rawValue,
+                        ebirdCode: entry.ebirdCode
+                    )
+                    if let existing = byClassID[classID] {
+                        if prob > existing.confidence {
+                            byClassID[classID] = newMatch
+                        }
+                    } else {
+                        byClassID[classID] = newMatch
+                    }
+                }
+            }
+            let thisCropCandidates = byClassID.values
+                .sorted { $0.confidence > $1.confidence }
+                .prefix(10)
+            if bestTop5 == nil && !thisCropCandidates.isEmpty {
+                bestTop5 = Array(thisCropCandidates)
             }
         }
 
@@ -356,16 +381,23 @@ final class CoreMLInferenceClient: InferenceClient, @unchecked Sendable {
         let osea       = cached("OSEAClassifier").flatMap    { try? OSEAClassifier(url: $0) }
         let aesthetics = cached("AestheticsModel").flatMap   { try? AestheticsModel(url: $0) }
 
-        // Species DB is bundled inside SuperPickyInference (small, always needed).
-        let species = SpeciesDatabase.bundledURL().flatMap { try? SpeciesDatabase(url: $0) }
-
         // Species filter: Avonet SQLite is downloaded on first launch via
         // ModelManager into the same modelsDir; the eBird JSONs live in
         // the framework bundle. If avonet.db isn't there yet (fresh
         // install, offline), the filter still loads with a nil Avonet
         // path and falls straight through to the eBird cascade.
+        // Built first so the eBird ↔ class-id mapping can feed the
+        // species database below.
         let avonetURL = modelsDir.appendingPathComponent("avonet.db")
         let filter = try? SpeciesFilter(avonetPath: avonetURL)
+
+        // Species DB is bundled inside SuperPickyInference (small, always
+        // needed). Annotate each row with its eBird code from the filter
+        // so UI code can use it as a stable identifier.
+        let ebirdByClassID = filter?.ebirdCodeByClassID ?? [:]
+        let species = SpeciesDatabase.bundledURL().flatMap {
+            try? SpeciesDatabase(url: $0, ebirdByClassID: ebirdByClassID)
+        }
 
         return CoreMLInferenceClient(
             flightModel:     try FlightModel(url: flightURL),

--- a/apps/mac-client/SuperPickyApp/ExifPanelView.swift
+++ b/apps/mac-client/SuperPickyApp/ExifPanelView.swift
@@ -110,9 +110,9 @@ struct ExifPanelView: View {
                                     .padding(.vertical, 3)
                                     .background(.quaternary)
                                     .clipShape(Capsule())
+                                    .accessibilityIdentifier("ExifKeyword_\(keyword)")
                             }
                         }
-                        .accessibilityIdentifier("Exif_Keywords")
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
                     }
@@ -138,7 +138,11 @@ struct ExifPanelView: View {
         .shadow(color: .black.opacity(0.2), radius: 8, x: -2, y: 2)
         .padding(8)
         .accessibilityIdentifier("ExifPanel")
-        .task(id: photo.id) {
+        // Keywords come from the XMP sidecar, which the species edit panel
+        // rewrites on every edit — key on assignedSpeciesJSON so the task
+        // re-fires and re-reads keywords when species change (photo.id alone
+        // stays stable across edits).
+        .task(id: [photo.id.uuidString, photo.assignedSpeciesJSON ?? ""]) {
             loaded = false
             exifData = await Task.detached {
                 EXIFReader.read(from: photo.filePath)

--- a/apps/mac-client/SuperPickyApp/MainView.swift
+++ b/apps/mac-client/SuperPickyApp/MainView.swift
@@ -1,10 +1,15 @@
 import SwiftUI
+import SuperPickyInference
 import os
 
 struct MainView: View {
     @Environment(CullingConfig.self) private var config
     let modelState: ModelDownloadState
     @State private var appState = AppState()
+    /// Bundled species reference DB (~11 k entries, ~2 ms load). Used for
+    /// autocomplete in the species edit panel, independent of whether the
+    /// CoreML inference pipeline is running.
+    @State private var speciesDB: SpeciesDatabase? = nil
     @State private var processingTask: Task<Void, Never>?
     @State private var isExporting = false
     @State private var exportProgress = 0
@@ -76,6 +81,22 @@ struct MainView: View {
                     },
                     onCorrectSpecies: { id, name in
                         appState.correctSpecies(id: id, commonName: name)
+                    },
+                    onAssignedSpeciesChanged: { id, species in
+                        appState.setAssignedSpecies(id: id, species: species)
+                    },
+                    searchSpecies: { query in
+                        speciesDB?.search(query: query).map { entry in
+                            SpeciesMatch(
+                                scientificName: entry.scientificName,
+                                commonName: entry.englishName,
+                                confidence: 0,
+                                cnName: entry.chineseName.isEmpty ? nil : entry.chineseName,
+                                pinyin: entry.pinyin,
+                                thresholdUsed: "manual",
+                                ebirdCode: entry.ebirdCode
+                            )
+                        } ?? []
                     }
                 )
             }
@@ -102,6 +123,7 @@ struct MainView: View {
         .onAppear {
             appState.speciesSortOrder = config.speciesSortOrder
             syncSpeciesDisplay()
+            loadSpeciesDatabase()
             if let testFolder = ProcessInfo.processInfo.environment["TEST_FOLDER"] {
                 let folder = URL(fileURLWithPath: testFolder)
                 Task {
@@ -142,6 +164,15 @@ struct MainView: View {
         } message: {
             Text(exportResultMessage)
         }
+    }
+
+    /// Load the bundled species DB once on appear. Keeps the species edit
+    /// panel's autocomplete working even if the CoreML pipeline isn't
+    /// available (e.g. models haven't been downloaded yet).
+    private func loadSpeciesDatabase() {
+        guard speciesDB == nil else { return }
+        guard let url = SpeciesDatabase.bundledURL() else { return }
+        speciesDB = try? SpeciesDatabase(url: url)
     }
 
     /// Mirror the current config's display-name + locale into AppState so

--- a/apps/mac-client/SuperPickyApp/Photo.swift
+++ b/apps/mac-client/SuperPickyApp/Photo.swift
@@ -144,8 +144,12 @@ struct Photo: Identifiable, Codable, Sendable, FetchableRecord, PersistableRecor
                 speciesPinyin = nil
                 speciesConfidence = nil
             } else {
-                let data = try? JSONEncoder().encode(newValue)
-                assignedSpeciesJSON = data.flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+                if let data = try? JSONEncoder().encode(newValue),
+                   let json = String(data: data, encoding: .utf8) {
+                    assignedSpeciesJSON = json
+                } else {
+                    assignedSpeciesJSON = "[]"
+                }
                 let primary = newValue[0]
                 speciesScientificName = primary.scientificName
                 speciesCommonName = primary.commonName

--- a/apps/mac-client/SuperPickyApp/Photo.swift
+++ b/apps/mac-client/SuperPickyApp/Photo.swift
@@ -40,6 +40,14 @@ struct Photo: Identifiable, Codable, Sendable, FetchableRecord, PersistableRecor
     var aestheticsDistributionJSON: String?
     var birdBboxJSON: String?
 
+    /// JSON-encoded `[SpeciesMatch]` — the set of species currently tagged on
+    /// this photo. First entry is the "primary" species (mirrored into the
+    /// scalar `species*` columns for back-compat with burst-dominance,
+    /// sidebar hierarchy, and legacy queries). Empty/nil when the photo is
+    /// unidentified. Written only via the `assignedSpecies` accessor so the
+    /// primary-column mirror stays in sync.
+    var assignedSpeciesJSON: String?
+
     // Reverse-geocoded location from the photo's GPS EXIF (resolved via
     // CLGeocoder + cell-keyed cache in ReverseGeocoder). Written to the
     // XMP sidecar as photoshop:City / State / Country / Iptc4xmpCore:
@@ -84,9 +92,67 @@ struct Photo: Identifiable, Codable, Sendable, FetchableRecord, PersistableRecor
         speciesCnName = donor.speciesCnName
         speciesPinyin = donor.speciesPinyin
         speciesConfidence = donor.speciesConfidence
+        assignedSpeciesJSON = donor.assignedSpeciesJSON
     }
 
     var hasSpecies: Bool {
         speciesCommonName != nil || speciesScientificName != nil
+    }
+
+    /// Currently-assigned species list, decoded from `assignedSpeciesJSON`.
+    /// Writing this property updates the JSON blob *and* mirrors the first
+    /// entry into the scalar `species*` columns so sidebar hierarchy,
+    /// burst-dominance, and legacy queries keep working without change.
+    var assignedSpecies: [SpeciesMatch] {
+        get {
+            if let json = assignedSpeciesJSON,
+               let data = json.data(using: .utf8),
+               let list = try? JSONDecoder().decode([SpeciesMatch].self, from: data) {
+                return list
+            }
+            // Fall back to the scalar primary columns so rows written
+            // before migration v8, or synthesized by tests that only set
+            // scalar fields, still report a sensible list. Scientific name
+            // may be missing (common-only, cn-only cases): derive a stable
+            // scientific-name slot from the common or Chinese name so
+            // `SpeciesMatch.speciesID` stays non-empty.
+            if speciesCommonName != nil || speciesScientificName != nil
+                || speciesCnName != nil || speciesPinyin != nil {
+                let sci = speciesScientificName
+                    ?? speciesCommonName
+                    ?? speciesCnName
+                    ?? speciesPinyin
+                    ?? ""
+                return [SpeciesMatch(
+                    scientificName: sci,
+                    commonName: speciesCommonName,
+                    confidence: speciesConfidence ?? 0,
+                    cnName: speciesCnName,
+                    pinyin: speciesPinyin,
+                    thresholdUsed: nil,
+                    ebirdCode: nil
+                )]
+            }
+            return []
+        }
+        set {
+            if newValue.isEmpty {
+                assignedSpeciesJSON = "[]"
+                speciesScientificName = nil
+                speciesCommonName = nil
+                speciesCnName = nil
+                speciesPinyin = nil
+                speciesConfidence = nil
+            } else {
+                let data = try? JSONEncoder().encode(newValue)
+                assignedSpeciesJSON = data.flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+                let primary = newValue[0]
+                speciesScientificName = primary.scientificName
+                speciesCommonName = primary.commonName
+                speciesCnName = primary.cnName
+                speciesPinyin = primary.pinyin
+                speciesConfidence = primary.confidence
+            }
+        }
     }
 }

--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -554,11 +554,12 @@ final class PipelineCoordinator: @unchecked Sendable {
         ])
 
         if let top = identifyResult.species.first {
-            photo.speciesScientificName = top.scientificName
-            photo.speciesCommonName = top.commonName
-            photo.speciesCnName = top.cnName
-            photo.speciesPinyin = top.pinyin
-            photo.speciesConfidence = top.confidence
+            // Writing `assignedSpecies` mirrors the primary SpeciesMatch
+            // into the scalar species* columns, so we avoid setting them
+            // twice.
+            photo.assignedSpecies = [top]
+        } else {
+            photo.assignedSpecies = []
         }
         if let top5 = identifyResult.top5 {
             photo.speciesTop5JSON = Self.encodeJSON(top5)

--- a/apps/mac-client/SuperPickyApp/PreviewView.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewView.swift
@@ -180,6 +180,17 @@ struct InfoBarView: View {
                         Text("\(Int(conf * 100))%")
                             .foregroundStyle(.secondary)
                     }
+                    let extras = max(0, photo.assignedSpecies.count - 1)
+                    if extras > 0 {
+                        Text("+\(extras)")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(.quaternary)
+                            .clipShape(Capsule())
+                            .accessibilityIdentifier("InfoBarExtraSpeciesCount")
+                    }
                 } icon: {
                     Image(systemName: "bird.fill")
                 }

--- a/apps/mac-client/SuperPickyApp/ReportDatabase.swift
+++ b/apps/mac-client/SuperPickyApp/ReportDatabase.swift
@@ -99,6 +99,43 @@ final class ReportDatabase: Sendable {
                 t.add(column: "locationSublocation", .text)
             }
         }
+        migrator.registerMigration("v8_assigned_species") { db in
+            // Multi-species tagging. Each photo now carries a JSON-encoded
+            // list of SpeciesMatch objects; the scalar species* columns
+            // continue to mirror the first entry for back-compat.
+            try db.alter(table: "photos") { t in
+                t.add(column: "assignedSpeciesJSON", .text)
+            }
+            // Backfill existing rows: emit a one-element list derived from
+            // the legacy scalar columns so pre-v8 photos show a consistent
+            // assigned list immediately (no reprocess required).
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT id, speciesScientificName, speciesCommonName,
+                       speciesCnName, speciesPinyin, speciesConfidence
+                FROM photos
+                WHERE speciesScientificName IS NOT NULL
+            """)
+            for row in rows {
+                let id: String = row["id"]
+                let sci: String = row["speciesScientificName"]
+                let match = SpeciesMatch(
+                    scientificName: sci,
+                    commonName: row["speciesCommonName"],
+                    confidence: row["speciesConfidence"] ?? 0,
+                    cnName: row["speciesCnName"],
+                    pinyin: row["speciesPinyin"],
+                    thresholdUsed: nil,
+                    ebirdCode: nil
+                )
+                if let data = try? JSONEncoder().encode([match]),
+                   let json = String(data: data, encoding: .utf8) {
+                    try db.execute(
+                        sql: "UPDATE photos SET assignedSpeciesJSON = ? WHERE id = ?",
+                        arguments: [json, id]
+                    )
+                }
+            }
+        }
         try migrator.migrate(dbQueue)
     }
 

--- a/apps/mac-client/SuperPickyApp/SourceListView.swift
+++ b/apps/mac-client/SuperPickyApp/SourceListView.swift
@@ -133,7 +133,7 @@ struct SourceListView: View {
                                 Image(systemName: species.isUnidentified ? "questionmark.circle" : "bird")
                                     .foregroundStyle(.secondary)
                             }
-                            .tag(SidebarSelection.species(species.name))
+                            .tag(SidebarSelection.species(species.speciesID))
                         } else {
                             // Has bursts — native DisclosureGroup
                             DisclosureGroup {
@@ -163,7 +163,7 @@ struct SourceListView: View {
                                         Image(systemName: "photo")
                                             .foregroundStyle(.secondary)
                                     }
-                                    .tag(SidebarSelection.singles(species.name))
+                                    .tag(SidebarSelection.singles(species.speciesID))
                                 }
                             } label: {
                                 Label {
@@ -178,7 +178,7 @@ struct SourceListView: View {
                                         .foregroundStyle(.secondary)
                                 }
                             }
-                            .tag(SidebarSelection.species(species.name))
+                            .tag(SidebarSelection.species(species.speciesID))
                         }
                     }
                 } header: {

--- a/apps/mac-client/SuperPickyApp/SpeciesEditPanelView.swift
+++ b/apps/mac-client/SuperPickyApp/SpeciesEditPanelView.swift
@@ -57,8 +57,8 @@ struct SpeciesEditPanelView: View {
                 .accessibilityIdentifier("SpeciesEditPanel_EmptyAssigned")
         } else {
             VStack(alignment: .leading, spacing: 4) {
-                ForEach(Array(assigned.enumerated()), id: \.element.speciesID) { index, match in
-                    assignedRow(match: match, isPrimary: index == 0, index: index)
+                ForEach(assigned.indices, id: \.self) { index in
+                    assignedRow(match: assigned[index], isPrimary: index == 0, index: index)
                 }
             }
             .padding(.horizontal, 12)

--- a/apps/mac-client/SuperPickyApp/SpeciesEditPanelView.swift
+++ b/apps/mac-client/SuperPickyApp/SpeciesEditPanelView.swift
@@ -166,6 +166,7 @@ struct SpeciesEditPanelView: View {
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
+                .accessibilityIdentifier("SpeciesEditPanel_MakePrimary_\(match.speciesID)")
                 .help(config.localized("Make primary"))
             }
             Button {
@@ -275,23 +276,10 @@ struct SpeciesEditPanelView: View {
     }
 
     private func commitSearchQuery() {
+        // Unmatched text is ignored — only SpeciesDatabase entries are allowed
+        // to avoid typos/unlisted names polluting the sidebar and XMP keywords.
         let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        let match: SpeciesMatch
-        if let first = searchResults.first {
-            match = first
-        } else {
-            // No autocomplete match — treat as user-entered custom species.
-            match = SpeciesMatch(
-                scientificName: trimmed,
-                commonName: trimmed,
-                confidence: 0,
-                cnName: nil,
-                pinyin: nil,
-                thresholdUsed: "manual",
-                ebirdCode: nil
-            )
-        }
+        guard !trimmed.isEmpty, let match = searchResults.first else { return }
         var list = assigned
         guard !assignedIDs.contains(match.speciesID) else {
             searchQuery = ""

--- a/apps/mac-client/SuperPickyApp/SpeciesEditPanelView.swift
+++ b/apps/mac-client/SuperPickyApp/SpeciesEditPanelView.swift
@@ -1,0 +1,324 @@
+import SwiftUI
+
+/// Floating panel for editing which species are tagged on the selected
+/// photo. Sections: currently assigned (removable chips + primary marker),
+/// OSEA candidates grouped by filter level, and an autocomplete-backed
+/// free-form search for species OSEA missed.
+struct SpeciesEditPanelView: View {
+    @Environment(CullingConfig.self) private var config
+    let photo: Photo
+    /// Called with the new full assigned-species list whenever the user
+    /// makes a change. Parent persists via `AppState.setAssignedSpecies`.
+    var onAssignedChanged: ([SpeciesMatch]) -> Void
+    /// Autocomplete backend — defaults to "no matches" so previews and
+    /// unit tests don't need the CoreML species database wired up.
+    var searchSpecies: (_ query: String) -> [SpeciesMatch] = { _ in [] }
+
+    @State private var searchQuery: String = ""
+    @State private var searchResults: [SpeciesMatch] = []
+
+    private var assigned: [SpeciesMatch] { photo.assignedSpecies }
+    private var candidates: [SpeciesMatch] { decodeCandidates() }
+    private var assignedIDs: Set<String> { Set(assigned.map(\.speciesID)) }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                assignedSection
+                candidatesSection
+                searchSection
+            }
+            .padding(.vertical, 8)
+        }
+        .frame(width: 280, alignment: .top)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .shadow(color: .black.opacity(0.2), radius: 8, x: -2, y: 2)
+        .padding(8)
+        .accessibilityIdentifier("SpeciesEditPanel")
+        .onChange(of: photo.id) {
+            searchQuery = ""
+            searchResults = []
+        }
+    }
+
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var assignedSection: some View {
+        sectionHeader(config.localized("Assigned"), showDivider: false)
+        if assigned.isEmpty {
+            Text(config.localized("No species assigned"))
+                .font(.system(size: 12))
+                .foregroundStyle(.tertiary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 4)
+                .accessibilityIdentifier("SpeciesEditPanel_EmptyAssigned")
+        } else {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(assigned.enumerated()), id: \.element.speciesID) { index, match in
+                    assignedRow(match: match, isPrimary: index == 0, index: index)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+        }
+    }
+
+    @ViewBuilder
+    private var candidatesSection: some View {
+        let available = candidates.filter { !assignedIDs.contains($0.speciesID) }
+        if !available.isEmpty {
+            sectionHeader(config.localized("OSEA Candidates"))
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(available, id: \.speciesID) { match in
+                    candidateRow(match: match)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+        }
+    }
+
+    @ViewBuilder
+    private var searchSection: some View {
+        sectionHeader(config.localized("Add Species"))
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                TextField(config.localized("Search species"), text: $searchQuery)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12))
+                    .accessibilityIdentifier("SpeciesEditPanel_SearchField")
+                    .onSubmit {
+                        commitSearchQuery()
+                    }
+                if !searchQuery.isEmpty {
+                    Button {
+                        searchQuery = ""
+                        searchResults = []
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(6)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.6))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            if !searchResults.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(searchResults.prefix(8), id: \.speciesID) { match in
+                        searchResultRow(match: match)
+                    }
+                }
+                .padding(.top, 2)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .padding(.bottom, 4)
+        .onChange(of: searchQuery) { _, newValue in
+            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                searchResults = []
+                return
+            }
+            searchResults = searchSpecies(trimmed)
+                .filter { !assignedIDs.contains($0.speciesID) }
+        }
+    }
+
+    // MARK: - Row builders
+
+    private func assignedRow(match: SpeciesMatch, isPrimary: Bool, index: Int) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: isPrimary ? "crown.fill" : "bird.fill")
+                .font(.system(size: 10))
+                .foregroundStyle(isPrimary ? .yellow : .secondary)
+                .frame(width: 14)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(displayLabel(for: match))
+                    .font(.system(size: 12, weight: isPrimary ? .semibold : .regular))
+                    .lineLimit(1)
+                Text(match.scientificName)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .italic()
+                    .lineLimit(1)
+            }
+            Spacer()
+            if !isPrimary {
+                Button {
+                    var list = assigned
+                    let entry = list.remove(at: index)
+                    list.insert(entry, at: 0)
+                    onAssignedChanged(list)
+                } label: {
+                    Image(systemName: "arrow.up.circle")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help(config.localized("Make primary"))
+            }
+            Button {
+                var list = assigned
+                list.remove(at: index)
+                onAssignedChanged(list)
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("SpeciesEditPanel_Remove_\(match.speciesID)")
+            .help(config.localized("Remove"))
+        }
+    }
+
+    private func candidateRow(match: SpeciesMatch) -> some View {
+        HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(displayLabel(for: match))
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(match.scientificName)
+                        .italic()
+                    if match.confidence > 0 {
+                        Text("\(Int(match.confidence * 100))%")
+                    }
+                    if let level = match.thresholdUsed {
+                        Text(levelLabel(level))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .font(.system(size: 10))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+            }
+            Spacer()
+            Button {
+                var list = assigned
+                list.append(match)
+                onAssignedChanged(list)
+            } label: {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.accentColor)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("SpeciesEditPanel_Add_\(match.speciesID)")
+        }
+    }
+
+    private func searchResultRow(match: SpeciesMatch) -> some View {
+        Button {
+            var list = assigned
+            list.append(match)
+            onAssignedChanged(list)
+            searchQuery = ""
+            searchResults = []
+        } label: {
+            HStack(spacing: 6) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(displayLabel(for: match))
+                        .font(.system(size: 12))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Text(match.scientificName)
+                        .font(.system(size: 10))
+                        .italic()
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+                Spacer()
+                Image(systemName: "plus.circle")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.accentColor)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Helpers
+
+    private func displayLabel(for match: SpeciesMatch) -> String {
+        config.localizedName(en: match.commonName ?? match.scientificName, cn: match.cnName)
+    }
+
+    private func levelLabel(_ raw: String) -> String {
+        switch raw {
+        case "gps": return config.localized("GPS")
+        case "country": return config.localized("Region")
+        case "global": return config.localized("Global")
+        case "manual": return config.localized("Manual")
+        default: return raw
+        }
+    }
+
+    private func decodeCandidates() -> [SpeciesMatch] {
+        guard let json = photo.speciesTop5JSON,
+              let data = json.data(using: .utf8),
+              let list = try? JSONDecoder().decode([SpeciesMatch].self, from: data) else {
+            return []
+        }
+        return list
+    }
+
+    private func commitSearchQuery() {
+        let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let match: SpeciesMatch
+        if let first = searchResults.first {
+            match = first
+        } else {
+            // No autocomplete match — treat as user-entered custom species.
+            match = SpeciesMatch(
+                scientificName: trimmed,
+                commonName: trimmed,
+                confidence: 0,
+                cnName: nil,
+                pinyin: nil,
+                thresholdUsed: "manual",
+                ebirdCode: nil
+            )
+        }
+        var list = assigned
+        guard !assignedIDs.contains(match.speciesID) else {
+            searchQuery = ""
+            searchResults = []
+            return
+        }
+        list.append(match)
+        onAssignedChanged(list)
+        searchQuery = ""
+        searchResults = []
+    }
+
+    private func sectionHeader(_ title: String, showDivider: Bool = true) -> some View {
+        VStack(spacing: 0) {
+            if showDivider {
+                Divider()
+                    .padding(.horizontal, 12)
+            }
+            Text(title)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .tracking(0.8)
+                .textCase(.uppercase)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.top, showDivider ? 8 : 2)
+                .padding(.bottom, 4)
+        }
+    }
+}

--- a/apps/mac-client/SuperPickyApp/SpeciesEditPanelView.swift
+++ b/apps/mac-client/SuperPickyApp/SpeciesEditPanelView.swift
@@ -212,7 +212,7 @@ struct SpeciesEditPanelView: View {
             } label: {
                 Image(systemName: "plus.circle.fill")
                     .font(.system(size: 13))
-                    .foregroundStyle(.accentColor)
+                    .foregroundStyle(Color.accentColor)
             }
             .buttonStyle(.plain)
             .accessibilityIdentifier("SpeciesEditPanel_Add_\(match.speciesID)")
@@ -242,7 +242,7 @@ struct SpeciesEditPanelView: View {
                 Spacer()
                 Image(systemName: "plus.circle")
                     .font(.system(size: 12))
-                    .foregroundStyle(.accentColor)
+                    .foregroundStyle(Color.accentColor)
             }
             .contentShape(Rectangle())
         }

--- a/apps/mac-client/SuperPickyApp/SpeciesHierarchyBuilder.swift
+++ b/apps/mac-client/SuperPickyApp/SpeciesHierarchyBuilder.swift
@@ -1,58 +1,97 @@
 import Foundation
 
 /// Pure computation: groups photos into species hierarchy entries.
+///
+/// A photo may carry multiple species in its `assignedSpecies` list; the
+/// builder emits one contribution *per assigned species*, so a photo
+/// tagged with both A and B appears under both buckets. The primary
+/// (first) entry still drives burst-dominant-species assignment so a
+/// burst lives under one species only.
+///
+/// Bucket identity is `SpeciesMatch.speciesID` (eBird code or, when the
+/// user entered a custom species, the scientific name). Never the
+/// localized common name — renames don't jump buckets.
 struct SpeciesHierarchyBuilder {
+
+    /// Sentinel used internally so `Dictionary` can key off a non-optional
+    /// value. Rendered as `isUnidentified: true` with `speciesID == nil` in
+    /// the emitted `SpeciesEntry`.
+    private static let unidentifiedKey = "__unidentified__"
+
     static func build(
         from photos: [Photo],
         sortOrder: SpeciesSortOrder = .name,
         displayName: (SpeciesEntry) -> String = { $0.name },
         locale: Locale = .current
     ) -> [SpeciesEntry] {
-        // Assign each burst to its dominant species by highest confidence ID.
-        // A burst spanning multiple species classifications appears only once.
-        var burstToSpecies: [UUID: String] = [:]
-        var burstBestConfidence: [UUID: (species: String, confidence: Float)] = [:]
+        // Assign each burst to its dominant species by highest confidence
+        // primary ID. A burst spanning multiple species classifications
+        // appears only once. Uses the PRIMARY species (assignedSpecies.first)
+        // — not the union — so multi-species tagging on individual photos
+        // doesn't duplicate bursts across buckets.
+        var burstPrimaryByGroup: [UUID: String] = [:]
+        var burstBestConfidence: [UUID: (id: String, confidence: Float)] = [:]
         var burstPhotos: [UUID: [Photo]] = [:]
 
         for photo in photos {
             guard let groupID = photo.burstGroupID else { continue }
             burstPhotos[groupID, default: []].append(photo)
 
-            guard let name = photo.speciesCommonName ?? photo.speciesScientificName else { continue }
-            let confidence = photo.speciesConfidence ?? 0
+            guard let primary = photo.assignedSpecies.first else { continue }
+            let confidence = primary.confidence
             if let current = burstBestConfidence[groupID] {
                 if confidence > current.confidence {
-                    burstBestConfidence[groupID] = (name, confidence)
+                    burstBestConfidence[groupID] = (primary.speciesID, confidence)
                 }
             } else {
-                burstBestConfidence[groupID] = (name, confidence)
+                burstBestConfidence[groupID] = (primary.speciesID, confidence)
             }
         }
 
         for groupID in burstPhotos.keys {
-            burstToSpecies[groupID] = burstBestConfidence[groupID]?.species ?? "Unidentified"
+            burstPrimaryByGroup[groupID] = burstBestConfidence[groupID]?.id ?? unidentifiedKey
         }
 
-        // Group photos by species
-        var bySpecies: [String: (photos: [Photo], isUnidentified: Bool)] = [:]
+        // Group photos by species ID. A multi-species photo contributes
+        // to every bucket it's tagged with.
+        struct Bucket {
+            var scientificName: String?
+            var commonName: String?
+            var cnName: String?
+            var photos: [Photo] = []
+            var isUnidentified: Bool = false
+        }
+        var bySpeciesID: [String: Bucket] = [:]
+
         for photo in photos {
-            let hasSpecies = photo.speciesScientificName != nil
-            let name = photo.speciesCommonName ?? photo.speciesScientificName ?? String(localized: "Unidentified")
-            var entry = bySpecies[name] ?? (photos: [], isUnidentified: !hasSpecies)
-            entry.photos.append(photo)
-            bySpecies[name] = entry
+            let list = photo.assignedSpecies
+            if list.isEmpty {
+                var bucket = bySpeciesID[unidentifiedKey] ?? Bucket(isUnidentified: true)
+                bucket.photos.append(photo)
+                bySpeciesID[unidentifiedKey] = bucket
+                continue
+            }
+            for match in list {
+                var bucket = bySpeciesID[match.speciesID] ?? Bucket()
+                if bucket.scientificName == nil { bucket.scientificName = match.scientificName }
+                if bucket.commonName == nil { bucket.commonName = match.commonName }
+                if bucket.cnName == nil { bucket.cnName = match.cnName }
+                bucket.photos.append(photo)
+                bySpeciesID[match.speciesID] = bucket
+            }
         }
 
-        let entries = bySpecies.map { name, entry -> SpeciesEntry in
-            // Only include burst groups whose dominant species matches this entry
+        let entries = bySpeciesID.map { id, bucket -> SpeciesEntry in
+            // Only include burst groups whose primary species matches this
+            // bucket. A multi-species photo still counts in every bucket,
+            // but each of its bursts shows up under only one species.
             var burstGroupIDs: Set<UUID> = []
             var singleCount = 0
-            for photo in entry.photos {
+            for photo in bucket.photos {
                 if let groupID = photo.burstGroupID {
-                    if burstToSpecies[groupID] == name {
+                    if burstPrimaryByGroup[groupID] == id {
                         burstGroupIDs.insert(groupID)
                     }
-                    // Photos in bursts owned by another species don't count as singles
                 } else {
                     singleCount += 1
                 }
@@ -68,13 +107,20 @@ struct SpeciesHierarchyBuilder {
                 )
             }.sorted { $0.count > $1.count }
 
+            let label: String = {
+                if bucket.isUnidentified { return String(localized: "Unidentified") }
+                return bucket.commonName ?? bucket.scientificName ?? String(localized: "Unidentified")
+            }()
+
             return SpeciesEntry(
-                name: name,
-                cnName: entry.photos.first?.speciesCnName,
-                count: entry.photos.count,
+                speciesID: bucket.isUnidentified ? nil : id,
+                scientificName: bucket.scientificName,
+                name: label,
+                cnName: bucket.cnName,
+                count: bucket.photos.count,
                 burstGroups: burstGroups,
                 singlePhotos: singleCount,
-                isUnidentified: entry.isUnidentified
+                isUnidentified: bucket.isUnidentified
             )
         }
         return sorted(entries: entries, by: sortOrder, displayName: displayName, locale: locale)

--- a/apps/mac-client/SuperPickyApp/SpeciesMatch.swift
+++ b/apps/mac-client/SuperPickyApp/SpeciesMatch.swift
@@ -1,13 +1,38 @@
 import Foundation
 
-struct SpeciesMatch: Codable, Identifiable, Sendable {
-    var id: String { scientificName }
+struct SpeciesMatch: Codable, Identifiable, Sendable, Hashable {
+    var id: String { speciesID }
     let scientificName: String
     let commonName: String?
     let confidence: Float
     let cnName: String?
     let pinyin: String?
     let thresholdUsed: String?
+    /// Stable eBird species code (e.g. "mallar3") when the match came from
+    /// the OSEA class vocabulary. `nil` for user-entered custom species the
+    /// model doesn't know. Used as the bucket key for the sidebar and filter
+    /// so renaming the common name doesn't jump the photo between buckets.
+    let ebirdCode: String?
+
+    /// Stable identifier: eBird code when available, otherwise fall back to
+    /// the scientific name. Never the localized common name.
+    var speciesID: String { ebirdCode ?? scientificName }
+
+    init(scientificName: String,
+         commonName: String?,
+         confidence: Float,
+         cnName: String?,
+         pinyin: String?,
+         thresholdUsed: String?,
+         ebirdCode: String? = nil) {
+        self.scientificName = scientificName
+        self.commonName = commonName
+        self.confidence = confidence
+        self.cnName = cnName
+        self.pinyin = pinyin
+        self.thresholdUsed = thresholdUsed
+        self.ebirdCode = ebirdCode
+    }
 
     enum CodingKeys: String, CodingKey {
         case scientificName = "name"
@@ -16,5 +41,6 @@ struct SpeciesMatch: Codable, Identifiable, Sendable {
         case cnName = "cn_name"
         case pinyin
         case thresholdUsed = "threshold_used"
+        case ebirdCode = "ebird_code"
     }
 }

--- a/apps/mac-client/SuperPickyApp/TestSupport/MockInferenceClientForUI.swift
+++ b/apps/mac-client/SuperPickyApp/TestSupport/MockInferenceClientForUI.swift
@@ -5,7 +5,6 @@ import CoreGraphics
 struct MockInferenceClientForUI: InferenceClient {
     func detect(image: CGImage) async throws -> DetectionResult { DetectionResult(birds: []) }
     func aesthetics(image: CGImage) async throws -> AestheticsResponse {
-        // Vary score slightly based on image dimensions for diversity
         let score = 4.5 + Float(image.width % 3)
         return AestheticsResponse(score: score, distribution: [])
     }
@@ -15,36 +14,54 @@ struct MockInferenceClientForUI: InferenceClient {
                        beak: Keypoint(x: 0.5, y: 0.5, visibility: 0.95))
     }
     func flight(image: CGImage) async throws -> FlightResult {
-        // Some photos "fly" based on width parity
         FlightResult(isFlying: image.width % 5 == 0, confidence: 0.8)
     }
-    // Real species results from preen dry-run on test-photos
-    private static let speciesByFile: [String: (String, String, Float, String, String)] = [
-        // (scientific, common, confidence, cn, pinyin)
-        "DSC00001": ("Haliaeetus leucocephalus", "Bald Eagle", 0.98, "白头海雕", "baitouhaidiao"),
-        "DSC00003": ("Haliaeetus leucocephalus", "Bald Eagle", 0.98, "白头海雕", "baitouhaidiao"),
-        "DSC00005": ("Haliaeetus leucocephalus", "Bald Eagle", 0.97, "白头海雕", "baitouhaidiao"),
-        "DSC00006": ("Haliaeetus leucocephalus", "Bald Eagle", 0.98, "白头海雕", "baitouhaidiao"),
-        "DSC00007": ("Haliaeetus leucocephalus", "Bald Eagle", 0.97, "白头海雕", "baitouhaidiao"),
-        "DSC00008": ("Haliaeetus leucocephalus", "Bald Eagle", 0.97, "白头海雕", "baitouhaidiao"),
-        "DSC00017": ("Haliaeetus leucocephalus", "Bald Eagle", 0.99, "白头海雕", "baitouhaidiao"),
-        "DSC00022": ("Haliaeetus leucocephalus", "Bald Eagle", 0.96, "白头海雕", "baitouhaidiao"),
+
+    private struct Fixture {
+        let scientific: String
+        let common: String
+        let confidence: Float
+        let cn: String
+        let pinyin: String
+        let ebird: String
+    }
+
+    // Real species results from preen dry-run on test-photos.
+    private static let speciesByFile: [String: Fixture] = [
+        "DSC00001": Fixture(scientific: "Haliaeetus leucocephalus", common: "Bald Eagle",         confidence: 0.98, cn: "白头海雕", pinyin: "baitouhaidiao", ebird: "baleag"),
+        "DSC00003": Fixture(scientific: "Haliaeetus leucocephalus", common: "Bald Eagle",         confidence: 0.98, cn: "白头海雕", pinyin: "baitouhaidiao", ebird: "baleag"),
+        "DSC00005": Fixture(scientific: "Haliaeetus leucocephalus", common: "Bald Eagle",         confidence: 0.97, cn: "白头海雕", pinyin: "baitouhaidiao", ebird: "baleag"),
+        "DSC00006": Fixture(scientific: "Haliaeetus leucocephalus", common: "Bald Eagle",         confidence: 0.98, cn: "白头海雕", pinyin: "baitouhaidiao", ebird: "baleag"),
+        "DSC00007": Fixture(scientific: "Haliaeetus leucocephalus", common: "Bald Eagle",         confidence: 0.97, cn: "白头海雕", pinyin: "baitouhaidiao", ebird: "baleag"),
+        "DSC00008": Fixture(scientific: "Haliaeetus leucocephalus", common: "Bald Eagle",         confidence: 0.97, cn: "白头海雕", pinyin: "baitouhaidiao", ebird: "baleag"),
+        "DSC00017": Fixture(scientific: "Haliaeetus leucocephalus", common: "Bald Eagle",         confidence: 0.99, cn: "白头海雕", pinyin: "baitouhaidiao", ebird: "baleag"),
+        "DSC00022": Fixture(scientific: "Haliaeetus leucocephalus", common: "Bald Eagle",         confidence: 0.96, cn: "白头海雕", pinyin: "baitouhaidiao", ebird: "baleag"),
         // DSC00029: bird detected, not identified
         // DSC00035: no birds
-        "DSC00037": ("Gavia immer", "Common Loon", 0.81, "普通潜鸟", "putongqianniao"),
-        "DSC00045": ("Bucephala islandica", "Barrow's Goldeneye", 0.98, "巴氏鹊鸭", "bashiqueya"),
-        "DSC00046": ("Bucephala islandica", "Barrow's Goldeneye", 0.98, "巴氏鹊鸭", "bashiqueya"),
-        "DSC00050": ("Gavia immer", "Common Loon", 0.95, "普通潜鸟", "putongqianniao"),
-        "DSC00090": ("Gavia immer", "Common Loon", 0.95, "普通潜鸟", "putongqianniao"),
-        "DSC00168": ("Cepphus columba", "Pigeon Guillemot", 1.0, "海鸽", "haige"),
-        "DSC00169": ("Cepphus columba", "Pigeon Guillemot", 1.0, "海鸽", "haige"),
+        "DSC00037": Fixture(scientific: "Gavia immer",              common: "Common Loon",        confidence: 0.81, cn: "普通潜鸟", pinyin: "putongqianniao", ebird: "comloo"),
+        "DSC00045": Fixture(scientific: "Bucephala islandica",      common: "Barrow's Goldeneye", confidence: 0.98, cn: "巴氏鹊鸭", pinyin: "bashiqueya",     ebird: "bargol"),
+        "DSC00046": Fixture(scientific: "Bucephala islandica",      common: "Barrow's Goldeneye", confidence: 0.98, cn: "巴氏鹊鸭", pinyin: "bashiqueya",     ebird: "bargol"),
+        "DSC00050": Fixture(scientific: "Gavia immer",              common: "Common Loon",        confidence: 0.95, cn: "普通潜鸟", pinyin: "putongqianniao", ebird: "comloo"),
+        "DSC00090": Fixture(scientific: "Gavia immer",              common: "Common Loon",        confidence: 0.95, cn: "普通潜鸟", pinyin: "putongqianniao", ebird: "comloo"),
+        "DSC00168": Fixture(scientific: "Cepphus columba",          common: "Pigeon Guillemot",   confidence: 1.0,  cn: "海鸽",     pinyin: "haige",          ebird: "piggui"),
+        "DSC00169": Fixture(scientific: "Cepphus columba",          common: "Pigeon Guillemot",   confidence: 1.0,  cn: "海鸽",     pinyin: "haige",          ebird: "piggui"),
+    ]
+
+    // thresholdUsed "country" so the candidate rows render the "Region"
+    // level label — exercises levelLabel(_:) in the edit panel.
+    private static let nearMissPool: [SpeciesMatch] = [
+        SpeciesMatch(scientificName: "Aquila chrysaetos", commonName: "Golden Eagle",
+                     confidence: 0.12, cnName: "金雕", pinyin: "jindiao",
+                     thresholdUsed: "country", ebirdCode: "goleag"),
+        SpeciesMatch(scientificName: "Pandion haliaetus", commonName: "Osprey",
+                     confidence: 0.06, cnName: "鹗", pinyin: "e",
+                     thresholdUsed: "country", ebirdCode: "osprey"),
     ]
 
     func identify(filePath: String, topK: Int, preDecodedImage: CGImage?, preGPS: (lat: Double, lon: Double)?) async throws -> IdentifyResponse {
         let filename = (filePath as NSString).lastPathComponent
         let stem = (filename as NSString).deletingPathExtension
 
-        // DSC00035: no birds at all
         if stem == "DSC00035" {
             return IdentifyResponse(species: [], birds: nil, totalDetected: 0)
         }
@@ -55,19 +72,20 @@ struct MockInferenceClientForUI: InferenceClient {
             mask: Data()
         )
 
-        // DSC00029: bird detected but not identified
-        guard let sp = Self.speciesByFile[stem] else {
+        guard let fixture = Self.speciesByFile[stem] else {
             return IdentifyResponse(species: [], birds: [bird], totalDetected: 1)
         }
 
         let species = SpeciesMatch(
-            scientificName: sp.0,
-            commonName: sp.1,
-            confidence: sp.2,
-            cnName: sp.3,
-            pinyin: sp.4,
-            thresholdUsed: "mock"
+            scientificName: fixture.scientific,
+            commonName: fixture.common,
+            confidence: fixture.confidence,
+            cnName: fixture.cn,
+            pinyin: fixture.pinyin,
+            thresholdUsed: "mock",
+            ebirdCode: fixture.ebird
         )
-        return IdentifyResponse(species: [species], birds: [bird], totalDetected: 1)
+        let top5 = [species] + Self.nearMissPool.filter { $0.scientificName != fixture.scientific }
+        return IdentifyResponse(species: [species], birds: [bird], totalDetected: 1, top5: top5)
     }
 }

--- a/apps/mac-client/SuperPickyApp/XMPWriter.swift
+++ b/apps/mac-client/SuperPickyApp/XMPWriter.swift
@@ -10,7 +10,8 @@ struct XMPWriter {
 
     /// Generate XMP string for a photo
     static func generate(photo: Photo) -> String {
-        let hasKeywords = photo.speciesCommonName != nil || photo.speciesCnName != nil || photo.isFlying
+        let assigned = photo.assignedSpecies
+        let hasKeywords = !assigned.isEmpty || photo.isFlying
         let hasLocation = photo.locationCity != nil || photo.locationState != nil
             || photo.locationCountry != nil || photo.locationCountryCode != nil
             || photo.locationSublocation != nil
@@ -32,17 +33,23 @@ struct XMPWriter {
         if hasKeywords {
             xml += "      <dc:subject>\n"
             xml += "        <rdf:Bag>\n"
-            if let common = photo.speciesCommonName {
-                xml += "          <rdf:li>\(xmlEscape(common))</rdf:li>\n"
-            }
-            if let scientific = photo.speciesScientificName {
-                xml += "          <rdf:li>\(xmlEscape(scientific))</rdf:li>\n"
-            }
-            if let cn = photo.speciesCnName {
-                xml += "          <rdf:li>\(xmlEscape(cn))</rdf:li>\n"
-            }
-            if let pinyin = photo.speciesPinyin {
-                xml += "          <rdf:li>\(xmlEscape(pinyin))</rdf:li>\n"
+            // Emit a keyword per assigned species, deduplicating so a
+            // photo tagged with two species whose common names collide
+            // doesn't produce duplicate rdf:li entries.
+            var emitted = Set<String>()
+            for match in assigned {
+                if let common = match.commonName, emitted.insert(common).inserted {
+                    xml += "          <rdf:li>\(xmlEscape(common))</rdf:li>\n"
+                }
+                if emitted.insert(match.scientificName).inserted {
+                    xml += "          <rdf:li>\(xmlEscape(match.scientificName))</rdf:li>\n"
+                }
+                if let cn = match.cnName, emitted.insert(cn).inserted {
+                    xml += "          <rdf:li>\(xmlEscape(cn))</rdf:li>\n"
+                }
+                if let pinyin = match.pinyin, emitted.insert(pinyin).inserted {
+                    xml += "          <rdf:li>\(xmlEscape(pinyin))</rdf:li>\n"
+                }
             }
             if photo.isFlying {
                 xml += "          <rdf:li>In Flight</rdf:li>\n"
@@ -52,8 +59,12 @@ struct XMPWriter {
 
             xml += "      <lr:hierarchicalSubject>\n"
             xml += "        <rdf:Bag>\n"
-            if let common = photo.speciesCommonName {
-                xml += "          <rdf:li>Bird|\(xmlEscape(common))</rdf:li>\n"
+            var hierEmitted = Set<String>()
+            for match in assigned {
+                guard let common = match.commonName else { continue }
+                if hierEmitted.insert(common).inserted {
+                    xml += "          <rdf:li>Bird|\(xmlEscape(common))</rdf:li>\n"
+                }
             }
             if photo.isFlying {
                 xml += "          <rdf:li>Behavior|In Flight</rdf:li>\n"

--- a/apps/mac-client/SuperPickyInference/Data/SpeciesDatabase.swift
+++ b/apps/mac-client/SuperPickyInference/Data/SpeciesDatabase.swift
@@ -15,14 +15,19 @@ public struct SpeciesEntry: Sendable {
     public let englishName: String
     public let chineseName: String
     public let pinyin: String?
+    public let ebirdCode: String?
 }
 
 public final class SpeciesDatabase: Sendable {
 
     private let byClassID: [Int: SpeciesEntry]
+    /// Flat array for linear-scan autocomplete. Holds the same values as
+    /// `byClassID` but in a form that's cheap to iterate without materializing
+    /// the dictionary's values on each search call.
+    private let all: [SpeciesEntry]
     private let logger = Logger(subsystem: "com.superpicky.mac", category: "SpeciesDB")
 
-    public init(url: URL) throws {
+    public init(url: URL, ebirdByClassID: [Int: String] = [:]) throws {
         var db: OpaquePointer?
         guard sqlite3_open_v2(url.path, &db,
                               SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK,
@@ -55,13 +60,55 @@ public final class SpeciesDatabase: Sendable {
                                           scientificName: scientific,
                                           englishName: english,
                                           chineseName: chinese,
-                                          pinyin: pinyin)
+                                          pinyin: pinyin,
+                                          ebirdCode: ebirdByClassID[classID])
         }
         self.byClassID = dict
+        self.all = Array(dict.values)
     }
 
     public func lookup(classID: Int) -> SpeciesEntry? {
         byClassID[classID]
+    }
+
+    /// Substring autocomplete across english / scientific / chinese / pinyin.
+    /// Ranks prefix matches ahead of substring matches, then alphabetical by
+    /// english name. Linear scan over ~11k entries is fine at typing speeds.
+    public func search(query: String, limit: Int = 20) -> [SpeciesEntry] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else { return [] }
+
+        struct Scored {
+            let entry: SpeciesEntry
+            let score: Int
+        }
+
+        var scored: [Scored] = []
+        scored.reserveCapacity(64)
+        for entry in all {
+            let eng = entry.englishName.lowercased()
+            let sci = entry.scientificName.lowercased()
+            let cn  = entry.chineseName.lowercased()
+            let py  = entry.pinyin?.lowercased() ?? ""
+
+            var score = 0
+            if eng.hasPrefix(trimmed) || sci.hasPrefix(trimmed)
+                || cn.hasPrefix(trimmed) || (!py.isEmpty && py.hasPrefix(trimmed)) {
+                score = 3
+            } else if eng.contains(trimmed) || sci.contains(trimmed)
+                || cn.contains(trimmed) || (!py.isEmpty && py.contains(trimmed)) {
+                score = 1
+            }
+            if score > 0 {
+                scored.append(Scored(entry: entry, score: score))
+            }
+        }
+
+        scored.sort { a, b in
+            if a.score != b.score { return a.score > b.score }
+            return a.entry.englishName.localizedCaseInsensitiveCompare(b.entry.englishName) == .orderedAscending
+        }
+        return scored.prefix(limit).map(\.entry)
     }
 
     /// Locate the bundled `bird_reference.sqlite` inside the SuperPickyInference

--- a/apps/mac-client/SuperPickyInference/Data/SpeciesDatabase.swift
+++ b/apps/mac-client/SuperPickyInference/Data/SpeciesDatabase.swift
@@ -108,7 +108,7 @@ public final class SpeciesDatabase: Sendable {
             if a.score != b.score { return a.score > b.score }
             return a.entry.englishName.localizedCaseInsensitiveCompare(b.entry.englishName) == .orderedAscending
         }
-        return scored.prefix(limit).map(\.entry)
+        return scored.prefix(limit).map { $0.entry }
     }
 
     /// Locate the bundled `bird_reference.sqlite` inside the SuperPickyInference

--- a/apps/mac-client/SuperPickyInference/Data/SpeciesFilter.swift
+++ b/apps/mac-client/SuperPickyInference/Data/SpeciesFilter.swift
@@ -28,6 +28,15 @@ public final class SpeciesFilter: @unchecked Sendable {
     private let ebirdBundle: Bundle
     /// Inverted map: eBird code ("mallar3") → OSEA class id (integer).
     private let classIDByEbirdCode: [String: Int]
+
+    /// Reverse lookup: OSEA class id → eBird code. Exposed so `SpeciesDatabase`
+    /// can annotate its `SpeciesEntry` rows with a stable external identifier
+    /// without re-parsing the bundled mapping file.
+    public var ebirdCodeByClassID: [Int: String] {
+        var out = [Int: String](minimumCapacity: classIDByEbirdCode.count)
+        for (code, id) in classIDByEbirdCode { out[id] = code }
+        return out
+    }
     private let logger = Logger(subsystem: "com.superpicky.mac", category: "SpeciesFilter")
 
     /// Long-lived SQLite handle. nil if the DB file wasn't present at init

--- a/apps/mac-client/SuperPickyTests/Core/AssignedSpeciesTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/AssignedSpeciesTests.swift
@@ -182,7 +182,8 @@ import Foundation
 
         // DB round-trip: refetch via a fresh database handle.
         let db2 = try ReportDatabase(folderPath: folder)
-        let refetched = try #require(try db2.fetchPhoto(id: photo.id))
+        let fetched = try db2.fetchPhoto(id: photo.id)
+        let refetched = try #require(fetched)
         #expect(refetched.assignedSpecies.count == 2)
         #expect(refetched.assignedSpecies.map(\.speciesID) == ["eagle", "hawk"])
     }
@@ -250,7 +251,8 @@ import Foundation
         appState.correctSpecies(id: photo.id, commonName: "Golden Eagle")
 
         let db2 = try ReportDatabase(folderPath: folder)
-        let refetched = try #require(try db2.fetchPhoto(id: photo.id))
+        let fetched = try db2.fetchPhoto(id: photo.id)
+        let refetched = try #require(fetched)
         #expect(refetched.assignedSpecies.first?.commonName == "Golden Eagle")
         // Stable identity preserved — the sidebar bucket shouldn't jump.
         #expect(refetched.assignedSpecies.first?.speciesID == "goleag")
@@ -270,7 +272,8 @@ import Foundation
         appState.correctSpecies(id: photo.id, commonName: "Mystery Bird")
 
         let db2 = try ReportDatabase(folderPath: folder)
-        let refetched = try #require(try db2.fetchPhoto(id: photo.id))
+        let fetched = try db2.fetchPhoto(id: photo.id)
+        let refetched = try #require(fetched)
         #expect(refetched.assignedSpecies.count == 1)
         #expect(refetched.assignedSpecies.first?.commonName == "Mystery Bird")
         #expect(refetched.assignedSpecies.first?.ebirdCode == nil)

--- a/apps/mac-client/SuperPickyTests/Core/AssignedSpeciesTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/AssignedSpeciesTests.swift
@@ -1,0 +1,310 @@
+import Testing
+import Foundation
+@testable import SuperPicky
+
+/// Covers the multi-species assignment behaviour on `Photo` and the
+/// `AppState` mutation APIs (`setAssignedSpecies`, `correctSpecies`)
+/// that back the new species edit panel.
+@Suite(.serialized) struct AssignedSpeciesTests {
+
+    // MARK: - Helpers
+
+    private func makeTempFolder() throws -> URL {
+        let folder = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        return folder
+    }
+
+    private func makePhoto(folder: URL, filename: String = "IMG_\(UUID().uuidString).CR3") -> Photo {
+        Photo(
+            filename: filename,
+            filePath: folder.appendingPathComponent(filename).path,
+            folderPath: folder.path
+        )
+    }
+
+    private func match(sci: String, common: String?, ebird: String? = nil,
+                       cn: String? = nil, conf: Float = 0.9,
+                       threshold: String? = nil) -> SpeciesMatch {
+        SpeciesMatch(
+            scientificName: sci, commonName: common, confidence: conf,
+            cnName: cn, pinyin: nil, thresholdUsed: threshold, ebirdCode: ebird
+        )
+    }
+
+    // MARK: - SpeciesMatch identity
+
+    @Test func speciesIDPrefersEbirdCodeOverScientificName() {
+        let m = match(sci: "Aquila chrysaetos", common: "Golden Eagle", ebird: "goleag")
+        #expect(m.speciesID == "goleag")
+    }
+
+    @Test func speciesIDFallsBackToScientificNameWhenNoEbirdCode() {
+        let m = match(sci: "Custom Species", common: "My Bird")
+        #expect(m.speciesID == "Custom Species")
+    }
+
+    @Test func speciesMatchDecodesEbirdCodeFromJSON() throws {
+        let json = """
+        {"name": "Aquila chrysaetos", "common_name": "Golden Eagle",
+         "confidence": 0.9, "ebird_code": "goleag"}
+        """.data(using: .utf8)!
+        let m = try JSONDecoder().decode(SpeciesMatch.self, from: json)
+        #expect(m.ebirdCode == "goleag")
+        #expect(m.speciesID == "goleag")
+    }
+
+    // MARK: - Photo.assignedSpecies accessor
+
+    @Test func assignedSpeciesSetterMirrorsPrimaryIntoScalarColumns() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        var photo = makePhoto(folder: folder)
+        let primary = match(sci: "Aquila chrysaetos", common: "Golden Eagle",
+                            ebird: "goleag", cn: "金雕", conf: 0.92)
+        photo.assignedSpecies = [primary]
+
+        #expect(photo.speciesScientificName == "Aquila chrysaetos")
+        #expect(photo.speciesCommonName == "Golden Eagle")
+        #expect(photo.speciesCnName == "金雕")
+        #expect(photo.speciesConfidence == 0.92)
+        #expect(photo.assignedSpeciesJSON != nil)
+    }
+
+    @Test func assignedSpeciesGetterRoundTripsList() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        var photo = makePhoto(folder: folder)
+        let list = [
+            match(sci: "Aquila", common: "Eagle", ebird: "eagle"),
+            match(sci: "Accipiter", common: "Hawk", ebird: "hawk"),
+        ]
+        photo.assignedSpecies = list
+        let decoded = photo.assignedSpecies
+        #expect(decoded.count == 2)
+        #expect(decoded.map(\.speciesID) == ["eagle", "hawk"])
+        #expect(decoded.first?.commonName == "Eagle")
+    }
+
+    @Test func assignedSpeciesSetterEmptyClearsScalarColumns() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        var photo = makePhoto(folder: folder)
+        photo.assignedSpecies = [match(sci: "Aquila", common: "Eagle", ebird: "eagle")]
+        #expect(photo.speciesCommonName == "Eagle")
+
+        photo.assignedSpecies = []
+        #expect(photo.speciesScientificName == nil)
+        #expect(photo.speciesCommonName == nil)
+        #expect(photo.speciesCnName == nil)
+        #expect(photo.speciesPinyin == nil)
+        #expect(photo.speciesConfidence == nil)
+        // Persisted so the getter doesn't re-synthesize from the now-nil scalars.
+        #expect(photo.assignedSpeciesJSON == "[]")
+    }
+
+    @Test func assignedSpeciesGetterFallsBackToScalarColumnsWhenJSONIsNil() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        var photo = makePhoto(folder: folder)
+        photo.speciesCommonName = "Robin"
+        photo.speciesScientificName = "Turdus migratorius"
+        photo.speciesConfidence = 0.7
+        // assignedSpeciesJSON stays nil — simulates a pre-v8 row.
+        #expect(photo.assignedSpeciesJSON == nil)
+
+        let list = photo.assignedSpecies
+        #expect(list.count == 1)
+        #expect(list.first?.scientificName == "Turdus migratorius")
+        #expect(list.first?.commonName == "Robin")
+        #expect(list.first?.confidence == 0.7)
+        #expect(list.first?.ebirdCode == nil)
+    }
+
+    @Test func assignedSpeciesFallbackSynthesizesFromCommonNameOnly() {
+        var photo = Photo(filename: "x.CR3", filePath: "/tmp/x.CR3", folderPath: "/tmp")
+        photo.speciesCommonName = "Robin"
+        let list = photo.assignedSpecies
+        #expect(list.count == 1)
+        // Scientific name is missing — the getter derives a stable slot from
+        // the common name so `speciesID` isn't empty.
+        #expect(list.first?.scientificName == "Robin")
+        #expect(list.first?.speciesID == "Robin")
+    }
+
+    @Test func assignedSpeciesFallbackEmptyWhenAllScalarNil() {
+        let photo = Photo(filename: "x.CR3", filePath: "/tmp/x.CR3", folderPath: "/tmp")
+        #expect(photo.assignedSpecies.isEmpty)
+    }
+
+    // MARK: - Photo.inheritSpecies
+
+    @Test func inheritSpeciesCopiesAssignedSpeciesJSON() {
+        var donor = Photo(filename: "d.CR3", filePath: "/tmp/d.CR3", folderPath: "/tmp")
+        donor.assignedSpecies = [
+            match(sci: "Aquila", common: "Eagle", ebird: "eagle"),
+            match(sci: "Accipiter", common: "Hawk", ebird: "hawk"),
+        ]
+
+        var recipient = Photo(filename: "r.CR3", filePath: "/tmp/r.CR3", folderPath: "/tmp")
+        recipient.inheritSpecies(from: donor)
+
+        #expect(recipient.assignedSpeciesJSON == donor.assignedSpeciesJSON)
+        #expect(recipient.assignedSpecies.map(\.speciesID) == ["eagle", "hawk"])
+        // Scalar mirrors come along too.
+        #expect(recipient.speciesCommonName == "Eagle")
+    }
+
+    // MARK: - AppState.setAssignedSpecies
+
+    @Test func setAssignedSpeciesPersistsToDB() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let db = try ReportDatabase(folderPath: folder)
+        var photo = makePhoto(folder: folder, filename: "seed.CR3")
+        photo.assignedSpecies = [match(sci: "Aquila", common: "Eagle", ebird: "eagle")]
+        try db.save(&photo)
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+
+        let hawk = match(sci: "Accipiter", common: "Hawk", ebird: "hawk")
+        appState.setAssignedSpecies(id: photo.id, species: [
+            match(sci: "Aquila", common: "Eagle", ebird: "eagle"),
+            hawk,
+        ])
+
+        // DB round-trip: refetch via a fresh database handle.
+        let db2 = try ReportDatabase(folderPath: folder)
+        let refetched = try #require(try db2.fetchPhoto(id: photo.id))
+        #expect(refetched.assignedSpecies.count == 2)
+        #expect(refetched.assignedSpecies.map(\.speciesID) == ["eagle", "hawk"])
+    }
+
+    @Test func setAssignedSpeciesUpdatesSidebarBuckets() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let db = try ReportDatabase(folderPath: folder)
+        var photo = makePhoto(folder: folder, filename: "seed.CR3")
+        photo.assignedSpecies = [match(sci: "Aquila", common: "Eagle", ebird: "eagle")]
+        try db.save(&photo)
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+        #expect(appState.speciesEntries.contains { $0.speciesID == "eagle" })
+        #expect(!appState.speciesEntries.contains { $0.speciesID == "hawk" })
+
+        appState.setAssignedSpecies(id: photo.id, species: [
+            match(sci: "Aquila", common: "Eagle", ebird: "eagle"),
+            match(sci: "Accipiter", common: "Hawk", ebird: "hawk"),
+        ])
+
+        #expect(appState.speciesEntries.contains { $0.speciesID == "eagle" })
+        #expect(appState.speciesEntries.contains { $0.speciesID == "hawk" })
+    }
+
+    @Test func setAssignedSpeciesEmptyMovesPhotoToUnidentified() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let db = try ReportDatabase(folderPath: folder)
+        var photo = makePhoto(folder: folder, filename: "seed.CR3")
+        photo.assignedSpecies = [match(sci: "Aquila", common: "Eagle", ebird: "eagle")]
+        try db.save(&photo)
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+        appState.setAssignedSpecies(id: photo.id, species: [])
+
+        appState.sidebarSelection = .species(nil) // Unidentified bucket
+        appState.applyFilter()
+        #expect(appState.photos.count == 1)
+
+        appState.sidebarSelection = .species("eagle")
+        appState.applyFilter()
+        #expect(appState.photos.isEmpty)
+    }
+
+    // MARK: - AppState.correctSpecies (inline rename shim)
+
+    @Test func correctSpeciesRenamesCommonNameWithoutChangingSpeciesID() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let db = try ReportDatabase(folderPath: folder)
+        var photo = makePhoto(folder: folder, filename: "seed.CR3")
+        photo.assignedSpecies = [match(sci: "Aquila chrysaetos",
+                                        common: "Bald Eagle", // deliberately wrong
+                                        ebird: "goleag")]
+        try db.save(&photo)
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+        appState.correctSpecies(id: photo.id, commonName: "Golden Eagle")
+
+        let db2 = try ReportDatabase(folderPath: folder)
+        let refetched = try #require(try db2.fetchPhoto(id: photo.id))
+        #expect(refetched.assignedSpecies.first?.commonName == "Golden Eagle")
+        // Stable identity preserved — the sidebar bucket shouldn't jump.
+        #expect(refetched.assignedSpecies.first?.speciesID == "goleag")
+        #expect(refetched.assignedSpecies.first?.scientificName == "Aquila chrysaetos")
+    }
+
+    @Test func correctSpeciesOnUnidentifiedPhotoCreatesCustomEntry() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let db = try ReportDatabase(folderPath: folder)
+        var photo = makePhoto(folder: folder, filename: "seed.CR3")
+        try db.save(&photo)
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+        appState.correctSpecies(id: photo.id, commonName: "Mystery Bird")
+
+        let db2 = try ReportDatabase(folderPath: folder)
+        let refetched = try #require(try db2.fetchPhoto(id: photo.id))
+        #expect(refetched.assignedSpecies.count == 1)
+        #expect(refetched.assignedSpecies.first?.commonName == "Mystery Bird")
+        #expect(refetched.assignedSpecies.first?.ebirdCode == nil)
+        // Fallback: scientific name == typed text when OSEA has no match.
+        #expect(refetched.assignedSpecies.first?.scientificName == "Mystery Bird")
+    }
+
+    // MARK: - photoHasSpeciesID via .species(...) filter
+
+    @Test func speciesFilterMatchesAnyAssignedEntry() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let db = try ReportDatabase(folderPath: folder)
+        var a = makePhoto(folder: folder, filename: "a.CR3")
+        a.assignedSpecies = [match(sci: "Aquila", common: "Eagle", ebird: "eagle")]
+        var b = makePhoto(folder: folder, filename: "b.CR3")
+        b.assignedSpecies = [
+            match(sci: "Aquila", common: "Eagle", ebird: "eagle"),
+            match(sci: "Accipiter", common: "Hawk", ebird: "hawk"),
+        ]
+        var c = makePhoto(folder: folder, filename: "c.CR3")
+        c.assignedSpecies = [match(sci: "Accipiter", common: "Hawk", ebird: "hawk")]
+        for var p in [a, b, c] { try db.save(&p) }
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+
+        appState.sidebarSelection = .species("eagle")
+        appState.applyFilter()
+        #expect(appState.photos.count == 2) // a + b
+
+        appState.sidebarSelection = .species("hawk")
+        appState.applyFilter()
+        #expect(appState.photos.count == 2) // b + c
+    }
+}

--- a/apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift
@@ -181,8 +181,9 @@ import Foundation
         let appState = AppState()
         appState.loadPhotos(for: folder)
 
-        // Filter singles for Eagle
-        appState.sidebarSelection = .singles("Eagle")
+        // Filter singles for Eagle (bucket key is the scientific name because
+        // no eBird code is set on test SpeciesMatch entries).
+        appState.sidebarSelection = .singles("Aquila")
         appState.applyFilter()
 
         #expect(appState.photos.count == 1)
@@ -206,8 +207,8 @@ import Foundation
         let appState = AppState()
         appState.loadPhotos(for: folder)
 
-        let unidentifiedName = appState.speciesEntries.first { $0.isUnidentified }?.name ?? "Unidentified"
-        appState.sidebarSelection = .singles(unidentifiedName)
+        // Unidentified bucket is keyed by `nil`, not by a display string.
+        appState.sidebarSelection = .singles(nil)
         appState.applyFilter()
 
         #expect(appState.photos.count == 2)
@@ -246,9 +247,9 @@ import Foundation
         defer { try? FileManager.default.removeItem(at: folder) }
 
         let entries = [
-            SpeciesEntry(name: "Hawk", cnName: "鹰", count: 1, burstGroups: [], singlePhotos: 1, isUnidentified: false),
-            SpeciesEntry(name: "Eagle", cnName: "雕", count: 1, burstGroups: [], singlePhotos: 1, isUnidentified: false),
-            SpeciesEntry(name: "Egret", cnName: "白鹭", count: 1, burstGroups: [], singlePhotos: 1, isUnidentified: false),
+            SpeciesEntry(speciesID: "hawk", scientificName: "Accipiter", name: "Hawk", cnName: "鹰", count: 1, burstGroups: [], singlePhotos: 1, isUnidentified: false),
+            SpeciesEntry(speciesID: "eagle", scientificName: "Aquila", name: "Eagle", cnName: "雕", count: 1, burstGroups: [], singlePhotos: 1, isUnidentified: false),
+            SpeciesEntry(speciesID: "egret", scientificName: "Egretta", name: "Egret", cnName: "白鹭", count: 1, burstGroups: [], singlePhotos: 1, isUnidentified: false),
         ]
 
         let sorted = SpeciesHierarchyBuilder.sorted(
@@ -317,5 +318,67 @@ import Foundation
         let eagle = appState.speciesEntries.first { $0.name == "Eagle" }
         #expect(eagle?.burstGroups.isEmpty == true)
         #expect(eagle?.singlePhotos == 2)
+    }
+
+    // MARK: - Multi-species assignment
+
+    @Test func photoWithTwoSpeciesAppearsInBothBuckets() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        var photo = makePhoto(folder: folder)
+        photo.assignedSpecies = [
+            SpeciesMatch(scientificName: "Aquila", commonName: "Eagle",
+                         confidence: 0.9, cnName: nil, pinyin: nil,
+                         thresholdUsed: "gps", ebirdCode: "eagle"),
+            SpeciesMatch(scientificName: "Accipiter", commonName: "Hawk",
+                         confidence: 0.4, cnName: nil, pinyin: nil,
+                         thresholdUsed: "country", ebirdCode: "hawk"),
+        ]
+        try setupDB(folder: folder, photos: [photo])
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+
+        let eagle = appState.speciesEntries.first { $0.speciesID == "eagle" }
+        let hawk = appState.speciesEntries.first { $0.speciesID == "hawk" }
+        #expect(eagle?.count == 1)
+        #expect(hawk?.count == 1)
+        #expect(eagle?.singlePhotos == 1)
+        #expect(hawk?.singlePhotos == 1)
+
+        // Filtering by either bucket returns the same photo.
+        appState.sidebarSelection = .species("eagle")
+        appState.applyFilter()
+        #expect(appState.photos.count == 1)
+
+        appState.sidebarSelection = .species("hawk")
+        appState.applyFilter()
+        #expect(appState.photos.count == 1)
+    }
+
+    @Test func twoSpeciesWithSameDisplayNameStayDistinct() throws {
+        // Safety net for the "never key by display name" rule: two species
+        // sharing the same common name but different eBird codes must show
+        // up as two buckets, not one merged entry.
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        var a = makePhoto(folder: folder, filename: "IMG_A.CR3")
+        a.assignedSpecies = [SpeciesMatch(scientificName: "Species A", commonName: "Sparrow",
+                                           confidence: 0.8, cnName: nil, pinyin: nil,
+                                           thresholdUsed: "gps", ebirdCode: "sparow_a")]
+        var b = makePhoto(folder: folder, filename: "IMG_B.CR3")
+        b.assignedSpecies = [SpeciesMatch(scientificName: "Species B", commonName: "Sparrow",
+                                           confidence: 0.8, cnName: nil, pinyin: nil,
+                                           thresholdUsed: "gps", ebirdCode: "sparow_b")]
+        try setupDB(folder: folder, photos: [a, b])
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+
+        let sparrowBuckets = appState.speciesEntries.filter { $0.name == "Sparrow" }
+        #expect(sparrowBuckets.count == 2)
+        #expect(Set(sparrowBuckets.compactMap(\.speciesID)) == Set(["sparow_a", "sparow_b"]))
     }
 }

--- a/apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift
@@ -357,6 +357,46 @@ import Foundation
         #expect(appState.photos.count == 1)
     }
 
+    @Test func multiSpeciesPhotoInBurstAppearsOnceUnderDominantSpeciesBucket() throws {
+        // Burst members each tagged primary=Eagle; one of them also carries
+        // a secondary Hawk tag. The burst bucket assignment should stick
+        // with Eagle (driven by PRIMARY species confidence, not the union)
+        // so the same burst doesn't show up under both Eagle and Hawk.
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let burstID = UUID()
+        var a = makePhoto(folder: folder, filename: "A.CR3", burstGroupID: burstID)
+        a.assignedSpecies = [
+            SpeciesMatch(scientificName: "Aquila", commonName: "Eagle",
+                         confidence: 0.95, cnName: nil, pinyin: nil,
+                         thresholdUsed: "gps", ebirdCode: "eagle"),
+        ]
+        var b = makePhoto(folder: folder, filename: "B.CR3", burstGroupID: burstID)
+        b.assignedSpecies = [
+            SpeciesMatch(scientificName: "Aquila", commonName: "Eagle",
+                         confidence: 0.92, cnName: nil, pinyin: nil,
+                         thresholdUsed: "gps", ebirdCode: "eagle"),
+            SpeciesMatch(scientificName: "Accipiter", commonName: "Hawk",
+                         confidence: 0.30, cnName: nil, pinyin: nil,
+                         thresholdUsed: "country", ebirdCode: "hawk"),
+        ]
+        try setupDB(folder: folder, photos: [a, b])
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+
+        let eagle = appState.speciesEntries.first { $0.speciesID == "eagle" }
+        let hawk = appState.speciesEntries.first { $0.speciesID == "hawk" }
+
+        // Eagle owns the burst; Hawk still has the one photo as a single
+        // contribution (count=1) but no burst under its bucket.
+        #expect(eagle?.burstGroups.count == 1)
+        #expect(eagle?.burstGroups.first?.count == 2)
+        #expect(hawk?.burstGroups.isEmpty == true)
+        #expect(hawk?.count == 1)
+    }
+
     @Test func twoSpeciesWithSameDisplayNameStayDistinct() throws {
         // Safety net for the "never key by display name" rule: two species
         // sharing the same common name but different eBird codes must show

--- a/apps/mac-client/SuperPickyTests/Core/XMPWriterTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/XMPWriterTests.swift
@@ -181,4 +181,47 @@ import Foundation
         #expect(xml.contains("<rdf:li>Bird|Robin</rdf:li>"))
         // No scientific name line beyond the common name
     }
+
+    // MARK: - Multi-species
+
+    @Test func xmpEmitsKeywordsForEveryAssignedSpecies() {
+        var photo = makePhoto(starRating: 4, isFlying: false)
+        photo.assignedSpecies = [
+            SpeciesMatch(scientificName: "Aquila chrysaetos", commonName: "Golden Eagle",
+                         confidence: 0.9, cnName: "金雕", pinyin: "jindiao",
+                         thresholdUsed: "gps", ebirdCode: "goleag"),
+            SpeciesMatch(scientificName: "Buteo jamaicensis", commonName: "Red-tailed Hawk",
+                         confidence: 0.4, cnName: nil, pinyin: nil,
+                         thresholdUsed: "country", ebirdCode: "rethaw"),
+        ]
+        let xml = XMPWriter.generate(photo: photo)
+        #expect(xml.contains("<rdf:li>Golden Eagle</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Aquila chrysaetos</rdf:li>"))
+        #expect(xml.contains("<rdf:li>金雕</rdf:li>"))
+        #expect(xml.contains("<rdf:li>jindiao</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Red-tailed Hawk</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Buteo jamaicensis</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Bird|Golden Eagle</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Bird|Red-tailed Hawk</rdf:li>"))
+    }
+
+    @Test func xmpDedupesKeywordsThatCollideAcrossSpecies() {
+        // Two matches sharing the same common name — rare but possible for
+        // renamed OSEA classes. Only one rdf:li per unique string.
+        var photo = makePhoto(starRating: 3)
+        photo.assignedSpecies = [
+            SpeciesMatch(scientificName: "Species A", commonName: "Sparrow",
+                         confidence: 0.8, cnName: nil, pinyin: nil,
+                         thresholdUsed: "global", ebirdCode: "a"),
+            SpeciesMatch(scientificName: "Species B", commonName: "Sparrow",
+                         confidence: 0.3, cnName: nil, pinyin: nil,
+                         thresholdUsed: "global", ebirdCode: "b"),
+        ]
+        let xml = XMPWriter.generate(photo: photo)
+        let sparrowCount = xml.components(separatedBy: "<rdf:li>Sparrow</rdf:li>").count - 1
+        #expect(sparrowCount == 1)
+        // Hierarchy also dedupes
+        let hierCount = xml.components(separatedBy: "<rdf:li>Bird|Sparrow</rdf:li>").count - 1
+        #expect(hierCount == 1)
+    }
 }

--- a/apps/mac-client/SuperPickyTests/Core/XMPWriterTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/XMPWriterTests.swift
@@ -205,6 +205,43 @@ import Foundation
         #expect(xml.contains("<rdf:li>Bird|Red-tailed Hawk</rdf:li>"))
     }
 
+    @Test func xmpMultipleSpeciesPlusFlyingEmitsAllKeywords() {
+        var photo = makePhoto(starRating: 4, isFlying: true)
+        photo.assignedSpecies = [
+            SpeciesMatch(scientificName: "A", commonName: "First",
+                         confidence: 0.9, cnName: nil, pinyin: nil,
+                         thresholdUsed: "gps", ebirdCode: "a"),
+            SpeciesMatch(scientificName: "B", commonName: "Second",
+                         confidence: 0.5, cnName: nil, pinyin: nil,
+                         thresholdUsed: "country", ebirdCode: "b"),
+        ]
+        let xml = XMPWriter.generate(photo: photo)
+        #expect(xml.contains("<rdf:li>First</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Second</rdf:li>"))
+        #expect(xml.contains("<rdf:li>In Flight</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Bird|First</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Bird|Second</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Behavior|In Flight</rdf:li>"))
+    }
+
+    @Test func xmpEmptyAssignedListWithFlyingStillEmitsFlightKeyword() {
+        var photo = makePhoto(starRating: 3, isFlying: true)
+        photo.assignedSpecies = []
+        let xml = XMPWriter.generate(photo: photo)
+        // Flight section present even when the photo has no species.
+        #expect(xml.contains("dc:subject"))
+        #expect(xml.contains("<rdf:li>In Flight</rdf:li>"))
+        #expect(xml.contains("<rdf:li>Behavior|In Flight</rdf:li>"))
+    }
+
+    @Test func xmpEmptyAssignedListAndNotFlyingOmitsKeywordSections() {
+        var photo = makePhoto(starRating: 2)
+        photo.assignedSpecies = []
+        let xml = XMPWriter.generate(photo: photo)
+        #expect(!xml.contains("dc:subject"))
+        #expect(!xml.contains("lr:hierarchicalSubject"))
+    }
+
     @Test func xmpDedupesKeywordsThatCollideAcrossSpecies() {
         // Two matches sharing the same common name — rare but possible for
         // renamed OSEA classes. Only one rdf:li per unique string.

--- a/apps/mac-client/SuperPickyTests/Data/ReportDatabaseTests.swift
+++ b/apps/mac-client/SuperPickyTests/Data/ReportDatabaseTests.swift
@@ -159,12 +159,13 @@ import GRDB
         // Clear assignedSpeciesJSON to mimic a pre-migration row that the
         // backfill wouldn't have seen (or any row where it's still nil),
         // then re-fetch to confirm the accessor fallback.
-        _ = try db.fetchPhoto(id: legacy.id)
-        var row = try #require(try db.fetchPhoto(id: legacy.id))
+        let fetched = try db.fetchPhoto(id: legacy.id)
+        var row = try #require(fetched)
         row.assignedSpeciesJSON = nil
         try db.save(&row)
 
-        let refetched = try #require(try db.fetchPhoto(id: legacy.id))
+        let reread = try db.fetchPhoto(id: legacy.id)
+        let refetched = try #require(reread)
         #expect(refetched.assignedSpecies.count == 1)
         #expect(refetched.assignedSpecies.first?.scientificName == "Falco peregrinus")
         #expect(refetched.assignedSpecies.first?.commonName == "Peregrine Falcon")

--- a/apps/mac-client/SuperPickyTests/Data/ReportDatabaseTests.swift
+++ b/apps/mac-client/SuperPickyTests/Data/ReportDatabaseTests.swift
@@ -137,6 +137,39 @@ import GRDB
         #expect(fetched == nil)
     }
 
+    @Test func v8MigrationBackfillsAssignedSpeciesFromScalarColumns() throws {
+        let tempDir = try makeTempDir()
+        // Fresh DB via ReportDatabase — already at v8.
+        let db = try ReportDatabase(folderPath: tempDir)
+
+        // Insert a photo using ONLY the legacy scalar columns (simulating a
+        // row written before the assignedSpecies accessor existed). Then
+        // verify the accessor falls back to synthesizing a one-element
+        // list so existing tests and persisted data keep working.
+        var legacy = Photo(
+            filename: "legacy.CR3",
+            filePath: tempDir.appendingPathComponent("legacy.CR3").path,
+            folderPath: tempDir.path
+        )
+        legacy.speciesScientificName = "Falco peregrinus"
+        legacy.speciesCommonName = "Peregrine Falcon"
+        legacy.speciesConfidence = 0.88
+        try db.save(&legacy)
+
+        // Clear assignedSpeciesJSON to mimic a pre-migration row that the
+        // backfill wouldn't have seen (or any row where it's still nil),
+        // then re-fetch to confirm the accessor fallback.
+        _ = try db.fetchPhoto(id: legacy.id)
+        var row = try #require(try db.fetchPhoto(id: legacy.id))
+        row.assignedSpeciesJSON = nil
+        try db.save(&row)
+
+        let refetched = try #require(try db.fetchPhoto(id: legacy.id))
+        #expect(refetched.assignedSpecies.count == 1)
+        #expect(refetched.assignedSpecies.first?.scientificName == "Falco peregrinus")
+        #expect(refetched.assignedSpecies.first?.commonName == "Peregrine Falcon")
+    }
+
     @Test func deleteNonManualPhotos_preservesManualRatings() throws {
         let dir = try makeTempDir()
         var db = try ReportDatabase(folderPath: dir)

--- a/apps/mac-client/SuperPickyTests/Inference/SpeciesDatabaseTests.swift
+++ b/apps/mac-client/SuperPickyTests/Inference/SpeciesDatabaseTests.swift
@@ -31,4 +31,32 @@ struct SpeciesDatabaseTests {
         #expect(!pinyin.isEmpty)
         #expect(!pinyin.contains(" "))
     }
+
+    /// Autocomplete powers the species edit panel. Validates that a
+    /// well-known English-name prefix finds the species (ranked ahead of
+    /// substring matches) and that scientific + Chinese + pinyin lookups
+    /// also hit.
+    @Test("search matches english, scientific, chinese, pinyin")
+    func searchMatchesAcrossNameFields() throws {
+        let url = try #require(SpeciesDatabase.bundledURL(),
+                               "bundled bird_reference.sqlite is missing")
+        let db = try SpeciesDatabase(url: url)
+
+        let englishHits = db.search(query: "Anna")
+        #expect(englishHits.contains { $0.englishName == "Anna's Hummingbird" })
+
+        let scientificHits = db.search(query: "Calypte")
+        #expect(scientificHits.contains { $0.englishName == "Anna's Hummingbird" })
+
+        let chineseHits = db.search(query: "安氏")
+        #expect(chineseHits.contains { $0.englishName == "Anna's Hummingbird" })
+    }
+
+    @Test("search returns no matches on empty query")
+    func searchRejectsEmptyQuery() throws {
+        let url = try #require(SpeciesDatabase.bundledURL())
+        let db = try SpeciesDatabase(url: url)
+        #expect(db.search(query: "").isEmpty)
+        #expect(db.search(query: "   ").isEmpty)
+    }
 }

--- a/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -9,6 +9,7 @@ import XCTest
 /// - 10-19: Keyboard shortcuts (fullscreen, zoom, navigation)
 /// - 20-29: Star filter and photo counter
 /// - 30-39: Export
+/// - 40-49: Species edit panel
 final class CullingWorkflowUITests: XCTestCase {
 
     static var app: XCUIApplication!
@@ -245,5 +246,340 @@ final class CullingWorkflowUITests: XCTestCase {
         let resetText = counter.value as? String ?? ""
         XCTAssertEqual(resetText, initialText,
                        "After reset, counter should match initial")
+    }
+
+    // MARK: - 40-49: Species Edit Panel
+
+    // Thumbnail identifiers repeat in the accessibility tree (favorite badge
+    // etc.); `.firstMatch` picks the top-level image view the existing
+    // screenshot tests target too.
+    private func selectThumbnail(filename: String) {
+        let thumb = Self.app.images.matching(identifier: "Thumbnail_\(filename)").firstMatch
+        XCTAssertTrue(thumb.waitForExistence(timeout: 10),
+                      "\(filename) thumbnail should exist")
+
+        // Prior tests may have scrolled the horizontal strip so the target
+        // is off-screen. Arrow keys navigate selection *and* auto-scroll;
+        // batch into chunks of 5 to amortise the expensive isHittable query.
+        if !thumb.isHittable {
+            Self.app.images["PhotoPreview"].click()
+            for direction in [XCUIKeyboardKey.leftArrow, .rightArrow] {
+                for _ in 0..<6 {
+                    if thumb.isHittable { break }
+                    for _ in 0..<5 { Self.app.typeKey(direction, modifierFlags: []) }
+                }
+                if thumb.isHittable { break }
+            }
+        }
+        thumb.click()
+        Thread.sleep(forTimeInterval: 0.5)
+    }
+
+    private func selectEaglePhoto() { selectThumbnail(filename: "DSC00001.jpg") }
+
+    // The panel's root ScrollView isn't reliably queryable by its accessibility
+    // identifier; the search field is unique to the panel and works as a proxy.
+    private func panelIsOpen() -> Bool {
+        Self.app.textFields["SpeciesEditPanel_SearchField"].exists
+    }
+
+    private func ensurePanelClosed() {
+        guard panelIsOpen() else { return }
+        Self.app.buttons["SpeciesEditToggle"].click()
+        Thread.sleep(forTimeInterval: 0.4)
+    }
+
+    private func openPanelOnEagle() {
+        ensurePanelClosed()
+        selectEaglePhoto()
+        Self.app.buttons["SpeciesEditToggle"].click()
+        XCTAssertTrue(Self.app.textFields["SpeciesEditPanel_SearchField"].waitForExistence(timeout: 3),
+                      "Panel should open")
+    }
+
+    private func clearSearchField() {
+        Self.app.typeKey("a", modifierFlags: .command)
+        Self.app.typeKey(.delete, modifierFlags: [])
+        Thread.sleep(forTimeInterval: 0.2)
+    }
+
+    private func poll(timeout: TimeInterval, _ check: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if check() { return true }
+            Thread.sleep(forTimeInterval: 0.15)
+        }
+        return false
+    }
+
+    private func waitForSidecar(at path: String,
+                                containing needle: String,
+                                timeout: TimeInterval) -> Bool {
+        poll(timeout: timeout) {
+            (try? String(contentsOfFile: path))?.contains(needle) ?? false
+        }
+    }
+
+    private func waitForSidecar(at path: String,
+                                satisfying predicate: @escaping (String) -> Bool,
+                                timeout: TimeInterval) -> Bool {
+        poll(timeout: timeout) {
+            guard let contents = try? String(contentsOfFile: path) else { return false }
+            return predicate(contents)
+        }
+    }
+
+    func test40_SpeciesEditToggleExists() {
+        XCTAssertTrue(Self.app.buttons["SpeciesEditToggle"].waitForExistence(timeout: 5))
+    }
+
+    func test41_ToggleOpensPanelWithAssignedSpecies() {
+        openPanelOnEagle()
+        XCTAssertTrue(Self.app.buttons["SpeciesEditPanel_Remove_baleag"].waitForExistence(timeout: 2))
+        ensurePanelClosed()
+    }
+
+    func test42_KeyboardShortcutSToggles() {
+        let app = Self.app!
+        ensurePanelClosed()
+        selectEaglePhoto()
+
+        // PhotoPreview click hands focus back to the NSEvent key monitor.
+        app.images["PhotoPreview"].click()
+        Thread.sleep(forTimeInterval: 0.3)
+
+        app.typeKey("s", modifierFlags: [])
+        let field = app.textFields["SpeciesEditPanel_SearchField"]
+        XCTAssertTrue(field.waitForExistence(timeout: 2), "`s` should open panel")
+
+        app.typeKey("s", modifierFlags: [])
+        Thread.sleep(forTimeInterval: 0.4)
+        XCTAssertFalse(field.exists, "`s` again should close panel")
+    }
+
+    func test43_CandidatesListShowsNonAssignedTop5() {
+        let app = Self.app!
+        openPanelOnEagle()
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Add_goleag"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Add_osprey"].exists)
+        ensurePanelClosed()
+    }
+
+    func test44_AddCandidateMovesToAssigned() {
+        let app = Self.app!
+        openPanelOnEagle()
+
+        let add = app.buttons["SpeciesEditPanel_Add_goleag"]
+        XCTAssertTrue(add.waitForExistence(timeout: 3))
+        add.click()
+
+        let remove = app.buttons["SpeciesEditPanel_Remove_goleag"]
+        XCTAssertTrue(remove.waitForExistence(timeout: 2))
+        XCTAssertFalse(app.buttons["SpeciesEditPanel_Add_goleag"].exists)
+
+        remove.click()
+        Thread.sleep(forTimeInterval: 0.3)
+        ensurePanelClosed()
+    }
+
+    func test45_RemoveSecondarySpecies() {
+        let app = Self.app!
+        openPanelOnEagle()
+
+        app.buttons["SpeciesEditPanel_Add_goleag"].click()
+        let remove = app.buttons["SpeciesEditPanel_Remove_goleag"]
+        XCTAssertTrue(remove.waitForExistence(timeout: 2))
+        remove.click()
+
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Add_goleag"].waitForExistence(timeout: 2))
+        XCTAssertFalse(app.buttons["SpeciesEditPanel_Remove_goleag"].exists)
+        ensurePanelClosed()
+    }
+
+    func test46_SearchFieldAcceptsInput() {
+        let app = Self.app!
+        openPanelOnEagle()
+
+        let field = app.textFields["SpeciesEditPanel_SearchField"]
+        field.click()
+        field.typeText("robin")
+        Thread.sleep(forTimeInterval: 0.3)
+
+        let value = field.value as? String ?? ""
+        XCTAssertTrue(value.contains("robin"), "Got: \(value)")
+
+        clearSearchField()
+        ensurePanelClosed()
+    }
+
+    func test47_UnmatchedSearchReturnIsIgnored() {
+        let app = Self.app!
+        openPanelOnEagle()
+
+        let field = app.textFields["SpeciesEditPanel_SearchField"]
+        field.click()
+        let garbage = "MyCustomSpeciesXYZ"
+        field.typeText(garbage)
+        app.typeKey(.return, modifierFlags: [])
+        Thread.sleep(forTimeInterval: 0.5)
+
+        XCTAssertFalse(app.buttons["SpeciesEditPanel_Remove_\(garbage)"].exists,
+                       "Unmatched Return must not add a custom species")
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Remove_baleag"].exists)
+
+        clearSearchField()
+        ensurePanelClosed()
+    }
+
+    func test48_EmptyAssignedStateShown() {
+        let app = Self.app!
+        ensurePanelClosed()
+        // DSC00029 is a bird-but-unidentified photo in the mock fixture.
+        selectThumbnail(filename: "DSC00029.jpg")
+        app.buttons["SpeciesEditToggle"].click()
+        XCTAssertTrue(app.textFields["SpeciesEditPanel_SearchField"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["SpeciesEditPanel_EmptyAssigned"].waitForExistence(timeout: 2))
+        XCTAssertFalse(app.buttons["SpeciesEditPanel_Remove_baleag"].exists)
+        ensurePanelClosed()
+    }
+
+    func test49_PhotoChangeClearsSearch() {
+        let app = Self.app!
+        openPanelOnEagle()
+
+        let field = app.textFields["SpeciesEditPanel_SearchField"]
+        field.click()
+        field.typeText("transient")
+        Thread.sleep(forTimeInterval: 0.3)
+        XCTAssertTrue((field.value as? String ?? "").contains("transient"))
+
+        // Click a sibling thumbnail rather than pressing arrow keys — while
+        // the search field has focus, the app's NSEvent monitor skips keys.
+        let sibling = app.images.matching(identifier: "Thumbnail_DSC00003.jpg").firstMatch
+        XCTAssertTrue(sibling.waitForExistence(timeout: 5))
+        sibling.click()
+        Thread.sleep(forTimeInterval: 0.8)
+
+        let cleared = (field.value as? String ?? "")
+        XCTAssertTrue(cleared.isEmpty || cleared == "Search species",
+                      "Got: '\(cleared)'")
+        ensurePanelClosed()
+    }
+
+    func test50_RemovePrimaryPromotesNext() {
+        let app = Self.app!
+        openPanelOnEagle()
+
+        app.buttons["SpeciesEditPanel_Add_goleag"].click()
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Remove_goleag"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_MakePrimary_goleag"].exists)
+        XCTAssertFalse(app.buttons["SpeciesEditPanel_MakePrimary_baleag"].exists)
+
+        app.buttons["SpeciesEditPanel_Remove_baleag"].click()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        XCTAssertFalse(app.buttons["SpeciesEditPanel_Remove_baleag"].exists)
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Remove_goleag"].exists)
+        XCTAssertFalse(app.buttons["SpeciesEditPanel_MakePrimary_goleag"].exists,
+                       "Golden should now be primary")
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Add_baleag"].waitForExistence(timeout: 2))
+
+        // Restore state for later tests.
+        app.buttons["SpeciesEditPanel_Remove_goleag"].click()
+        Thread.sleep(forTimeInterval: 0.3)
+        app.buttons["SpeciesEditPanel_Add_baleag"].click()
+        Thread.sleep(forTimeInterval: 0.3)
+        ensurePanelClosed()
+    }
+
+    func test51_MakePrimaryReordersAssigned() {
+        let app = Self.app!
+        openPanelOnEagle()
+
+        app.buttons["SpeciesEditPanel_Add_goleag"].click()
+        Thread.sleep(forTimeInterval: 0.4)
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_MakePrimary_goleag"].exists)
+        XCTAssertFalse(app.buttons["SpeciesEditPanel_MakePrimary_baleag"].exists)
+
+        app.buttons["SpeciesEditPanel_MakePrimary_goleag"].click()
+
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_MakePrimary_baleag"].waitForExistence(timeout: 2),
+                      "Bald should now have a make-primary button as secondary")
+        XCTAssertFalse(app.buttons["SpeciesEditPanel_MakePrimary_goleag"].exists)
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Remove_goleag"].exists)
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Remove_baleag"].exists)
+
+        app.buttons["SpeciesEditPanel_Remove_goleag"].click()
+        Thread.sleep(forTimeInterval: 0.3)
+        ensurePanelClosed()
+    }
+
+    func test52_CandidateRowsShowLevelAndConfidence() {
+        let app = Self.app!
+        openPanelOnEagle()
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Add_goleag"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["12%"].exists, "Confidence percentage should render")
+        XCTAssertTrue(app.staticTexts["Region"].exists, "thresholdUsed=country → 'Region' label")
+        ensurePanelClosed()
+    }
+
+    func test53_SpeciesEditWritesToXMPSidecar() {
+        let app = Self.app!
+        let sidecarPath = (Self.testDir! as NSString).appendingPathComponent("DSC00001.xmp")
+        openPanelOnEagle()
+
+        app.buttons["SpeciesEditPanel_Add_goleag"].click()
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Remove_goleag"].waitForExistence(timeout: 2))
+
+        XCTAssertTrue(waitForSidecar(at: sidecarPath, containing: "Golden Eagle", timeout: 3))
+        let afterAdd = (try? String(contentsOfFile: sidecarPath)) ?? ""
+        XCTAssertTrue(afterAdd.contains("Bald Eagle"))
+
+        app.buttons["SpeciesEditPanel_Remove_goleag"].click()
+        XCTAssertTrue(waitForSidecar(at: sidecarPath,
+                                     satisfying: { !$0.contains("Golden Eagle") },
+                                     timeout: 3))
+        let afterRemove = (try? String(contentsOfFile: sidecarPath)) ?? ""
+        XCTAssertTrue(afterRemove.contains("Bald Eagle"))
+        ensurePanelClosed()
+    }
+
+    // Regression: the EXIF panel's `.task(id:)` was keyed only on photo.id,
+    // so species edits (which rewrite the XMP sidecar without changing the
+    // id) left the keywords list stale.
+    func test54_InfoPanelRefreshesKeywordsOnSpeciesEdit() {
+        let app = Self.app!
+        ensurePanelClosed()
+        selectEaglePhoto()
+
+        let sidecarPath = (Self.testDir! as NSString).appendingPathComponent("DSC00001.xmp")
+        XCTAssertTrue(waitForSidecar(at: sidecarPath, containing: "Bald Eagle", timeout: 5))
+
+        let baldKeyword = app.staticTexts["ExifKeyword_Bald Eagle"]
+        if !baldKeyword.exists {
+            app.buttons["ExifToggle"].click()
+        }
+        XCTAssertTrue(baldKeyword.waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["ExifKeyword_Golden Eagle"].exists)
+
+        app.buttons["SpeciesEditToggle"].click()
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Add_goleag"].waitForExistence(timeout: 3))
+        app.buttons["SpeciesEditPanel_Add_goleag"].click()
+        XCTAssertTrue(app.buttons["SpeciesEditPanel_Remove_goleag"].waitForExistence(timeout: 2))
+
+        XCTAssertTrue(waitForSidecar(at: sidecarPath, containing: "Golden Eagle", timeout: 3))
+        XCTAssertTrue(app.staticTexts["ExifKeyword_Golden Eagle"].waitForExistence(timeout: 5),
+                      "EXIF keywords should refresh after species edit")
+        XCTAssertTrue(app.staticTexts["ExifKeyword_Bald Eagle"].exists)
+
+        app.buttons["SpeciesEditPanel_Remove_goleag"].click()
+        XCTAssertTrue(poll(timeout: 4) { !app.staticTexts["ExifKeyword_Golden Eagle"].exists },
+                      "Keyword should drop after removal")
+
+        ensurePanelClosed()
+        if baldKeyword.exists {
+            app.buttons["ExifToggle"].click()
+            Thread.sleep(forTimeInterval: 0.3)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Floating species edit panel (toolbar toggle + `S` shortcut) that lets the user add/remove species for the selected photo. Shows OSEA candidates grouped by cascade level (GPS / Region / Global) and an autocomplete-backed search against the full SpeciesDatabase for species OSEA missed.
- A photo now carries a list of `SpeciesMatch` in a new `assignedSpeciesJSON` column (migration v8 with backfill) — sidebar hierarchy, species filter, and XMP keywords iterate the full list so a photo tagged A+B shows under both sidebar buckets and writes both keyword sets to the sidecar.
- Identity is separated from display throughout: `SpeciesEntry` and `SidebarSelection.species(String?)` are keyed by eBird code (falling back to scientific name for custom entries), never by the localized common name. Renames no longer move the photo between buckets.
- OSEA candidate capture unions top-5 across every cascade level so near-misses from the regional tier still surface in the edit panel.

## Test plan

- [x] Extended `XMPWriterTests` — multi-species keywords, flying+multi, dedup on same common name, empty-list handling
- [x] Extended `SpeciesHierarchyTests` — photo under both buckets, same-common-name distinct by scientific name, burst primary-species bucketing with secondary tags
- [x] New `AssignedSpeciesTests` — `Photo.assignedSpecies` round-trip + scalar mirror, empty clears scalars, fallback path, `inheritSpecies`, `AppState.setAssignedSpecies` persistence + hierarchy update, `correctSpecies` preserves eBird ID
- [x] `ReportDatabaseTests.v8MigrationBackfillsAssignedSpeciesFromScalarColumns`
- [x] `SpeciesDatabaseTests.searchMatchesAcrossNameFields` for autocomplete
- [ ] Manual: toolbar bird icon opens panel; candidates list shows; add/remove updates sidebar counts; XMP sidecar lists both species; autocomplete finds a typed species by eBird code
- [ ] CI green

https://claude.ai/code/session_014mpiCsa5w83UBaGpCVxRah