### PR TITLE
ui(settings): align slider rows and remove tick marks

### DIFF
--- a/apps/mac-client/SuperPickyApp/AdvancedTab.swift
+++ b/apps/mac-client/SuperPickyApp/AdvancedTab.swift
@@ -7,83 +7,82 @@ struct AdvancedTab: View {
         @Bindable var config = config
         Form {
             Section(config.localized("Thresholds")) {
-                HStack {
-                    Text(config.localized("Sharpness"))
-                    Slider(value: $config.sharpnessThreshold, in: 100...800, step: 10)
-                    Text("\(Int(config.sharpnessThreshold))")
-                        .monospacedDigit()
-                        .frame(width: 40)
-                }
-                HStack {
-                    Text(config.localized("Aesthetics"))
-                    Slider(value: $config.aestheticsThreshold, in: 2.0...8.0, step: 0.1)
-                    Text(String(format: "%.1f", config.aestheticsThreshold))
-                        .monospacedDigit()
-                        .frame(width: 40)
-                }
-                HStack {
-                    Text(config.localized("Min Confidence"))
-                    Slider(value: $config.minConfidence, in: 0.3...0.7, step: 0.05)
-                    Text(String(format: "%.2f", config.minConfidence))
-                        .monospacedDigit()
-                        .frame(width: 40)
-                }
-                HStack {
-                    Text(config.localized("Min Aesthetics"))
-                    Slider(value: $config.minAesthetics, in: 2.0...5.0, step: 0.1)
-                    Text(String(format: "%.1f", config.minAesthetics))
-                        .monospacedDigit()
-                        .frame(width: 40)
-                }
+                SliderRow(label: config.localized("Sharpness"),
+                          value: snappedBinding($config.sharpnessThreshold, step: 10),
+                          range: 100...800,
+                          display: "\(Int(config.sharpnessThreshold))")
+                SliderRow(label: config.localized("Aesthetics"),
+                          value: snappedBinding($config.aestheticsThreshold, step: 0.1),
+                          range: 2.0...8.0,
+                          display: String(format: "%.1f", config.aestheticsThreshold))
+                SliderRow(label: config.localized("Min Confidence"),
+                          value: snappedBinding($config.minConfidence, step: 0.05),
+                          range: 0.3...0.7,
+                          display: String(format: "%.2f", config.minConfidence))
+                SliderRow(label: config.localized("Min Aesthetics"),
+                          value: snappedBinding($config.minAesthetics, step: 0.1),
+                          range: 2.0...5.0,
+                          display: String(format: "%.1f", config.minAesthetics))
             }
             Section(config.localized("Burst Detection")) {
                 Toggle(config.localized("Enable burst detection"), isOn: $config.burstDetectionEnabled)
                 if config.burstDetectionEnabled {
-                    HStack {
-                        Text(config.localized("Burst FPS"))
-                        Slider(
-                            value: Binding(
-                                get: { Double(config.burstFps) },
-                                set: { config.burstFps = Int($0) }
-                            ),
-                            in: 4...20,
-                            step: 1
-                        )
-                        Text("\(config.burstFps)")
-                            .monospacedDigit()
-                            .frame(width: 30)
-                    }
-                    HStack {
-                        Text(config.localized("Min Burst Count"))
-                        Slider(
-                            value: Binding(
-                                get: { Double(config.burstMinCount) },
-                                set: { config.burstMinCount = Int($0) }
-                            ),
-                            in: 2...10,
-                            step: 1
-                        )
-                        Text("\(config.burstMinCount)")
-                            .monospacedDigit()
-                            .frame(width: 30)
-                    }
-                    HStack {
-                        Text(config.localized("Hash Tolerance"))
-                        Slider(
-                            value: Binding(
-                                get: { Double(config.burstHashTolerance) },
-                                set: { config.burstHashTolerance = Int($0) }
-                            ),
-                            in: 4...30,
-                            step: 1
-                        )
-                        Text("\(config.burstHashTolerance)")
-                            .monospacedDigit()
-                            .frame(width: 30)
-                    }
+                    SliderRow(label: config.localized("Burst FPS"),
+                              value: intBinding($config.burstFps, in: 4...20),
+                              range: 4...20,
+                              display: "\(config.burstFps)")
+                    SliderRow(label: config.localized("Min Burst Count"),
+                              value: intBinding($config.burstMinCount, in: 2...10),
+                              range: 2...10,
+                              display: "\(config.burstMinCount)")
+                    SliderRow(label: config.localized("Hash Tolerance"),
+                              value: intBinding($config.burstHashTolerance, in: 4...30),
+                              range: 4...30,
+                              display: "\(config.burstHashTolerance)")
                 }
             }
         }
         .formStyle(.grouped)
     }
+}
+
+struct SliderRow<V: BinaryFloatingPoint>: View where V.Stride: BinaryFloatingPoint {
+    let label: String
+    @Binding var value: V
+    let range: ClosedRange<V>
+    let display: String
+
+    var body: some View {
+        LabeledContent {
+            HStack(spacing: 8) {
+                Slider(value: $value, in: range)
+                Text(display)
+                    .monospacedDigit()
+                    .frame(width: 40, alignment: .trailing)
+            }
+        } label: {
+            Text(label)
+        }
+    }
+}
+
+func snappedBinding(_ source: Binding<Float>, step: Float) -> Binding<Float> {
+    Binding(
+        get: { source.wrappedValue },
+        set: { source.wrappedValue = (($0 / step).rounded() * step) }
+    )
+}
+
+func snappedBinding(_ source: Binding<Double>, step: Double) -> Binding<Double> {
+    Binding(
+        get: { source.wrappedValue },
+        set: { source.wrappedValue = (($0 / step).rounded() * step) }
+    )
+}
+
+func intBinding(_ source: Binding<Int>, in range: ClosedRange<Int>) -> Binding<Double> {
+    Binding(
+        get: { Double(source.wrappedValue) },
+        set: { source.wrappedValue = min(range.upperBound, max(range.lowerBound, Int($0.rounded()))) }
+    )
 }

--- a/apps/mac-client/SuperPickyApp/BirdIDTab.swift
+++ b/apps/mac-client/SuperPickyApp/BirdIDTab.swift
@@ -15,20 +15,13 @@ struct BirdIDTab: View {
             }
 
             Section(config.localized("Confidence")) {
-                HStack {
-                    Text(config.localized("Bird ID Confidence"))
-                    Slider(
-                        value: Binding(
-                            get: { Double(config.birdIdConfidence) },
-                            set: { config.birdIdConfidence = Int($0) }
-                        ),
-                        in: 50...95,
-                        step: 5
-                    )
-                    Text("\(config.birdIdConfidence)%")
-                        .monospacedDigit()
-                        .frame(width: 40)
-                }
+                SliderRow(label: config.localized("Bird ID Confidence"),
+                          value: Binding(
+                              get: { Double(config.birdIdConfidence) },
+                              set: { config.birdIdConfidence = (Int(($0 / 5).rounded()) * 5) }
+                          ),
+                          range: 50...95,
+                          display: "\(config.birdIdConfidence)%")
                 Text(config.localized("Species below this confidence will not be written to EXIF."))
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/apps/mac-client/SuperPickyApp/CullingTab.swift
+++ b/apps/mac-client/SuperPickyApp/CullingTab.swift
@@ -9,32 +9,22 @@ struct CullingTab: View {
             Section(config.localized("Detection")) {
                 Toggle(config.localized("Enable exposure detection"), isOn: $config.exposureDetectionEnabled)
                 if config.exposureDetectionEnabled {
-                    HStack {
-                        Text(config.localized("Threshold"))
-                        Slider(value: $config.exposureThreshold, in: 0.05...0.20, step: 0.01)
-                        Text("\(Int(config.exposureThreshold * 100))%")
-                            .monospacedDigit()
-                            .frame(width: 40)
-                    }
+                    SliderRow(label: config.localized("Threshold"),
+                              value: snappedBinding($config.exposureThreshold, step: 0.01),
+                              range: 0.05...0.20,
+                              display: "\(Int(config.exposureThreshold * 100))%")
                 }
                 Toggle(config.localized("Enable flight detection"), isOn: $config.flightDetectionEnabled)
             }
 
             Section(config.localized("Picks")) {
-                HStack {
-                    Text(config.localized("Top percentage"))
-                    Slider(
-                        value: Binding(
-                            get: { Double(config.pickedTopPercentage) },
-                            set: { config.pickedTopPercentage = Int($0) }
-                        ),
-                        in: 10...50,
-                        step: 5
-                    )
-                    Text("\(config.pickedTopPercentage)%")
-                        .monospacedDigit()
-                        .frame(width: 40)
-                }
+                SliderRow(label: config.localized("Top percentage"),
+                          value: Binding(
+                              get: { Double(config.pickedTopPercentage) },
+                              set: { config.pickedTopPercentage = (Int(($0 / 5).rounded()) * 5) }
+                          ),
+                          range: 10...50,
+                          display: "\(config.pickedTopPercentage)%")
                 Text(config.localized("Percentage of top-rated photos to flag as picks."))
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/apps/mac-client/SuperPickyApp/SettingsView.swift
+++ b/apps/mac-client/SuperPickyApp/SettingsView.swift
@@ -16,7 +16,7 @@ struct SettingsView: View {
             AdvancedTab()
                 .tabItem { Label(config.localized("Advanced"), systemImage: "wrench.and.screwdriver") }
         }
-        .frame(width: 500, height: 300)
+        .frame(width: 640, height: 360)
         .environment(\.locale, config.appLanguage.locale)
         .task(id: config.appLanguage) {
             try? await Task.sleep(for: .milliseconds(100))


### PR DESCRIPTION
## Summary
- Shared `SliderRow` built on `LabeledContent` in Culling, Bird ID, and Advanced tabs — label column is sized by Form (not my padded HStack), so slider tracks align across rows and fill the full row width.
- Dropped `step:` from every `Slider` (on macOS that's what draws the tick-mark dashed line under the track) and snapped values via computed bindings (`snappedBinding` for `Float`/`Double`, `intBinding` for `Int`).
- Widened the Settings window from 500×300 to 640×360 so the now-full-width tracks actually have room.

## Test plan
- [ ] Open Settings → Culling: exposure `Threshold` and `Top percentage` sliders align, no ticks.
- [ ] Open Settings → Bird ID: `Bird ID Confidence` slider spans full row, no ticks.
- [ ] Open Settings → Advanced: all four Threshold sliders and all three Burst Detection sliders align, no ticks.
- [ ] Drag each slider — verify values still snap to their step (10 for sharpness, 0.05 for min confidence, 5 for percentages, 1 for Int sliders, etc.).
- [ ] Toggle language to 中文 — labels still fit the column.