### PR TITLE
fix(sidebar): burst appears under every tagged species

### DIFF
--- a/apps/mac-client/SuperPickyApp/SpeciesHierarchyBuilder.swift
+++ b/apps/mac-client/SuperPickyApp/SpeciesHierarchyBuilder.swift
@@ -4,9 +4,10 @@ import Foundation
 ///
 /// A photo may carry multiple species in its `assignedSpecies` list; the
 /// builder emits one contribution *per assigned species*, so a photo
-/// tagged with both A and B appears under both buckets. The primary
-/// (first) entry still drives burst-dominant-species assignment so a
-/// burst lives under one species only.
+/// tagged with both A and B appears under both buckets. Bursts follow
+/// the same rule: a burst whose members are tagged with species A and B
+/// appears under both A and B, each with a `BurstGroupEntry` carrying
+/// the full burst size.
 ///
 /// Bucket identity is `SpeciesMatch.speciesID` (eBird code or, when the
 /// user entered a custom species, the scientific name). Never the
@@ -24,32 +25,13 @@ struct SpeciesHierarchyBuilder {
         displayName: (SpeciesEntry) -> String = { $0.name },
         locale: Locale = .current
     ) -> [SpeciesEntry] {
-        // Assign each burst to its dominant species by highest confidence
-        // primary ID. A burst spanning multiple species classifications
-        // appears only once. Uses the PRIMARY species (assignedSpecies.first)
-        // — not the union — so multi-species tagging on individual photos
-        // doesn't duplicate bursts across buckets.
-        var burstPrimaryByGroup: [UUID: String] = [:]
-        var burstBestConfidence: [UUID: (id: String, confidence: Float)] = [:]
+        // Group burst members by group ID so each burst emits one
+        // BurstGroupEntry per bucket it's attached to, carrying the full
+        // burst size.
         var burstPhotos: [UUID: [Photo]] = [:]
-
         for photo in photos {
             guard let groupID = photo.burstGroupID else { continue }
             burstPhotos[groupID, default: []].append(photo)
-
-            guard let primary = photo.assignedSpecies.first else { continue }
-            let confidence = primary.confidence
-            if let current = burstBestConfidence[groupID] {
-                if confidence > current.confidence {
-                    burstBestConfidence[groupID] = (primary.speciesID, confidence)
-                }
-            } else {
-                burstBestConfidence[groupID] = (primary.speciesID, confidence)
-            }
-        }
-
-        for groupID in burstPhotos.keys {
-            burstPrimaryByGroup[groupID] = burstBestConfidence[groupID]?.id ?? unidentifiedKey
         }
 
         // Group photos by species ID. A multi-species photo contributes
@@ -82,16 +64,15 @@ struct SpeciesHierarchyBuilder {
         }
 
         let entries = bySpeciesID.map { id, bucket -> SpeciesEntry in
-            // Only include burst groups whose primary species matches this
-            // bucket. A multi-species photo still counts in every bucket,
-            // but each of its bursts shows up under only one species.
+            // A burst attaches to every bucket any of its members is
+            // tagged with. Because `bucket.photos` already filters to
+            // photos whose `assignedSpecies` includes `id`, any burst
+            // member seen here implies the burst is tagged with `id`.
             var burstGroupIDs: Set<UUID> = []
             var singleCount = 0
             for photo in bucket.photos {
                 if let groupID = photo.burstGroupID {
-                    if burstPrimaryByGroup[groupID] == id {
-                        burstGroupIDs.insert(groupID)
-                    }
+                    burstGroupIDs.insert(groupID)
                 } else {
                     singleCount += 1
                 }

--- a/apps/mac-client/SuperPickyTests/Core/AssignedSpeciesTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/AssignedSpeciesTests.swift
@@ -419,4 +419,41 @@ import Foundation
         #expect(soloAfter.assignedSpecies.map(\.speciesID) == ["hawk"])
         #expect(otherAfter.assignedSpecies.map(\.speciesID) == ["eagle"])
     }
+
+    @Test func burstFanOutWithSecondarySpeciesAppearsUnderBothSidebarBuckets() throws {
+        // Start with a burst where every member is tagged Eagle.
+        // Edit one member's species list to [Eagle, Hawk] — fan-out
+        // propagates [Eagle, Hawk] to every burst member. The sidebar
+        // hierarchy then shows the burst under BOTH Eagle and Hawk.
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let db = try ReportDatabase(folderPath: folder)
+        let eagle = match(sci: "Aquila", common: "Eagle", ebird: "eagle")
+
+        let burstID = UUID()
+        var burstIDs: [UUID] = []
+        for i in 0..<3 {
+            var p = makePhoto(folder: folder, filename: "burst_\(i).CR3")
+            p.burstGroupID = burstID
+            p.assignedSpecies = [eagle]
+            try db.save(&p)
+            burstIDs.append(p.id)
+        }
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+
+        let hawk = match(sci: "Accipiter", common: "Hawk", ebird: "hawk")
+        appState.setAssignedSpecies(id: burstIDs[0], species: [eagle, hawk])
+
+        let eagleEntry = appState.speciesEntries.first { $0.speciesID == "eagle" }
+        let hawkEntry = appState.speciesEntries.first { $0.speciesID == "hawk" }
+        #expect(eagleEntry?.burstGroups.count == 1)
+        #expect(eagleEntry?.burstGroups.first?.count == 3)
+        #expect(hawkEntry?.burstGroups.count == 1)
+        #expect(hawkEntry?.burstGroups.first?.count == 3)
+        #expect(eagleEntry?.burstGroups.first?.id == burstID)
+        #expect(hawkEntry?.burstGroups.first?.id == burstID)
+    }
 }

--- a/apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift
@@ -357,11 +357,11 @@ import Foundation
         #expect(appState.photos.count == 1)
     }
 
-    @Test func multiSpeciesPhotoInBurstAppearsOnceUnderDominantSpeciesBucket() throws {
+    @Test func multiSpeciesBurstAppearsUnderEveryTaggedSpecies() throws {
         // Burst members each tagged primary=Eagle; one of them also carries
-        // a secondary Hawk tag. The burst bucket assignment should stick
-        // with Eagle (driven by PRIMARY species confidence, not the union)
-        // so the same burst doesn't show up under both Eagle and Hawk.
+        // a secondary Hawk tag. The burst should appear under BOTH Eagle
+        // and Hawk in the sidebar so the secondary bucket isn't an empty
+        // drill-down.
         let folder = try makeTempFolder()
         defer { try? FileManager.default.removeItem(at: folder) }
 
@@ -389,11 +389,16 @@ import Foundation
         let eagle = appState.speciesEntries.first { $0.speciesID == "eagle" }
         let hawk = appState.speciesEntries.first { $0.speciesID == "hawk" }
 
-        // Eagle owns the burst; Hawk still has the one photo as a single
-        // contribution (count=1) but no burst under its bucket.
+        // Both buckets show the burst with the full burst size.
         #expect(eagle?.burstGroups.count == 1)
         #expect(eagle?.burstGroups.first?.count == 2)
-        #expect(hawk?.burstGroups.isEmpty == true)
+        #expect(hawk?.burstGroups.count == 1)
+        #expect(hawk?.burstGroups.first?.count == 2)
+        #expect(eagle?.burstGroups.first?.id == hawk?.burstGroups.first?.id)
+
+        // Bucket-level count: Eagle counts both members (both tagged Eagle);
+        // Hawk counts only the member actually tagged Hawk.
+        #expect(eagle?.count == 2)
         #expect(hawk?.count == 1)
     }
 

--- a/apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift
@@ -46,12 +46,14 @@ import Foundation
 
     // MARK: - Burst count uses global size
 
-    @Test func burstAssignedByHighestConfidence() throws {
+    @Test func burstWithMixedUnidentifiedAndTaggedMembersAppearsUnderBoth() throws {
         let folder = try makeTempFolder()
         defer { try? FileManager.default.removeItem(at: folder) }
 
         let burstID = UUID()
-        // 3 photos: 2 Unidentified, 1 Eagle with high confidence — Eagle wins
+        // 3 photos: 2 Unidentified, 1 Eagle. The burst is tagged with
+        // both "Unidentified" and "Eagle" across its members, so it must
+        // appear under BOTH sidebar buckets with the full burst size.
         let photos = [
             makePhoto(folder: folder, burstGroupID: burstID),
             makePhoto(folder: folder, burstGroupID: burstID),
@@ -65,20 +67,22 @@ import Foundation
         let eagle = appState.speciesEntries.first { $0.name == "Eagle" }
         let unidentified = appState.speciesEntries.first { $0.isUnidentified }
 
-        #expect(eagle != nil)
         #expect(eagle?.burstGroups.count == 1)
         #expect(eagle?.burstGroups.first?.count == 3) // global count
 
-        #expect(unidentified != nil)
-        #expect(unidentified?.burstGroups.isEmpty == true)
+        #expect(unidentified?.burstGroups.count == 1)
+        #expect(unidentified?.burstGroups.first?.count == 3)
+        #expect(eagle?.burstGroups.first?.id == unidentified?.burstGroups.first?.id)
     }
 
-    @Test func burstWithTwoSpeciesUsesHigherConfidence() throws {
+    @Test func burstWithDifferentSpeciesPerMemberAppearsUnderBoth() throws {
         let folder = try makeTempFolder()
         defer { try? FileManager.default.removeItem(at: folder) }
 
         let burstID = UUID()
-        // Eagle at 0.6, Hawk at 0.9 — Hawk wins
+        // Member A tagged Eagle, member B tagged Hawk (different primaries
+        // per member — can happen pre-fan-out or with non-fanned edits).
+        // The burst appears under BOTH Eagle and Hawk.
         let photos = [
             makePhoto(folder: folder, speciesCommonName: "Eagle", speciesScientificName: "Aquila", speciesConfidence: 0.6, burstGroupID: burstID),
             makePhoto(folder: folder, speciesCommonName: "Hawk", speciesScientificName: "Accipiter", speciesConfidence: 0.9, burstGroupID: burstID),
@@ -92,7 +96,10 @@ import Foundation
         let eagle = appState.speciesEntries.first { $0.name == "Eagle" }
 
         #expect(hawk?.burstGroups.count == 1)
-        #expect(eagle?.burstGroups.isEmpty == true)
+        #expect(hawk?.burstGroups.first?.count == 2)
+        #expect(eagle?.burstGroups.count == 1)
+        #expect(eagle?.burstGroups.first?.count == 2)
+        #expect(hawk?.burstGroups.first?.id == eagle?.burstGroups.first?.id)
     }
 
     @Test func burstAllUnidentifiedStaysUnidentified() throws {

--- a/docs/superpowers/plans/2026-04-20-burst-appears-under-every-tagged-species.md
+++ b/docs/superpowers/plans/2026-04-20-burst-appears-under-every-tagged-species.md
@@ -1,0 +1,335 @@
+# Burst Appears Under Every Tagged Species — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A burst whose members are tagged with more than one species appears under every tagged species in the sidebar, not only under the dominant primary species' bucket.
+
+**Architecture:** `SpeciesHierarchyBuilder.build` drops the "burst → dominant primary only" filter. Because `bucket.photos` is already built from the union of members' `assignedSpecies`, the fix is a one-line filter removal plus deletion of the now-unused `burstPrimaryByGroup` / `burstBestConfidence` helpers. No AppState changes, no UI changes.
+
+**Tech Stack:** Swift / Swift Testing, `SpeciesHierarchyBuilder` is a pure-computation struct.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-burst-appears-under-every-tagged-species-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `apps/mac-client/SuperPickyApp/SpeciesHierarchyBuilder.swift`
+  - Delete `burstPrimaryByGroup` and `burstBestConfidence`.
+  - Collapse the first-pass loop (36-49) to just populate `burstPhotos`.
+  - Replace the per-bucket filter (88-98) so every burst-member photo adds its groupID to `burstGroupIDs` unconditionally.
+
+- **Modify** `apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift`
+  - Rewrite and rename `multiSpeciesPhotoInBurstAppearsOnceUnderDominantSpeciesBucket` → `multiSpeciesBurstAppearsUnderEveryTaggedSpecies`.
+
+- **Modify** `apps/mac-client/SuperPickyTests/Core/AssignedSpeciesTests.swift`
+  - Add one new test covering the full user flow: fan-out secondary species onto a burst, rebuild, assert both sidebar buckets carry the burst.
+
+---
+
+## Task 1: Red test at the `SpeciesHierarchyBuilder` level
+
+**Files:**
+- Test: `apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift`
+
+- [ ] **Step 1: Rewrite and rename the test**
+
+Open `apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift` and replace the entire `multiSpeciesPhotoInBurstAppearsOnceUnderDominantSpeciesBucket` test body (starting at line 360) with:
+
+```swift
+    @Test func multiSpeciesBurstAppearsUnderEveryTaggedSpecies() throws {
+        // Burst members each tagged primary=Eagle; one of them also carries
+        // a secondary Hawk tag. The burst should appear under BOTH Eagle
+        // and Hawk in the sidebar so the secondary bucket isn't an empty
+        // drill-down.
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let burstID = UUID()
+        var a = makePhoto(folder: folder, filename: "A.CR3", burstGroupID: burstID)
+        a.assignedSpecies = [
+            SpeciesMatch(scientificName: "Aquila", commonName: "Eagle",
+                         confidence: 0.95, cnName: nil, pinyin: nil,
+                         thresholdUsed: "gps", ebirdCode: "eagle"),
+        ]
+        var b = makePhoto(folder: folder, filename: "B.CR3", burstGroupID: burstID)
+        b.assignedSpecies = [
+            SpeciesMatch(scientificName: "Aquila", commonName: "Eagle",
+                         confidence: 0.92, cnName: nil, pinyin: nil,
+                         thresholdUsed: "gps", ebirdCode: "eagle"),
+            SpeciesMatch(scientificName: "Accipiter", commonName: "Hawk",
+                         confidence: 0.30, cnName: nil, pinyin: nil,
+                         thresholdUsed: "country", ebirdCode: "hawk"),
+        ]
+        try setupDB(folder: folder, photos: [a, b])
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+
+        let eagle = appState.speciesEntries.first { $0.speciesID == "eagle" }
+        let hawk = appState.speciesEntries.first { $0.speciesID == "hawk" }
+
+        // Both buckets show the burst with the full burst size.
+        #expect(eagle?.burstGroups.count == 1)
+        #expect(eagle?.burstGroups.first?.count == 2)
+        #expect(hawk?.burstGroups.count == 1)
+        #expect(hawk?.burstGroups.first?.count == 2)
+        #expect(eagle?.burstGroups.first?.id == hawk?.burstGroups.first?.id)
+
+        // Bucket-level count: Eagle counts both members (both tagged Eagle);
+        // Hawk counts only the member actually tagged Hawk.
+        #expect(eagle?.count == 2)
+        #expect(hawk?.count == 1)
+    }
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+```bash
+cd apps/mac-client && swift test --filter SpeciesHierarchyTests.multiSpeciesBurstAppearsUnderEveryTaggedSpecies 2>&1 | tail -30
+```
+
+Expected: FAIL — `hawk?.burstGroups.count == 1` is violated because current code filters burst to dominant-primary only, so Hawk has `burstGroups.count == 0`.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac-sidebar-burst
+git add apps/mac-client/SuperPickyTests/Core/SpeciesHierarchyTests.swift
+git commit -m "test(sidebar): red test for burst appearing under every tagged species"
+```
+
+---
+
+## Task 2: Drop the dominant-primary filter in `SpeciesHierarchyBuilder.build`
+
+**Files:**
+- Modify: `apps/mac-client/SuperPickyApp/SpeciesHierarchyBuilder.swift`
+
+- [ ] **Step 1: Simplify the first-pass loop**
+
+Replace the current lines 27-53 (the two-pass burst-primary computation) with just the `burstPhotos` collection:
+
+```swift
+        // Group burst members by group ID so we can emit a single
+        // BurstGroupEntry per burst, with the total member count.
+        var burstPhotos: [UUID: [Photo]] = [:]
+        for photo in photos {
+            guard let groupID = photo.burstGroupID else { continue }
+            burstPhotos[groupID, default: []].append(photo)
+        }
+```
+
+Delete the `burstPrimaryByGroup` and `burstBestConfidence` declarations entirely.
+
+- [ ] **Step 2: Drop the filter in the per-bucket loop**
+
+Replace the current burstGroupIDs loop (lines 88-98):
+
+```swift
+            for photo in bucket.photos {
+                if let groupID = photo.burstGroupID {
+                    if burstPrimaryByGroup[groupID] == id {
+                        burstGroupIDs.insert(groupID)
+                    }
+                } else {
+                    singleCount += 1
+                }
+            }
+```
+
+with:
+
+```swift
+            for photo in bucket.photos {
+                if let groupID = photo.burstGroupID {
+                    burstGroupIDs.insert(groupID)
+                } else {
+                    singleCount += 1
+                }
+            }
+```
+
+The safety of dropping the filter follows from `bucket.photos` already being built from the per-species union at lines 74-81 — every photo in `bucket.photos` has `id` in its `assignedSpecies`, so its burst is legitimately tagged with `id`.
+
+- [ ] **Step 3: Update the doc comment at the top of the struct**
+
+Replace lines 3-13:
+
+```swift
+/// Pure computation: groups photos into species hierarchy entries.
+///
+/// A photo may carry multiple species in its `assignedSpecies` list; the
+/// builder emits one contribution *per assigned species*, so a photo
+/// tagged with both A and B appears under both buckets. The primary
+/// (first) entry still drives burst-dominant-species assignment so a
+/// burst lives under one species only.
+///
+/// Bucket identity is `SpeciesMatch.speciesID` (eBird code or, when the
+/// user entered a custom species, the scientific name). Never the
+/// localized common name — renames don't jump buckets.
+```
+
+with:
+
+```swift
+/// Pure computation: groups photos into species hierarchy entries.
+///
+/// A photo may carry multiple species in its `assignedSpecies` list; the
+/// builder emits one contribution *per assigned species*, so a photo
+/// tagged with both A and B appears under both buckets. Bursts follow
+/// the same rule: a burst whose members are tagged with species A and B
+/// appears under both A and B, each with a `BurstGroupEntry` carrying
+/// the full burst size.
+///
+/// Bucket identity is `SpeciesMatch.speciesID` (eBird code or, when the
+/// user entered a custom species, the scientific name). Never the
+/// localized common name — renames don't jump buckets.
+```
+
+- [ ] **Step 4: Run the failing test to verify it passes**
+
+```bash
+cd apps/mac-client && swift test --filter SpeciesHierarchyTests.multiSpeciesBurstAppearsUnderEveryTaggedSpecies 2>&1 | tail -20
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full `SpeciesHierarchyTests` suite to confirm no regressions**
+
+```bash
+cd apps/mac-client && swift test --filter SpeciesHierarchyTests 2>&1 | tail -20
+```
+
+Expected: PASS — every other test still green. `photoWithTwoSpeciesAppearsInBothBuckets` still passes because its photos have `burstGroupID == nil` (solo path unchanged). Tests asserting "burst appears once" with a single-species burst still pass because the per-burst species union is a singleton.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac-sidebar-burst
+git add apps/mac-client/SuperPickyApp/SpeciesHierarchyBuilder.swift
+git commit -m "feat(sidebar): burst appears under every tagged species"
+```
+
+---
+
+## Task 3: End-to-end AppState test for the fan-out + sidebar flow
+
+**Files:**
+- Test: `apps/mac-client/SuperPickyTests/Core/AssignedSpeciesTests.swift`
+
+- [ ] **Step 1: Add the integration test**
+
+Append this test after `setAssignedSpeciesOnSoloPhotoDoesNotTouchOtherPhotos` (the regression test added by PR #33):
+
+```swift
+    @Test func burstFanOutWithSecondarySpeciesAppearsUnderBothSidebarBuckets() throws {
+        // Start with a burst where every member is tagged Eagle.
+        // Edit one member's species list to [Eagle, Hawk] — fan-out
+        // propagates [Eagle, Hawk] to every burst member.
+        // After rebuilding the hierarchy, the burst should appear under
+        // BOTH Eagle and Hawk in the sidebar.
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let db = try ReportDatabase(folderPath: folder)
+        let eagle = match(sci: "Aquila", common: "Eagle", ebird: "eagle")
+
+        let burstID = UUID()
+        var burstIDs: [UUID] = []
+        for i in 0..<3 {
+            var p = makePhoto(folder: folder, filename: "burst_\(i).CR3")
+            p.burstGroupID = burstID
+            p.assignedSpecies = [eagle]
+            try db.save(&p)
+            burstIDs.append(p.id)
+        }
+
+        let appState = AppState()
+        appState.loadPhotos(for: folder)
+
+        let hawk = match(sci: "Accipiter", common: "Hawk", ebird: "hawk")
+        appState.setAssignedSpecies(id: burstIDs[0], species: [eagle, hawk])
+
+        let eagleEntry = appState.speciesEntries.first { $0.speciesID == "eagle" }
+        let hawkEntry = appState.speciesEntries.first { $0.speciesID == "hawk" }
+        #expect(eagleEntry?.burstGroups.count == 1)
+        #expect(eagleEntry?.burstGroups.first?.count == 3)
+        #expect(hawkEntry?.burstGroups.count == 1)
+        #expect(hawkEntry?.burstGroups.first?.count == 3)
+        #expect(eagleEntry?.burstGroups.first?.id == burstID)
+        #expect(hawkEntry?.burstGroups.first?.id == burstID)
+    }
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cd apps/mac-client && swift test --filter AssignedSpeciesTests.burstFanOutWithSecondarySpeciesAppearsUnderBothSidebarBuckets 2>&1 | tail -20
+```
+
+Expected: PASS — Task 2's fix already covers this, so this test is additive regression coverage for the user-facing flow, not a red-then-green step.
+
+- [ ] **Step 3: Run the full `AssignedSpeciesTests` suite**
+
+```bash
+cd apps/mac-client && swift test --filter AssignedSpeciesTests 2>&1 | tail -20
+```
+
+Expected: PASS for all 10 tests (9 from PR #33 + this new one).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac-sidebar-burst
+git add apps/mac-client/SuperPickyTests/Core/AssignedSpeciesTests.swift
+git commit -m "test(sidebar): end-to-end fan-out + sidebar bucket coverage"
+```
+
+---
+
+## Task 4: Full-suite verification + pre-commit gate
+
+- [ ] **Step 1: Run the full suite twice**
+
+Per project memory ("Run tests before push — twice if shared state"):
+
+```bash
+cd apps/mac-client && swift test 2>&1 | tail -5
+```
+
+Expected: PASS.
+
+```bash
+cd apps/mac-client && swift test 2>&1 | tail -5
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the pre-commit gate**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac-sidebar-burst
+scripts/pre-commit.sh 2>&1 | tail -20
+```
+
+Expected: PASS (G1 static + L1 unit).
+
+- [ ] **Step 3: Push + open PR**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac-sidebar-burst
+git push -u origin feat/sidebar-multispecies-burst
+gh pr create --base main --head feat/sidebar-multispecies-burst \
+  --title "fix(sidebar): burst appears under every tagged species" \
+  --body "..."
+```
+
+---
+
+## Out of scope (confirm in review)
+
+- No changes to `AppState` mutation methods, `Photo`, `ReportDatabase`, or any UI view.
+- No changes to `applyIncremental` — burst grouping during ingest is intentionally skipped there per its existing comment.
+- No XCUITest — species-edit XCUITests are still flagged as flaky.
+- No count-semantics change for partially-tagged bursts (rare post-fan-out).

--- a/docs/superpowers/specs/2026-04-20-burst-appears-under-every-tagged-species-design.md
+++ b/docs/superpowers/specs/2026-04-20-burst-appears-under-every-tagged-species-design.md
@@ -1,0 +1,111 @@
+# Burst appears under every tagged species in the sidebar
+
+**Date:** 2026-04-20
+**Status:** approved
+
+## Problem
+
+When a burst member's `assignedSpecies` carries more than one species entry,
+the sidebar attaches that burst to only one species bucket — the burst's
+"dominant primary species" (highest-confidence `assignedSpecies.first`
+across members). Every other tagged species still gets a sidebar row with
+a non-zero `count` (because bucket membership uses the full union), but
+its `burstGroups` is empty and `singlePhotos` is 0. Users see a row like
+"Hawk (3)" with nothing to click into.
+
+After the fan-out feature shipped (PR #33), this edge case is common, not
+rare: any time a user adds a secondary species to a burst member, the
+secondary species gets a visibly broken sidebar row.
+
+## Behavior
+
+A burst appears under every species bucket that any of its members is
+tagged with. Concretely, for each burst group:
+
+- Compute the union of `SpeciesMatch.speciesID` across the burst's
+  members' `assignedSpecies` lists.
+- For every species in that union, the burst's `BurstGroupEntry` is
+  attached to that species' `SpeciesEntry.burstGroups`.
+- `BurstGroupEntry.count` stays the **total burst size** (all members,
+  not just members tagged with this species), so clicking the same
+  burst in any bucket drills into the same set of photos.
+
+Solo (non-burst) photos already appear under every species they are
+tagged with (`SpeciesHierarchyBuilder.swift:74-81`). No change there.
+
+Unidentified burst members (empty `assignedSpecies`) contribute their
+burst to the Unidentified bucket — same rule applied to the
+`unidentifiedKey` sentinel.
+
+## Non-goals
+
+- **No change to solo multi-species photos.** Already correct.
+- **No change to fan-out.** `AppState.setAssignedSpecies` /
+  `AppState.correctSpecies` stay as they are.
+- **No change to `applyIncremental`.** Its existing doc comment already
+  states burst-group membership is only materialized by the full
+  rebuild at end-of-ingest (`SpeciesHierarchyBuilder.swift:27-31`). User
+  edits go through the full-rebuild path, so the bug is fully fixed by
+  changing `build(from:)`.
+- **No UI changes.** Sidebar row rendering, filter predicates
+  (`AppState.photoHasSpeciesID`), and drill-down behavior all stay.
+- **No count semantics change for partially-tagged bursts.** If member A
+  is `[Eagle]` and member B is `[Eagle, Hawk]`, the Hawk bucket shows
+  the burst with its full size (2) even though only 1 member is tagged
+  Hawk. Post-fan-out this case is rare; acceptable.
+
+## Implementation sketch
+
+Single file: `apps/mac-client/SuperPickyApp/SpeciesHierarchyBuilder.swift`.
+
+1. **Build a per-burst species set** alongside `burstPhotos`:
+
+   ```swift
+   var burstSpecies: [UUID: Set<String>] = [:]  // groupID → speciesIDs
+   ```
+
+   While iterating `photos` in the first pass (lines 36-49), collect every
+   `speciesID` in every burst member's `assignedSpecies`. If a burst has
+   only unidentified members (no species at all), store
+   `[unidentifiedKey]` so the burst still shows under Unidentified.
+
+2. **Replace the `burstPrimaryByGroup` filter** in the bucket-build pass
+   (lines 88-98) with a set-membership check:
+
+   ```swift
+   for photo in bucket.photos {
+       if let groupID = photo.burstGroupID {
+           burstGroupIDs.insert(groupID)
+       } else {
+           singleCount += 1
+       }
+   }
+   ```
+
+   Because `bucket.photos` only contains photos whose `assignedSpecies`
+   includes `id`, any burst member appearing here implies the burst is
+   tagged with `id`, which is exactly the condition we want.
+
+3. **Drop `burstPrimaryByGroup` / `burstBestConfidence`.** Their only
+   consumer was the filter above. Removing them keeps `build(from:)`
+   smaller and eliminates a second pass over `photos`.
+
+4. **Rewrite the existing test**
+   `multiSpeciesPhotoInBurstAppearsOnceUnderDominantSpeciesBucket`
+   (`SpeciesHierarchyTests.swift:360`) to assert the new behavior:
+   both Eagle and Hawk buckets include the burst. Rename to
+   `multiSpeciesBurstAppearsUnderEveryTaggedSpecies`.
+
+5. **Add one new AppState-level test**
+   (`AssignedSpeciesTests.swift`) that exercises the full user flow:
+   fan-out a secondary species onto a burst, rebuild hierarchy via
+   `loadPhotos`, assert both species buckets list the burst.
+
+## Verification
+
+- `swift test --filter SpeciesHierarchyTests` — rewritten test green,
+  neighbors untouched.
+- `swift test --filter AssignedSpeciesTests` — new fan-out/sidebar test
+  green, 9 pre-existing green.
+- `swift test` full suite green twice (shared-state flake memory).
+- `scripts/pre-commit.sh` green.


### PR DESCRIPTION
## Summary

- After PR #33's fan-out, adding a secondary species to a burst member propagated `[A, B]` to every burst frame — but the sidebar still showed the burst only under species A (the "dominant primary"). Species B got a sidebar row with a count but an empty drill-down.
- `SpeciesHierarchyBuilder.build` now attaches a burst to every species bucket any of its members is tagged with, with the `BurstGroupEntry` carrying the full burst size in every bucket. No UI, DB, or `AppState` changes.
- Removes the unused `burstPrimaryByGroup` / `burstBestConfidence` helpers (dead with the rule).

Spec: `docs/superpowers/specs/2026-04-20-burst-appears-under-every-tagged-species-design.md`
Plan: `docs/superpowers/plans/2026-04-20-burst-appears-under-every-tagged-species.md`

## Test Plan

- [x] New `multiSpeciesBurstAppearsUnderEveryTaggedSpecies` (unit) and `burstFanOutWithSecondarySpeciesAppearsUnderBothSidebarBuckets` (end-to-end fan-out → hierarchy) green
- [x] 2 pre-existing tests that encoded the old dominant-primary rule updated + renamed (`burstWithMixedUnidentifiedAndTaggedMembersAppearsUnderBoth`, `burstWithDifferentSpeciesPerMemberAppearsUnderBoth`)
- [x] Full `swift test` suite → 426/426 green (run twice)
- [x] `scripts/pre-commit.sh` → green