### PR TITLE
fix(uitests): use JPG thumbnails in species-edit tests, not ARW

### DIFF
--- a/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -489,7 +489,7 @@ final class CullingWorkflowUITests: XCTestCase {
         Thread.sleep(forTimeInterval: 0.5)
     }
 
-    private func selectEaglePhoto() { selectThumbnail(filename: "DSC09968.ARW") }
+    private func selectEaglePhoto() { selectThumbnail(filename: "DSC09969.jpg") }
 
     // SearchField sits at the bottom of a scrollable panel and can be pruned
     // from the accessibility tree when scrolled out of view. The root
@@ -714,8 +714,8 @@ final class CullingWorkflowUITests: XCTestCase {
     func test48_EmptyAssignedStateShown() {
         let app = Self.app!
         ensurePanelClosed()
-        // DSC09950 is a bird-but-unidentified photo in the mock fixture.
-        selectThumbnail(filename: "DSC09950.ARW")
+        // DSC09951 is a bird-but-unidentified photo in the mock fixture.
+        selectThumbnail(filename: "DSC09951.jpg")
         exifToggleButton.click()
         XCTAssertTrue(app.scrollViews["ExifPanel"].waitForExistence(timeout: 3))
         scrollPanelToBottom()
@@ -831,7 +831,7 @@ final class CullingWorkflowUITests: XCTestCase {
 
     func test53_SpeciesEditWritesToXMPSidecar() {
         let app = Self.app!
-        let sidecarPath = (Self.testDir! as NSString).appendingPathComponent("DSC09968.xmp")
+        let sidecarPath = (Self.testDir! as NSString).appendingPathComponent("DSC09969.xmp")
         openPanelOnEagle()
 
         tapButton(app.buttons["SpeciesEditPanel_Add_goleag"])
@@ -862,7 +862,7 @@ final class CullingWorkflowUITests: XCTestCase {
         ensurePanelClosed()
         selectEaglePhoto()
 
-        let sidecarPath = (Self.testDir! as NSString).appendingPathComponent("DSC09968.xmp")
+        let sidecarPath = (Self.testDir! as NSString).appendingPathComponent("DSC09969.xmp")
         XCTAssertTrue(waitForSidecar(at: sidecarPath, containing: "Bald Eagle", timeout: 5))
 
         let baldKeyword = app.staticTexts["ExifKeyword_Bald Eagle"]


### PR DESCRIPTION
## Summary

After 4ccbbb2 replaced test-photos with a mixed JPG+ARW Sony A1 set, `CullingWorkflowUITests` was pointing `selectEaglePhoto` at `DSC09968.ARW` and `test48` at `DSC09950.ARW`. CI's macOS runner didn't render those thumbnails inside the 10-second wait — ARW decoding is markedly slower there than locally — and the thumbnail strip populates lazily.

Switch those specific selections to JPG siblings that exist in the same bursts / unidentified cluster:
- `selectEaglePhoto` → `DSC09969.jpg` (next frame of Bald Eagle burst B1; mock still returns Bald Eagle)
- `test48_EmptyAssignedStateShown` → `DSC09951.jpg` (same unidentified-bird mini-burst)
- `test53` + `test54` sidecar path → `DSC09969.xmp`

The 4 kept ARW files (09176, 09950, 09968, 09985) still exercise the RAW decode path via the general `.jpg || .ARW` copy filter — only the panel-interaction selections move to JPG.

Fixes the 5 failures in CI run [24855678021](https://github.com/halfhacked/SuperPickyMac/actions/runs/24855678021): test41_ToggleOpensPanelWithAssignedSpecies, test48_EmptyAssignedStateShown, test49_PhotoChangeClearsSearch, and the 2 cascading from shared-app state.

## Test plan
- [x] `xcodebuild build -scheme SuperPicky -destination 'platform=macOS'` — BUILD SUCCEEDED
- [ ] CI XCUITest job green