### PR TITLE
fix(image-loader): return Sendable CGImage, wrap NSImage on MainActor

### DIFF
--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -8,17 +8,26 @@ enum ImageLoader {
     /// Load an image at a given max pixel size, or full resolution if nil.
     /// Uses the embedded preview when it's large enough (fast path for RAW),
     /// otherwise decodes the full image and downsamples.
+    ///
+    /// NSImage isn't Sendable, so decode returns a CGImage from the
+    /// background queue (Sendable) and the MainActor-isolated caller wraps
+    /// it — which also keeps AppKit construction off the worker thread.
+    @MainActor
     static func load(path: String, maxPixelSize: Int? = nil) async -> NSImage? {
-        let url = URL(fileURLWithPath: path)
+        guard let cgImage = await loadCGImage(path: path, maxPixelSize: maxPixelSize) else {
+            return nil
+        }
+        return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+    }
 
+    private static func loadCGImage(path: String, maxPixelSize: Int?) async -> CGImage? {
+        let url = URL(fileURLWithPath: path)
         return await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
                     continuation.resume(returning: nil)
                     return
                 }
-
-                let cgImage: CGImage?
                 if let maxPixelSize {
                     // RAWs embed a ~1600 px preview that satisfies `maxPixelSize`;
                     // use it (IfAbsent). Smaller sources (e.g. 1600 px JPEGs
@@ -27,26 +36,21 @@ enum ImageLoader {
                     // thumbnail and the preview ends up blurry.
                     let sourceSide = sourceMaxDimension(source: source)
                     let useEmbedded = sourceSide > maxPixelSize
-                    cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, [
+                    let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, [
                         kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
                         (useEmbedded
                          ? kCGImageSourceCreateThumbnailFromImageIfAbsent
                          : kCGImageSourceCreateThumbnailFromImageAlways): true,
                         kCGImageSourceCreateThumbnailWithTransform: true,
                     ] as CFDictionary)
+                    continuation.resume(returning: cgImage)
                 } else {
                     // Full-res: actual image decode
-                    cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
+                    let cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
                         kCGImageSourceCreateThumbnailWithTransform: true,
                     ] as CFDictionary)
+                    continuation.resume(returning: cgImage)
                 }
-
-                guard let cgImage else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-                continuation.resume(returning: nsImage)
             }
         }
     }


### PR DESCRIPTION
## Summary

Under `-warnings-as-errors` (PR #37), Swift 6 catches 4 non-Sendable-result errors where `await ImageLoader.load(...)` returns `NSImage?` across an isolation boundary:

```
PreviewView.swift:97,112,136 + ThumbnailStripView.swift:162
error: non-sendable result type 'NSImage?' cannot be sent from nonisolated
context in call to static method 'load(path:maxPixelSize:)'
```

NSImage isn't Sendable. The previous implementation constructed the NSImage inside the `DispatchQueue.global()` closure and sent it back via `continuation.resume(returning:)` — that's a cross-isolation send.

## Fix

Split into two pieces:
- `loadCGImage(path:maxPixelSize:)` — private, does the background decode, returns `CGImage?` (Sendable).
- `load(path:maxPixelSize:)` — `@MainActor`, calls `loadCGImage`, wraps the result in `NSImage` on the main thread.

All 6 existing call sites (PreviewView, ThumbnailStripView, FullscreenViewer, CompareView, and two shared helpers) continue to work unchanged — they already `await` from `@MainActor` SwiftUI contexts.

Bonus: AppKit construction moves off the worker thread, which is what NSImage docs expect.

## Test plan
- [x] `xcodebuild build -scheme SuperPicky -destination 'platform=macOS'` — BUILD SUCCEEDED, no warnings
- [x] `xcodebuild test -scheme SuperPicky -only-testing:SuperPickyTests` — TEST SUCCEEDED (all L1 pass)
- [ ] CI green (unblocks #37)