### PR TITLE
fix(compare-view): CGImage across async-let, wrap NSImage on MainActor

### DIFF
--- a/apps/mac-client/SuperPickyApp/CompareView.swift
+++ b/apps/mac-client/SuperPickyApp/CompareView.swift
@@ -127,23 +127,31 @@ struct CompareView: View {
     }
 
     private func loadImages() async {
-        async let left = loadImage(for: leftPhoto)
-        async let right = loadImage(for: rightPhoto)
+        // Decode in parallel via async let. Return CGImage (Sendable) from
+        // the child tasks and wrap in NSImage on MainActor — NSImage isn't
+        // Sendable, so `async let` with an NSImage return fails Swift 6
+        // strict-concurrency checking.
+        async let left = loadCGImage(for: leftPhoto)
+        async let right = loadCGImage(for: rightPhoto)
         let (l, r) = await (left, right)
         guard !Task.isCancelled else { return }
-        leftImage = l
-        rightImage = r
+        leftImage = l.map(Self.makeNSImage)
+        rightImage = r.map(Self.makeNSImage)
     }
 
     private func loadRightImage() async {
-        let loaded = await loadImage(for: rightPhoto)
+        let cg = await loadCGImage(for: rightPhoto)
         guard !Task.isCancelled else { return }
-        rightImage = loaded
+        rightImage = cg.map(Self.makeNSImage)
     }
 
-    private func loadImage(for photo: Photo?) async -> NSImage? {
+    private func loadCGImage(for photo: Photo?) async -> CGImage? {
         guard let photo else { return nil }
-        return await ImageLoader.load(path: photo.filePath, maxPixelSize: 2000)
+        return await ImageLoader.loadCGImage(path: photo.filePath, maxPixelSize: 2000)
+    }
+
+    private static func makeNSImage(_ cg: CGImage) -> NSImage {
+        NSImage(cgImage: cg, size: NSSize(width: cg.width, height: cg.height))
     }
 
     private func handleKey(_ key: KeyboardMonitor.KeyEvent) -> Bool {

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -20,7 +20,10 @@ enum ImageLoader {
         return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
     }
 
-    private static func loadCGImage(path: String, maxPixelSize: Int?) async -> CGImage? {
+    /// Sendable-friendly decode. Useful for `async let` / `TaskGroup`
+    /// concurrency where NSImage's non-Sendable result would error.
+    /// Call sites wrap in NSImage on their own actor.
+    static func loadCGImage(path: String, maxPixelSize: Int? = nil) async -> CGImage? {
         let url = URL(fileURLWithPath: path)
         return await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {


### PR DESCRIPTION
## Summary

Follow-up to #40. After that PR made `ImageLoader.load` `@MainActor`, `CompareView.loadImages` still fails `-warnings-as-errors`:

```
CompareView.swift:130,131 error: non-sendable result type 'NSImage?'
cannot be sent from main actor-isolated context in call to instance
method 'loadImage(for:)'
```

`async let` always spawns a child task — even when both parent and callee are `@MainActor`, the `NSImage?` result flows across the task boundary, which Swift 6 strict concurrency rejects.

## Fix

Expose the existing `ImageLoader.loadCGImage` helper (dropped `private`, added doc) and have CompareView's child tasks return `CGImage?` (Sendable). Wrap both results in `NSImage` on MainActor after the `await (left, right)` join.

Preserves the parallel decode that `async let` was there for — sequentialising the two awaits would have serialized the two background decodes.

Once this lands on `build/warnings-as-errors`, PR #37 should finally have zero `-warnings-as-errors` errors. PR #39 (ARW-thumbnail CI fix) has already merged.

## Test plan
- [x] `xcodebuild build -scheme SuperPicky -destination 'platform=macOS'` — BUILD SUCCEEDED, no warnings
- [ ] CI green on #37 after merge