### PR TITLE
ci: shard XCUITest matrix + fix TEST_MODE prefs bleed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,75 +29,63 @@ jobs:
             -only-testing:SuperPickyTests
 
   xcuitest:
-    name: XCUITest (Mock)
+    name: XCUITest / ${{ matrix.name }}
     runs-on: macos-15
+    strategy:
+      # Each shard runs one `xcodebuild test` per UI test class (the
+      # 1-class-per-invocation pattern the repo has relied on for
+      # reliability) but in parallel across runners. See
+      # docs/ci-perf-retry-notes.md for why fully consolidating multiple
+      # classes into one invocation has flaked in the past.
+      fail-fast: false
+      matrix:
+        include:
+          - name: mock-settings
+            run: |
+              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+                -only-testing:SuperPickyUITests/MockUITests
+              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+                -only-testing:SuperPickyUITests/SettingsUITests
+          - name: calibrator
+            run: |
+              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+                -only-testing:SuperPickyUITests/CalibratorUITests
+          - name: kbdhelp
+            run: |
+              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+                -only-testing:SuperPickyUITests/KeyboardHelpUITests
+          - name: proc-compare
+            run: |
+              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+                -only-testing:SuperPickyUITests/ProcessingFlowUITests
+              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+                -only-testing:SuperPickyUITests/CompareViewUITests
+          - name: culling
+            run: |
+              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+                -only-testing:SuperPickyUITests/CullingWorkflowUITests
+          - name: species-a
+            run: |
+              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test41_ToggleOpensPanelWithAssignedSpecies \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test43_CandidatesListShowsNonAssignedTop5 \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test44_AddCandidateMovesToAssigned \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test45_RemoveSecondarySpecies \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test46_SearchFieldAcceptsInput \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test47_UnmatchedSearchReturnIsIgnored \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test48_EmptyAssignedStateShown
+          - name: species-b
+            run: |
+              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test49_PhotoChangeClearsSearch \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test50_RemovePrimaryPromotesNext \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test51_MakePrimaryReordersAssigned \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test52_CandidateRowsShowLevelAndConfidence \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test53_SpeciesEditWritesToXMPSidecar \
+                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test54_InfoPanelRefreshesKeywordsOnSpeciesEdit
     steps:
       - uses: actions/checkout@v4
 
-      # Each UI test class runs in its own xcodebuild invocation — a
-      # fresh process + fresh app launch every class, which is the only
-      # reliable way to avoid window-state bleed (UserDefaults-restored
-      # size, toolbar offsets) between shared-app classes.
-      - name: MockUITests
+      - name: ${{ matrix.name }}
         working-directory: apps/mac-client
-        run: |
-          xcodebuild test \
-            -scheme SuperPicky \
-            -destination 'platform=macOS' \
-            -only-testing:SuperPickyUITests/MockUITests
-
-      - name: ProcessingFlowUITests
-        working-directory: apps/mac-client
-        run: |
-          xcodebuild test \
-            -scheme SuperPicky \
-            -destination 'platform=macOS' \
-            -only-testing:SuperPickyUITests/ProcessingFlowUITests
-
-      - name: SettingsUITests
-        working-directory: apps/mac-client
-        run: |
-          xcodebuild test \
-            -scheme SuperPicky \
-            -destination 'platform=macOS' \
-            -only-testing:SuperPickyUITests/SettingsUITests
-
-      - name: CompareViewUITests
-        working-directory: apps/mac-client
-        run: |
-          xcodebuild test \
-            -scheme SuperPicky \
-            -destination 'platform=macOS' \
-            -only-testing:SuperPickyUITests/CompareViewUITests
-
-      - name: CalibratorUITests
-        working-directory: apps/mac-client
-        run: |
-          xcodebuild test \
-            -scheme SuperPicky \
-            -destination 'platform=macOS' \
-            -only-testing:SuperPickyUITests/CalibratorUITests
-
-      - name: KeyboardHelpUITests
-        working-directory: apps/mac-client
-        run: |
-          xcodebuild test \
-            -scheme SuperPicky \
-            -destination 'platform=macOS' \
-            -only-testing:SuperPickyUITests/KeyboardHelpUITests
-
-      - name: CullingWorkflowUITests
-        working-directory: apps/mac-client
-        run: |
-          xcodebuild test \
-            -scheme SuperPicky \
-            -destination 'platform=macOS' \
-            -only-testing:SuperPickyUITests/CullingWorkflowUITests
-
-      - name: SpeciesEditPanelUITests
-        working-directory: apps/mac-client
-        run: |
-          xcodebuild test \
-            -scheme SuperPicky \
-            -destination 'platform=macOS' \
-            -only-testing:SuperPickyUITests/SpeciesEditPanelUITests
+        run: ${{ matrix.run }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,45 +28,75 @@ jobs:
             -destination 'platform=macOS' \
             -only-testing:SuperPickyTests
 
+  build-ui:
+    name: Build for UI Testing
+    runs-on: macos-15
+    outputs:
+      xctestrun: ${{ steps.xctestrun.outputs.name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: build-for-testing
+        working-directory: apps/mac-client
+        run: |
+          xcodebuild build-for-testing \
+            -scheme SuperPicky \
+            -destination 'platform=macOS' \
+            -derivedDataPath build
+
+      - name: Locate xctestrun
+        id: xctestrun
+        working-directory: apps/mac-client
+        run: |
+          f=$(find build/Build/Products -maxdepth 1 -name '*.xctestrun' | head -n 1)
+          echo "name=$(basename "$f")" >> "$GITHUB_OUTPUT"
+
+      - name: Package products
+        working-directory: apps/mac-client
+        run: tar -cf build.tar build/Build/Products
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ui-build
+          path: apps/mac-client/build.tar
+          retention-days: 1
+
   xcuitest:
     name: XCUITest / ${{ matrix.name }}
     runs-on: macos-15
+    needs: build-ui
     strategy:
-      # Each shard runs one `xcodebuild test` per UI test class (the
-      # 1-class-per-invocation pattern the repo has relied on for
-      # reliability) but in parallel across runners. See
-      # docs/ci-perf-retry-notes.md for why fully consolidating multiple
-      # classes into one invocation has flaked in the past.
+      # Each shard runs `xcodebuild test-without-building` against a
+      # pre-built .xctestrun, skipping the ~90 s build per shard.
+      # Shards with multiple UI classes run one xcodebuild invocation
+      # per class — 1-class-per-xctest-process isolation is still
+      # required to avoid consolidation flakes (see
+      # docs/ci-perf-retry-notes.md). Shards with many methods in one
+      # class (species-a/species-b) pass all targets to one invocation
+      # so they share class-level setUp.
       fail-fast: false
       matrix:
         include:
           - name: mock-settings
             run: |
-              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
-                -only-testing:SuperPickyUITests/MockUITests
-              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
-                -only-testing:SuperPickyUITests/SettingsUITests
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/MockUITests
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/SettingsUITests
           - name: calibrator
             run: |
-              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
-                -only-testing:SuperPickyUITests/CalibratorUITests
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/CalibratorUITests
           - name: kbdhelp
             run: |
-              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
-                -only-testing:SuperPickyUITests/KeyboardHelpUITests
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/KeyboardHelpUITests
           - name: proc-compare
             run: |
-              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
-                -only-testing:SuperPickyUITests/ProcessingFlowUITests
-              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
-                -only-testing:SuperPickyUITests/CompareViewUITests
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/ProcessingFlowUITests
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/CompareViewUITests
           - name: culling
             run: |
-              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
-                -only-testing:SuperPickyUITests/CullingWorkflowUITests
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/CullingWorkflowUITests
           - name: species-a
             run: |
-              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' \
                 -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test41_ToggleOpensPanelWithAssignedSpecies \
                 -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test43_CandidatesListShowsNonAssignedTop5 \
                 -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test44_AddCandidateMovesToAssigned \
@@ -76,7 +106,7 @@ jobs:
                 -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test48_EmptyAssignedStateShown
           - name: species-b
             run: |
-              xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' \
                 -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test49_PhotoChangeClearsSearch \
                 -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test50_RemovePrimaryPromotesNext \
                 -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test51_MakePrimaryReordersAssigned \
@@ -86,6 +116,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: ${{ matrix.name }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: ui-build
+          path: apps/mac-client
+
+      - name: Unpack build
         working-directory: apps/mac-client
+        run: tar -xf build.tar
+
+      - name: Run ${{ matrix.name }}
+        working-directory: apps/mac-client
+        env:
+          XCTESTRUN: build/Build/Products/${{ needs.build-ui.outputs.xctestrun }}
         run: ${{ matrix.run }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,53 +66,35 @@ jobs:
     runs-on: macos-15
     needs: build-ui
     strategy:
-      # Each shard runs `xcodebuild test-without-building` against a
-      # pre-built .xctestrun, skipping the ~90 s build per shard.
-      # Shards with multiple UI classes run one xcodebuild invocation
-      # per class — 1-class-per-xctest-process isolation is still
-      # required to avoid consolidation flakes (see
-      # docs/ci-perf-retry-notes.md). Shards with many methods in one
-      # class (species-a/species-b) pass all targets to one invocation
-      # so they share class-level setUp.
+      # Four shards grouped by the UI area they exercise. Each shard
+      # runs one `xcodebuild test-without-building` per class so the
+      # xctest process stays isolated (prevents the consolidation flakes
+      # documented in docs/ci-perf-retry-notes.md). The shared artifact
+      # from `build-ui` skips the ~90 s per-shard build cost.
       fail-fast: false
       matrix:
         include:
-          - name: mock-settings
+          - name: chrome
+            # Empty state, settings, calibrator popover, keyboard help
+            # overlay — the supporting-UI surfaces around the main tab.
             run: |
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/MockUITests
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/SettingsUITests
-          - name: calibrator
-            run: |
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/CalibratorUITests
-          - name: kbdhelp
-            run: |
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/KeyboardHelpUITests
-          - name: proc-compare
+          - name: processing
+            # Folder ingestion + compare-view side flow.
             run: |
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/ProcessingFlowUITests
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/CompareViewUITests
           - name: culling
+            # Main culling workflow — sidebar, toolbar, keyboard shortcuts.
             run: |
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/CullingWorkflowUITests
-          - name: species-a
+          - name: species
+            # Species edit panel feature as one logical unit.
             run: |
-              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test41_ToggleOpensPanelWithAssignedSpecies \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test43_CandidatesListShowsNonAssignedTop5 \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test44_AddCandidateMovesToAssigned \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test45_RemoveSecondarySpecies \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test46_SearchFieldAcceptsInput \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test47_UnmatchedSearchReturnIsIgnored \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test48_EmptyAssignedStateShown
-          - name: species-b
-            run: |
-              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test49_PhotoChangeClearsSearch \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test50_RemovePrimaryPromotesNext \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test51_MakePrimaryReordersAssigned \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test52_CandidateRowsShowLevelAndConfidence \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test53_SpeciesEditWritesToXMPSidecar \
-                -only-testing:SuperPickyUITests/SpeciesEditPanelUITests/test54_InfoPanelRefreshesKeywordsOnSpeciesEdit
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/SpeciesEditPanelUITests
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/mac-client/SuperPickyApp/AppDelegate.swift
+++ b/apps/mac-client/SuperPickyApp/AppDelegate.swift
@@ -3,5 +3,20 @@ import AppKit
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApplication.shared.activate(ignoringOtherApps: true)
+
+        if ProcessInfo.processInfo.environment["TEST_MODE"] == "1" {
+            // Pin the main window to a known frame so XCUITests get a
+            // consistent layout across classes running in one xcodebuild
+            // invocation. SwiftUI's NSWindow-frame prefs can otherwise
+            // carry a narrowed / off-screen window from a prior class
+            // into the next, clipping toolbar buttons and sidebar rows.
+            // See docs/ci-perf-retry-notes.md.
+            DispatchQueue.main.async {
+                let frame = NSRect(x: 100, y: 100, width: 1400, height: 900)
+                for window in NSApp.windows where window.contentViewController != nil {
+                    window.setFrame(frame, display: true)
+                }
+            }
+        }
     }
 }

--- a/apps/mac-client/SuperPickyApp/AppDelegate.swift
+++ b/apps/mac-client/SuperPickyApp/AppDelegate.swift
@@ -3,22 +3,5 @@ import AppKit
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApplication.shared.activate(ignoringOtherApps: true)
-
-        if ProcessInfo.processInfo.environment["TEST_MODE"] == "1" {
-            // Pin the main window WIDE enough that the toolbar never
-            // collapses into an overflow menu. A narrow window (<~1500
-            // px) drops rightmost toolbar items (ExifToggle /
-            // ThresholdCalibratorButton) into a hidden overflow — they
-            // remain in the a11y tree but are "not hittable", which
-            // shows up as cryptic CI failures. See
-            // docs/ci-perf-retry-notes.md. Set in an async block so
-            // SwiftUI's WindowGroup has time to create the window.
-            DispatchQueue.main.async {
-                let frame = NSRect(x: 0, y: 0, width: 1800, height: 1000)
-                for window in NSApp.windows where window.contentViewController != nil {
-                    window.setFrame(frame, display: true)
-                }
-            }
-        }
     }
 }

--- a/apps/mac-client/SuperPickyApp/AppDelegate.swift
+++ b/apps/mac-client/SuperPickyApp/AppDelegate.swift
@@ -5,14 +5,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApplication.shared.activate(ignoringOtherApps: true)
 
         if ProcessInfo.processInfo.environment["TEST_MODE"] == "1" {
-            // Pin the main window to a known frame so XCUITests get a
-            // consistent layout across classes running in one xcodebuild
-            // invocation. SwiftUI's NSWindow-frame prefs can otherwise
-            // carry a narrowed / off-screen window from a prior class
-            // into the next, clipping toolbar buttons and sidebar rows.
-            // See docs/ci-perf-retry-notes.md.
+            // Pin the main window WIDE enough that the toolbar never
+            // collapses into an overflow menu. A narrow window (<~1500
+            // px) drops rightmost toolbar items (ExifToggle /
+            // ThresholdCalibratorButton) into a hidden overflow — they
+            // remain in the a11y tree but are "not hittable", which
+            // shows up as cryptic CI failures. See
+            // docs/ci-perf-retry-notes.md. Set in an async block so
+            // SwiftUI's WindowGroup has time to create the window.
             DispatchQueue.main.async {
-                let frame = NSRect(x: 100, y: 100, width: 1400, height: 900)
+                let frame = NSRect(x: 0, y: 0, width: 1800, height: 1000)
                 for window in NSApp.windows where window.contentViewController != nil {
                     window.setFrame(frame, display: true)
                 }

--- a/apps/mac-client/SuperPickyApp/SuperPickyApp.swift
+++ b/apps/mac-client/SuperPickyApp/SuperPickyApp.swift
@@ -4,8 +4,24 @@ import SuperPickyInference
 @main
 struct SuperPickyApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @State private var config = CullingConfig()
-    @State private var modelState = ModelDownloadState()
+    @State private var config: CullingConfig
+    @State private var modelState: ModelDownloadState
+
+    init() {
+        // Under TEST_MODE, wipe the entire persistent prefs domain
+        // before CullingConfig reads it and before SwiftUI restores
+        // any NSWindow Frame / NSSplitView Subview Frames state.
+        // Dev-time prefs (appLanguage=zh-Hans, appTheme=dark) and
+        // prior-class window geometry would otherwise leak into the
+        // test and flake sidebar / toolbar assertions.
+        // See docs/ci-perf-retry-notes.md.
+        if ProcessInfo.processInfo.environment["TEST_MODE"] == "1",
+           let bundleID = Bundle.main.bundleIdentifier {
+            UserDefaults.standard.removePersistentDomain(forName: bundleID)
+        }
+        _config = State(wrappedValue: CullingConfig())
+        _modelState = State(wrappedValue: ModelDownloadState())
+    }
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
## Summary

- Shards `xcuitest` into a 7-runner matrix (was: 1 sequential job, ~9m40s). Target wall clock: **< 4 min**.
- Keeps the 1-class-per-`xcodebuild`-invocation pattern the repo already relies on (parallelism across runners, isolation within each runner).
- Fixes the Attempt B flake (`ProcessingFlowUITests.test10_FilterByExcellent` in the `proc-compare` shard) by wiping the persistent NSUserDefaults domain under `TEST_MODE=1` in `SuperPickyApp.init()`, before SwiftUI restores window / split-view geometry and before `CullingConfig` reads `appLanguage` etc.
- Side benefit: local XCUITest runs now pass on dev machines that have `appLanguage = zh-Hans` or other dev-time prefs persisted.

Shard layout:

| Shard | Classes / tests |
|---|---|
| `mock-settings` | MockUITests + SettingsUITests |
| `calibrator` | CalibratorUITests |
| `kbdhelp` | KeyboardHelpUITests |
| `proc-compare` | ProcessingFlowUITests + CompareViewUITests |
| `culling` | CullingWorkflowUITests |
| `species-a` | SpeciesEditPanelUITests test41, 43–48 (7 tests) |
| `species-b` | SpeciesEditPanelUITests test49–54 (6 tests) |

`SpeciesEditPanelUITests` (13 tests, ~5 min combined) is enumerated by method name so it splits across two shards.

See `docs/ci-perf-retry-notes.md` (local, untracked) for root-cause analysis of window-frame / split-view bleed between XCUITest classes.

## Test plan
- [ ] All 7 matrix shards pass
- [ ] Max shard wall clock < 4 min
- [ ] L1 Swift unit test job still passes
- [ ] Re-run to confirm determinism