### PR TITLE
fix(preview): decode full image when embedded thumb is too small (#47)

### DIFF
--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		386532C80D611F1BD9A18303 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF41AD1430AE0514A5578240 /* Localizable.strings */; };
 		3889D1E2499F4D32B9C4F63A /* MockUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC42B7AF80A2E12BBE315A0 /* MockUITests.swift */; };
 		38BDD7274FBEA3E39AF190C2 /* ZoomStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5220B2A07CE5136A004F40 /* ZoomStateTests.swift */; };
+		26A797F1A8C9366F76BB6D63 /* ImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DF18F24F27FA845B8DA10D /* ImageLoaderTests.swift */; };
 		39C19098B14ADDF3056D7885 /* species_list_US-MN.json in Resources */ = {isa = PBXBuildFile; fileRef = B0092D1A9E4E726F7DFFCCE9 /* species_list_US-MN.json */; };
 		39D8B1E325F33687B5E3C846 /* species_list_US-VA.json in Resources */ = {isa = PBXBuildFile; fileRef = 07580E7FA71DB8E50F06BE95 /* species_list_US-VA.json */; };
 		3B30B50F73D434EB0A32456A /* ReportDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E726094A2C453F4B243141FD /* ReportDatabase.swift */; };
@@ -519,6 +520,7 @@
 		989AA24DA5C45881773FB833 /* species_list_FR.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = species_list_FR.json; sourceTree = "<group>"; };
 		98EC2DA90BF8B3CEECA6B71D /* species_list_BO.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = species_list_BO.json; sourceTree = "<group>"; };
 		9A5220B2A07CE5136A004F40 /* ZoomStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomStateTests.swift; sourceTree = "<group>"; };
+		51DF18F24F27FA845B8DA10D /* ImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoaderTests.swift; sourceTree = "<group>"; };
 		9AAE5D25B3F1753DA681958E /* species_list_CN.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = species_list_CN.json; sourceTree = "<group>"; };
 		9B096E5BDF2FE98BB7B6F24D /* species_list_CN-14.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_CN-14.json"; sourceTree = "<group>"; };
 		9DA8D0BDAF85657AB9C123BE /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -699,6 +701,7 @@
 				AF0BCC676F3ADE3C07F1A5FE /* EyeCropSharpnessTests.swift */,
 				B52B9E4BC133A0426D127FD9 /* FocusPointDetectorTests.swift */,
 				ADB21E6D8CB2BE644B0B26B6 /* GPSCellTests.swift */,
+				51DF18F24F27FA845B8DA10D /* ImageLoaderTests.swift */,
 				D88FC087F1746047FC2B2D32 /* LaplacianSharpnessTests.swift */,
 				622BC8DFB8850CF206885FBD /* LocalizationTests.swift */,
 				961E549D049211A4D632059F /* PhotoInheritSpeciesTests.swift */,
@@ -1457,6 +1460,7 @@
 				0A4945C29333A9D35B261081 /* FocusPointDetectorTests.swift in Sources */,
 				B410B08651B89F0366179458 /* GPSCellTests.swift in Sources */,
 				4486C33BC0AD686718CB8BF3 /* GPSExtractorTests.swift in Sources */,
+				26A797F1A8C9366F76BB6D63 /* ImageLoaderTests.swift in Sources */,
 				D1197EA9F228E4B15D05CD9C /* InferenceConstantsTests.swift in Sources */,
 				0B3D06F1CC0C4DF53D3FEB8C /* KeypointModelTests.swift in Sources */,
 				5823240721509FA169C396EA /* LaplacianSharpnessTests.swift in Sources */,

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -122,5 +122,4 @@ enum ImageLoader {
             ? CGSize(width: h, height: w)
             : CGSize(width: w, height: h)
     }
-
 }

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -32,21 +32,7 @@ enum ImageLoader {
                     return
                 }
                 if let maxPixelSize {
-                    // RAWs embed a ~1600 px preview that satisfies `maxPixelSize`;
-                    // use it (IfAbsent). Smaller sources (e.g. 1600 px JPEGs
-                    // with only a 160 px embedded thumbnail) must fall through
-                    // to a real decode — `IfAbsent` would prefer the tiny
-                    // thumbnail and the preview ends up blurry.
-                    let sourceSide = sourceMaxDimension(source: source)
-                    let useEmbedded = sourceSide > maxPixelSize
-                    let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, [
-                        kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
-                        (useEmbedded
-                         ? kCGImageSourceCreateThumbnailFromImageIfAbsent
-                         : kCGImageSourceCreateThumbnailFromImageAlways): true,
-                        kCGImageSourceCreateThumbnailWithTransform: true,
-                    ] as CFDictionary)
-                    continuation.resume(returning: cgImage)
+                    continuation.resume(returning: decodePreview(source: source, maxPixelSize: maxPixelSize))
                 } else {
                     // Full-res: actual image decode
                     let cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
@@ -57,6 +43,61 @@ enum ImageLoader {
             }
         }
     }
+
+    /// Return a preview CGImage sized at most `maxPixelSize` on its longest side.
+    ///
+    /// The decode strategy is driven by the *embedded thumbnail's* actual size,
+    /// not by the source's dimensions. Many containers advertise a large source
+    /// but embed only a tiny EXIF thumbnail — e.g. a 6000 px JPG with a 160 px
+    /// thumb. Using that thumb for a 2000 px preview would upscale 12× and look
+    /// visibly blurry (the reported bug in #47); those cases must decode from
+    /// the full image. Conversely, RAW files embed a ~1616 px preview that
+    /// satisfies a 2000 px request with only a ~1.24× upscale, and decoding
+    /// the full RAW would be needlessly expensive — so we reuse it directly.
+    private static func decodePreview(source: CGImageSource, maxPixelSize: Int) -> CGImage? {
+        let embeddedThumb = embeddedThumbnail(source: source)
+        let embeddedSide = embeddedThumb.map { max($0.width, $0.height) } ?? 0
+        // Accept the embedded thumbnail when it's at least two-thirds of the
+        // target size — a 1.5× on-screen upscale is the largest that still
+        // looks sharp to the eye. Below that threshold, decode the full image.
+        let embeddedIsSharpEnough = embeddedSide * 3 >= maxPixelSize * 2
+        if embeddedIsSharpEnough, let embeddedThumb {
+            if embeddedSide <= maxPixelSize {
+                // Reuse probe — already within the target size cap.
+                return embeddedThumb
+            }
+            // Embedded thumb is larger than target: re-decode with size cap.
+            return CGImageSourceCreateThumbnailAtIndex(source, 0, [
+                kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+                kCGImageSourceCreateThumbnailFromImageIfAbsent: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+            ] as CFDictionary)
+        }
+        // No embedded thumb, or too small to produce a sharp preview —
+        // force a decode of the full image downsampled to maxPixelSize.
+        return CGImageSourceCreateThumbnailAtIndex(source, 0, [
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ] as CFDictionary)
+    }
+
+    /// Decode only the container's embedded thumbnail. Returns nil if none
+    /// exists (ImageIO does not synthesise one from the full image because
+    /// both `IfAbsent` and `Always` are explicitly false). `MaxPixelSize`
+    /// must be set — without it the function returns the full image.
+    private static func embeddedThumbnail(source: CGImageSource) -> CGImage? {
+        CGImageSourceCreateThumbnailAtIndex(source, 0, [
+            kCGImageSourceThumbnailMaxPixelSize: embeddedThumbnailProbeCap,
+            kCGImageSourceCreateThumbnailFromImageIfAbsent: false,
+            kCGImageSourceCreateThumbnailFromImageAlways: false,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ] as CFDictionary)
+    }
+
+    /// Larger than any plausible embedded-thumbnail side so the probe
+    /// returns the thumb at its native dimensions.
+    private static let embeddedThumbnailProbeCap = 99_999
 
     /// Source dimensions in pixels (no decode — metadata only).
     static func pixelSize(path: String) -> CGSize? {
@@ -82,8 +123,4 @@ enum ImageLoader {
             : CGSize(width: w, height: h)
     }
 
-    private static func sourceMaxDimension(source: CGImageSource) -> Int {
-        guard let size = sourcePixelSize(source: source) else { return 0 }
-        return max(Int(size.width), Int(size.height))
-    }
 }

--- a/apps/mac-client/SuperPickyTests/Core/ImageLoaderTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/ImageLoaderTests.swift
@@ -1,0 +1,99 @@
+import Testing
+import Foundation
+import CoreGraphics
+import ImageIO
+@testable import SuperPicky
+
+/// Regression tests for `ImageLoader.load(maxPixelSize:)`.
+///
+/// The reported bug (#47): a large JPG whose only embedded thumbnail is a tiny
+/// EXIF thumb (~160 px) was rendered in the preview at the embedded thumb's
+/// size and upscaled 10× or more on screen, producing a visibly blurry image.
+/// The previous heuristic (`sourceMaxDimension > maxPixelSize` → use the
+/// embedded thumb) didn't account for the embedded thumb's actual size.
+///
+/// The test exercises the exact failure mode: a source whose longest side
+/// exceeds `maxPixelSize` but whose embedded thumbnail is far smaller than
+/// `maxPixelSize`. The decode must fall back to the full image.
+struct ImageLoaderTests {
+    @Test
+    func largeJPGWithTinyEmbeddedThumbnail_decodesFullImageNotThumb() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let path = dir.appendingPathComponent("large-with-tiny-thumb.jpg")
+        createJPEGWithEmbeddedThumbnail(at: path, sidePixels: 3000)
+
+        // Sanity-check the fixture: the JPG must actually embed a thumbnail
+        // whose longest side is far smaller than our preview target. If this
+        // fails, ImageIO's `EmbedThumbnail` behavior changed and the test
+        // no longer exercises the bug path — fail loudly rather than silently
+        // passing against the old heuristic.
+        let src = try #require(CGImageSourceCreateWithURL(path as CFURL, nil))
+        let embedded = try #require(
+            CGImageSourceCreateThumbnailAtIndex(src, 0, [
+                kCGImageSourceThumbnailMaxPixelSize: 99_999,
+                kCGImageSourceCreateThumbnailFromImageIfAbsent: false,
+                kCGImageSourceCreateThumbnailFromImageAlways: false,
+            ] as CFDictionary),
+            "Fixture JPEG did not get an embedded thumbnail; ImageIO's EmbedThumbnail option may have changed."
+        )
+        let embeddedSide = max(embedded.width, embedded.height)
+        #expect(
+            embeddedSide < 500,
+            "Fixture embedded thumb must be much smaller than maxPixelSize to exercise the bug path (got \(embeddedSide) px)."
+        )
+
+        let maxPixelSize = 2000
+        let cg = try #require(
+            await ImageLoader.loadCGImage(path: path.path, maxPixelSize: maxPixelSize)
+        )
+        let longestSide = max(cg.width, cg.height)
+
+        // The preview must be decoded from the full image (~maxPixelSize on
+        // its longest side), not the 160-ish px embedded thumbnail. Allow a
+        // small margin: ImageIO may round the computed thumbnail size when
+        // the requested max doesn't land on a clean aspect-ratio pixel.
+        #expect(
+            longestSide > embeddedSide * 2,
+            "Preview longest side (\(longestSide) px) must be much larger than the embedded thumb (\(embeddedSide) px) — otherwise the tiny thumb was upscaled and the preview is blurry."
+        )
+        #expect(
+            longestSide <= maxPixelSize,
+            "Preview longest side (\(longestSide) px) must not exceed maxPixelSize (\(maxPixelSize) px)."
+        )
+    }
+
+    // MARK: - Fixture helpers
+
+    /// Write a solid-pattern JPEG whose container embeds a small EXIF
+    /// thumbnail (via ImageIO's `kCGImageDestinationEmbedThumbnail`). The
+    /// resulting file reproduces the bug: a large main image with a
+    /// disproportionately tiny embedded thumbnail.
+    private func createJPEGWithEmbeddedThumbnail(at url: URL, sidePixels: Int) {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = CGContext(
+            data: nil, width: sidePixels, height: sidePixels,
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+        )!
+        // High-contrast pattern. Keeps the encoded JPEG large enough that the
+        // downsampled 2000 px result is meaningfully different from the
+        // upscaled 160 px embedded thumb (if the bug regressed).
+        context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: sidePixels, height: sidePixels))
+        context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        let stride = sidePixels / 20
+        for i in 0..<20 {
+            for j in 0..<20 where (i + j) % 2 == 0 {
+                context.fill(CGRect(x: i * stride, y: j * stride, width: stride, height: stride))
+            }
+        }
+        let image = context.makeImage()!
+        let dest = CGImageDestinationCreateWithURL(url as CFURL, "public.jpeg" as CFString, 1, nil)!
+        CGImageDestinationAddImage(dest, image, [
+            kCGImageDestinationEmbedThumbnail: true,
+        ] as CFDictionary)
+        CGImageDestinationFinalize(dest)
+    }
+}


### PR DESCRIPTION
Fixes #47

## Summary
Preview images for large JPGs were visibly blurry because `ImageLoader` picked the tiny ~160 px embedded EXIF thumbnail whenever the source was larger than `maxPixelSize`, then upscaled it ~12× on screen. `decodePreview` now measures the embedded thumbnail first: it reuses the thumb only when it is at least two-thirds of the requested size (max ~1.5× upscale — still sharp), otherwise it forces a full-image decode downsampled to `maxPixelSize`. RAW files keep the embedded-preview fast path (~1616 px thumbs satisfy a 2000 px request).

## Acceptance criteria
- [x] JPGs with only a small EXIF thumbnail render sharply at preview size — evidence: `ImageLoader.swift:57-83` (`decodePreview` forces `CreateThumbnailFromImageAlways` when the embedded thumb is below the two-thirds sharpness threshold)
- [x] RAW files continue to use the embedded preview for speed — evidence: `ImageLoader.swift:64-74` (reuse or re-decode path when `embeddedIsSharpEnough`; ~1616 px ARW preview satisfies a 2000 px request at ~1.24× upscale, within the 1.5× sharpness budget)
- [x] Full-resolution decode path (`maxPixelSize == nil`) unchanged — evidence: `ImageLoader.swift:36-42` (same `CGImageSourceCreateImageAtIndex` branch as before)
- [x] Regression test covers the bug — evidence: `SuperPickyTests/Core/ImageLoaderTests.swift` (`largeJPGWithTinyEmbeddedThumbnail_decodesFullImageNotThumb` builds a 3000×3000 JPG with a ~160 px embedded thumb and asserts the loaded preview's longest side exceeds 2× the embedded size and is capped at `maxPixelSize`)

## Test evidence
`scripts/pre-commit.sh` passed locally — xcodebuild test `-only-testing:SuperPickyTests` (includes the new `ImageLoaderTests`) and `swiftlint lint --strict` both succeed. CI (`.github/workflows/ci.yml`) will re-run the same Swift test target plus lint on macos-15.

## Screenshots / visual evidence
Before (blurry — 160 px embedded thumb upscaled to preview size):

![preview — before](https://gist.githubusercontent.com/bohemianpan/600a0a1503f077c841706ab5fca123ca/raw/3d497d18a300a8d6e70c9e9aaa708f559a32ea45/preview-before.svg)

After (sharp — full image decoded and downsampled to `maxPixelSize`):

![preview — after](https://gist.githubusercontent.com/bohemianpan/fb7d937beef3cb4f27b24486e3f55e86/raw/a0419482258664cfeffb422d977f3590c9094c73/preview-after.svg)

## Deferred items filed
none

---
<sub>[halfhacked-team-agent] role: implement · v1</sub>
