### PR TITLE
perf(species): poll-based waits + fast-path eagle panel

### DIFF
--- a/apps/mac-client/SuperPickyUITests/SpeciesEditPanelUITests.swift
+++ b/apps/mac-client/SuperPickyUITests/SpeciesEditPanelUITests.swift
@@ -37,6 +37,11 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         XCTAssertTrue(thumb.waitForExistence(timeout: 5),
                       "\(filename) thumbnail should exist in the 3-photo species fixture")
         thumb.click()
+        // Brief settle so a subsequent `exifToggleButton.click()` doesn't
+        // race the still-processing thumbnail selection. Removing this
+        // caused a measurable CI regression (waitForExistence(panel) ate
+        // most of its 3 s budget instead of returning immediately).
+        Thread.sleep(forTimeInterval: 0.3)
         Self.currentPhotoFilename = filename
     }
 
@@ -74,11 +79,10 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
     private func openPanelOnEagle() {
         // Fast path: panel already open on the eagle from the previous
         // test in the shared-app suite. Skip the toggle-off / reselect /
-        // toggle-on cycle (roughly 1.5–2.5 s on the CI runner) and just
-        // re-establish the post-open contract (species section visible,
-        // assignments reset to the fixture default).
+        // toggle-on + re-scroll cycle (roughly 2–3 s on the CI runner).
+        // The panel's scroll offset persists, so the species section is
+        // already visible — only state-normalization is needed.
         if panelIsOpenOnEagle() {
-            scrollPanelToBottom()
             resetEagleSpeciesToBaleagOnly()
             return
         }
@@ -130,47 +134,22 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
     }
 
     /// Scrolls the ExifPanel down so the species section becomes visible.
-    /// Distinct from "species elements in the a11y tree": the ExifPanel
-    /// VStack mounts both EXIF and species children eagerly, so existence
-    /// is true from the moment the panel opens even when the candidate
-    /// buttons are off-screen. `tapButton` uses a coordinate click at the
-    /// element's reported center, which lands off-screen if we haven't
-    /// scrolled — so we must poll on `isHittable` of a candidate row
-    /// (not the assigned row, which can be hittable while candidates are
-    /// still below the fold).
+    /// A fixed post-scroll settle is simpler and faster on CI than polling
+    /// `.isHittable` on candidate elements — each `.isHittable` probe
+    /// triggers a snapshot refresh (~0.5 s on the macOS-15 runner) and
+    /// calling three of them in a poll loop costs more than a plain 0.3 s
+    /// wait. The race being mitigated is: the SwiftUI scroll animation
+    /// completes a frame or two after XCUITest returns from `scroll(...)`,
+    /// and a coordinate click issued before that frame lands off-screen.
     private func scrollPanelToBottom() {
         let panel = Self.app.scrollViews[A11y.exifPanel]
         guard panel.exists else { return }
-        // Fast out when a candidate-row element is already hittable (the
-        // panel retains its scroll offset between tests in the shared-app
-        // suite). Avoids another scroll animation on consecutive tests.
-        if candidateRowHittable() { return }
         // -600 is the original, proven-on-CI delta. Larger values risk
         // over-scrolling past the scroll-view's content bottom, which
         // XCTest reports as "Unable to find hit point" and aborts the
         // current test.
         panel.scroll(byDeltaX: 0, deltaY: -600)
-        // Poll until a candidate row is actually hittable — replaces a
-        // fixed 0.3 s post-scroll sleep. This is the "scroll has settled
-        // and clicks will land" signal that subsequent coordinate taps
-        // rely on.
-        _ = poll(timeout: 1.5) { self.candidateRowHittable() }
-    }
-
-    /// True when the *first* candidate row in the species section is
-    /// actually in the viewport — not just in the a11y tree. We check
-    /// `Add_goleag` specifically (the first-candidate default for the
-    /// eagle photo) because coordinate clicks on off-screen elements
-    /// silently miss: if we only check `Add_osprey`, an over-scroll past
-    /// goleag would still report "hittable" while the test's Add_goleag
-    /// click lands off-screen. `Remove_goleag` covers the leaked-state
-    /// case where goleag already moved to Assigned; `EmptyAssigned`
-    /// covers the DSC09951 (bird-no-species) path used by test48.
-    private func candidateRowHittable() -> Bool {
-        let app = Self.app!
-        return app.buttons[A11y.speciesEditAdd("goleag")].isHittable
-            || app.buttons[A11y.speciesEditRemove("goleag")].isHittable
-            || app.staticTexts[A11y.speciesEditPanelEmptyAssigned].isHittable
+        Thread.sleep(forTimeInterval: 0.3)
     }
 
     /// Click a button reliably on CI. The 12-pt SF-symbol Add/Remove
@@ -183,47 +162,22 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
     }
 
-    /// Grant keyboard focus to the species search TextField. The
-    /// coordinate click at the field's reported centre is the most
-    /// reliable focus-grant on the CI runner; a follow-up hover + click
-    /// pair covers occasional dropped first-clicks.
-    ///
-    /// Returns `nil` when the field can't be focused — callers MUST
-    /// branch on a nil return and skip any subsequent `typeText` /
-    /// `Cmd+A` / `Delete` sequence, which would otherwise route through
-    /// the app's global keyboard monitor (`x` rejects photo, Delete can
-    /// delete selected items) and corrupt state for downstream tests.
+    /// Grant keyboard focus to the species search TextField. CI's smaller
+    /// window occasionally leaves a single `field.click()` non-focus-
+    /// granting, so approach with a coordinate click first, then a hover
+    /// + click pair to cover dropped first-clicks.  Callers verify focus
+    /// landed by asserting on the typed value afterwards (`typeAndWaitFor`).
     @discardableResult
-    private func focusSearchField() -> XCUIElement? {
+    private func focusSearchField() -> XCUIElement {
         let field = Self.app.textFields[A11y.speciesEditPanelSearchField]
-        guard field.waitForExistence(timeout: 3) else {
-            XCTFail("Search field should exist after panel scroll")
-            return nil
-        }
+        _ = field.waitForExistence(timeout: 3)
         let center = field.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-        let sentinel = "q"
-        for attempt in 0..<3 {
-            // Only call `hover()` when the field is actually hittable —
-            // calling it on a clipped element throws "Not hittable" and
-            // fails the test. The coordinate click on `center` always
-            // proceeds (coordinate clicks don't require hittability).
-            if attempt > 0, field.isHittable { field.hover() }
-            center.click()
-            Self.app.typeText(sentinel)
-            if poll(timeout: 0.6, { self.fieldValueContains(field, sentinel) }) {
-                // Clear the sentinel via targeted key presses — at this
-                // point focus is confirmed, so the Cmd+A / Delete pair
-                // stays scoped to the field rather than the app window.
-                Self.app.typeKey("a", modifierFlags: .command)
-                Self.app.typeKey(.delete, modifierFlags: [])
-                _ = poll(timeout: 0.5) { (field.value as? String ?? "").isEmpty }
-                return field
-            }
-        }
-        XCTFail("Search field did not accept focus after 3 click attempts; " +
-                "test bodies must treat the nil return as fatal to avoid " +
-                "routing keystrokes through the app's global keyboard monitor")
-        return nil
+        center.click()
+        Thread.sleep(forTimeInterval: 0.15)
+        field.hover()
+        center.click()
+        Thread.sleep(forTimeInterval: 0.15)
+        return field
     }
 
     /// Returns true if the field currently carries the expected value.
@@ -346,7 +300,7 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
     func test46_SearchFieldAcceptsInput() {
         openPanelOnEagle()
 
-        guard let field = focusSearchField() else { return }
+        let field = focusSearchField()
         XCTAssertTrue(typeAndWaitFor(field, "robin"),
                       "SearchField should contain 'robin' after typing " +
                       "(value=\(String(describing: field.value)))")
@@ -358,7 +312,7 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         let app = Self.app!
         openPanelOnEagle()
 
-        guard let field = focusSearchField() else { return }
+        let field = focusSearchField()
         let garbage = "MyCustomSpeciesXYZ"
         guard typeAndWaitFor(field, garbage) else {
             XCTFail("SearchField did not receive input; cannot verify Return behaviour")
@@ -389,10 +343,9 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         scrollPanelToBottom()
         XCTAssertTrue(app.staticTexts[A11y.speciesEditPanelEmptyAssigned].waitForExistence(timeout: 2))
         XCTAssertFalse(app.buttons[A11y.speciesEditRemove("baleag")].exists)
-        // Close so the next test (test49) starts from a known-closed state
-        // — leaving the panel open on DSC09951 would force test49's
-        // openPanelOnEagle() to take the slow path anyway (different photo).
-        ensurePanelClosed()
+        // Leave the panel open; the next test's openPanelOnEagle() takes
+        // the slow path (different photo) and closes it before re-opening
+        // on the eagle — an explicit close here would just double-pay.
     }
 
     func test49_PhotoChangeClearsSearch() {
@@ -401,7 +354,7 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         app.typeKey("0", modifierFlags: .command)
         openPanelOnEagle()
 
-        guard let field = focusSearchField() else { return }
+        let field = focusSearchField()
         guard typeAndWaitFor(field, "robin") else {
             XCTFail("SearchField did not receive input; cannot verify clear-on-photo-change")
             clearSearchField()
@@ -422,11 +375,9 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         XCTAssertFalse(fieldValueContains(newField, "robin"),
                        "Search field should clear on photo change " +
                        "(value=\(String(describing: newField.value)))")
-
-        // Close so the next eagle test re-selects DSC09969 via the slow
-        // path (panelIsOpenOnEagle returns false when currentPhotoFilename
-        // tracks DSC09970).
-        ensurePanelClosed()
+        // Leave the panel open on DSC09970; the next eagle test's
+        // openPanelOnEagle() slow path (currentPhotoFilename != DSC09969)
+        // closes it before re-opening on the eagle.
     }
 
     func test50_RemovePrimaryPromotesNext() {

--- a/apps/mac-client/SuperPickyUITests/SpeciesEditPanelUITests.swift
+++ b/apps/mac-client/SuperPickyUITests/SpeciesEditPanelUITests.swift
@@ -15,6 +15,13 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
     // eliminates the `arrowStripUntil` detour when selecting thumbnails.
     override class var fixtureFolder: String { "test-photos-species" }
 
+    // Tracks which thumbnail was last selected, so `openPanelOnEagle` can
+    // short-circuit the close→reselect→reopen cycle for consecutive eagle
+    // tests. Can't be inferred from the panel alone because both DSC09969
+    // and DSC09970 render as Bald Eagle in the mock fixture — they'd be
+    // indistinguishable via the species buttons.
+    private static var currentPhotoFilename: String?
+
     override func setUpWithError() throws {
         continueAfterFailure = true
     }
@@ -30,7 +37,7 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         XCTAssertTrue(thumb.waitForExistence(timeout: 5),
                       "\(filename) thumbnail should exist in the 3-photo species fixture")
         thumb.click()
-        Thread.sleep(forTimeInterval: 0.3)
+        Self.currentPhotoFilename = filename
     }
 
     private func selectEaglePhoto() { selectThumbnail(filename: "DSC09969.jpg") }
@@ -40,6 +47,14 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
     // ScrollView's identifier is a stable proxy for "panel is mounted".
     private func panelIsOpen() -> Bool {
         Self.app.scrollViews[A11y.exifPanel].exists
+    }
+
+    /// Fast-path guard for `openPanelOnEagle`: true when a prior eagle test
+    /// already left the panel open on DSC09969. Callers that return on
+    /// `true` skip the close → reselect → reopen cycle, which is the
+    /// dominant per-test cost on CI (two toggle animations per hop).
+    private func panelIsOpenOnEagle() -> Bool {
+        Self.currentPhotoFilename == "DSC09969.jpg" && panelIsOpen()
     }
 
     // On macOS CI (GitHub Actions runner), SwiftUI toolbar buttons surface as a
@@ -53,10 +68,20 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
     private func ensurePanelClosed() {
         guard panelIsOpen() else { return }
         exifToggleButton.click()
-        _ = poll(timeout: 2) { !panelIsOpen() }
+        _ = poll(timeout: 2) { !self.panelIsOpen() }
     }
 
     private func openPanelOnEagle() {
+        // Fast path: panel already open on the eagle from the previous
+        // test in the shared-app suite. Skip the toggle-off / reselect /
+        // toggle-on cycle (roughly 1.5–2.5 s on the CI runner) and just
+        // re-establish the post-open contract (species section visible,
+        // assignments reset to the fixture default).
+        if panelIsOpenOnEagle() {
+            scrollPanelToBottom()
+            resetEagleSpeciesToBaleagOnly()
+            return
+        }
         ensurePanelClosed()
         selectEaglePhoto()
         exifToggleButton.click()
@@ -76,25 +101,76 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
     /// the eagle's species here before every test body runs.
     private func resetEagleSpeciesToBaleagOnly() {
         let app = Self.app!
-        // Drop goleag if it's still in Assigned from a prior test.
-        if app.buttons[A11y.speciesEditRemove("goleag")].exists {
-            tapButton(app.buttons[A11y.speciesEditRemove("goleag")])
-            _ = app.buttons[A11y.speciesEditAdd("goleag")].waitForExistence(timeout: 2)
+        let goleagRemove = app.buttons[A11y.speciesEditRemove("goleag")]
+        let baleagRemove = app.buttons[A11y.speciesEditRemove("baleag")]
+        let baleagAdd = app.buttons[A11y.speciesEditAdd("baleag")]
+        // Fast out when the fixture-default is already in place: baleag in
+        // Assigned, goleag not in Assigned. Avoids the redundant
+        // `waitForExistence` polls in the branches below for the common
+        // case where the prior test left state clean.
+        if baleagRemove.exists && !goleagRemove.exists { return }
+
+        // Restore baleag FIRST — if goleag is currently the only Assigned
+        // species (e.g., after test50 removed the primary baleag, promoting
+        // goleag), removing goleag here would leave zero assigned species
+        // and the app's `Remove` action fails silently (the panel refuses
+        // to clear the last assigned species on a bird-detected photo).
+        // Adding baleag first guarantees there are always ≥2 assigned
+        // species when goleag's Remove button is clicked.
+        if !baleagRemove.exists, baleagAdd.exists {
+            tapButton(baleagAdd)
+            XCTAssertTrue(baleagRemove.waitForExistence(timeout: 2),
+                          "Reset: baleag should return to Assigned after add")
         }
-        // Restore baleag if it was removed.
-        if !app.buttons[A11y.speciesEditRemove("baleag")].exists,
-           app.buttons[A11y.speciesEditAdd("baleag")].exists {
-            tapButton(app.buttons[A11y.speciesEditAdd("baleag")])
-            _ = app.buttons[A11y.speciesEditRemove("baleag")].waitForExistence(timeout: 2)
+        if goleagRemove.exists {
+            tapButton(goleagRemove)
+            XCTAssertTrue(app.buttons[A11y.speciesEditAdd("goleag")].waitForExistence(timeout: 2),
+                          "Reset: goleag should return to Candidates after remove")
         }
     }
 
     /// Scrolls the ExifPanel down so the species section becomes visible.
+    /// Distinct from "species elements in the a11y tree": the ExifPanel
+    /// VStack mounts both EXIF and species children eagerly, so existence
+    /// is true from the moment the panel opens even when the candidate
+    /// buttons are off-screen. `tapButton` uses a coordinate click at the
+    /// element's reported center, which lands off-screen if we haven't
+    /// scrolled — so we must poll on `isHittable` of a candidate row
+    /// (not the assigned row, which can be hittable while candidates are
+    /// still below the fold).
     private func scrollPanelToBottom() {
         let panel = Self.app.scrollViews[A11y.exifPanel]
         guard panel.exists else { return }
+        // Fast out when a candidate-row element is already hittable (the
+        // panel retains its scroll offset between tests in the shared-app
+        // suite). Avoids another scroll animation on consecutive tests.
+        if candidateRowHittable() { return }
+        // -600 is the original, proven-on-CI delta. Larger values risk
+        // over-scrolling past the scroll-view's content bottom, which
+        // XCTest reports as "Unable to find hit point" and aborts the
+        // current test.
         panel.scroll(byDeltaX: 0, deltaY: -600)
-        Thread.sleep(forTimeInterval: 0.3)
+        // Poll until a candidate row is actually hittable — replaces a
+        // fixed 0.3 s post-scroll sleep. This is the "scroll has settled
+        // and clicks will land" signal that subsequent coordinate taps
+        // rely on.
+        _ = poll(timeout: 1.5) { self.candidateRowHittable() }
+    }
+
+    /// True when the *first* candidate row in the species section is
+    /// actually in the viewport — not just in the a11y tree. We check
+    /// `Add_goleag` specifically (the first-candidate default for the
+    /// eagle photo) because coordinate clicks on off-screen elements
+    /// silently miss: if we only check `Add_osprey`, an over-scroll past
+    /// goleag would still report "hittable" while the test's Add_goleag
+    /// click lands off-screen. `Remove_goleag` covers the leaked-state
+    /// case where goleag already moved to Assigned; `EmptyAssigned`
+    /// covers the DSC09951 (bird-no-species) path used by test48.
+    private func candidateRowHittable() -> Bool {
+        let app = Self.app!
+        return app.buttons[A11y.speciesEditAdd("goleag")].isHittable
+            || app.buttons[A11y.speciesEditRemove("goleag")].isHittable
+            || app.staticTexts[A11y.speciesEditPanelEmptyAssigned].isHittable
     }
 
     /// Click a button reliably on CI. The 12-pt SF-symbol Add/Remove
@@ -107,24 +183,47 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
     }
 
-    /// Grant keyboard focus to the species search TextField. CI's smaller
-    /// window occasionally leaves `field.click()` non-focus-granting, so
-    /// approach with a coordinate click first and fall back to a hover +
-    /// click pair. Callers verify focus by typing a sentinel character and
-    /// reading back `field.value`; if the sentinel didn't land the field
-    /// didn't receive focus.
+    /// Grant keyboard focus to the species search TextField. The
+    /// coordinate click at the field's reported centre is the most
+    /// reliable focus-grant on the CI runner; a follow-up hover + click
+    /// pair covers occasional dropped first-clicks.
+    ///
+    /// Returns `nil` when the field can't be focused — callers MUST
+    /// branch on a nil return and skip any subsequent `typeText` /
+    /// `Cmd+A` / `Delete` sequence, which would otherwise route through
+    /// the app's global keyboard monitor (`x` rejects photo, Delete can
+    /// delete selected items) and corrupt state for downstream tests.
     @discardableResult
-    private func focusSearchField() -> XCUIElement {
+    private func focusSearchField() -> XCUIElement? {
         let field = Self.app.textFields[A11y.speciesEditPanelSearchField]
-        _ = field.waitForExistence(timeout: 3)
+        guard field.waitForExistence(timeout: 3) else {
+            XCTFail("Search field should exist after panel scroll")
+            return nil
+        }
         let center = field.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-        center.click()
-        Thread.sleep(forTimeInterval: 0.3)
-        field.hover()
-        Thread.sleep(forTimeInterval: 0.15)
-        center.click()
-        Thread.sleep(forTimeInterval: 0.3)
-        return field
+        let sentinel = "q"
+        for attempt in 0..<3 {
+            // Only call `hover()` when the field is actually hittable —
+            // calling it on a clipped element throws "Not hittable" and
+            // fails the test. The coordinate click on `center` always
+            // proceeds (coordinate clicks don't require hittability).
+            if attempt > 0, field.isHittable { field.hover() }
+            center.click()
+            Self.app.typeText(sentinel)
+            if poll(timeout: 0.6, { self.fieldValueContains(field, sentinel) }) {
+                // Clear the sentinel via targeted key presses — at this
+                // point focus is confirmed, so the Cmd+A / Delete pair
+                // stays scoped to the field rather than the app window.
+                Self.app.typeKey("a", modifierFlags: .command)
+                Self.app.typeKey(.delete, modifierFlags: [])
+                _ = poll(timeout: 0.5) { (field.value as? String ?? "").isEmpty }
+                return field
+            }
+        }
+        XCTFail("Search field did not accept focus after 3 click attempts; " +
+                "test bodies must treat the nil return as fatal to avoid " +
+                "routing keystrokes through the app's global keyboard monitor")
+        return nil
     }
 
     /// Returns true if the field currently carries the expected value.
@@ -135,16 +234,40 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         return value.contains(needle)
     }
 
+    /// Type `text` into a focused field and poll until the value reflects
+    /// it. Replaces the old pattern of `typeText(...)` + fixed `sleep` +
+    /// guarded `fieldValueContains` check; now the poll exits on the first
+    /// tick where the characters have landed.
+    @discardableResult
+    private func typeAndWaitFor(_ field: XCUIElement,
+                                _ text: String,
+                                timeout: TimeInterval = 2) -> Bool {
+        Self.app.typeText(text)
+        return poll(timeout: timeout) { self.fieldValueContains(field, text) }
+    }
+
+    /// Clear the search field's text. Assumes focus is still on the field
+    /// (typical path: `focusSearchField()` → `typeAndWaitFor(...)` →
+    /// `clearSearchField()` inside the same test). Sends Cmd+A then
+    /// Delete which, while the field is focused, stays scoped to the
+    /// field's text content — NOT the surrounding app.
     private func clearSearchField() {
+        let field = Self.app.textFields[A11y.speciesEditPanelSearchField]
         Self.app.typeKey("a", modifierFlags: .command)
         Self.app.typeKey(.delete, modifierFlags: [])
-        Thread.sleep(forTimeInterval: 0.2)
+        // Poll until the value actually empties instead of burning a fixed
+        // 0.2 s every clear.
+        _ = poll(timeout: 1) { (field.value as? String ?? "").isEmpty }
     }
 
     private func poll(timeout: TimeInterval, _ check: () -> Bool) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if check() { return true }
+            // Polling tick — the only fixed sleep in the file besides the
+            // documented absence-check dwell in test47. 0.15 s balances
+            // responsiveness (sub-second exit on the common case) against
+            // CPU spin while waiting for the UI to settle.
             Thread.sleep(forTimeInterval: 0.15)
         }
         return false
@@ -168,11 +291,18 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
     }
 
     // MARK: - Tests
+    //
+    // Eagle tests (test41–47, test50–54) intentionally do not call
+    // `ensurePanelClosed()` at the end of the test body — they leave the
+    // panel open on DSC09969 so the next eagle test hits the fast path in
+    // `openPanelOnEagle()`. Tests that switch to a different photo
+    // (test48 on DSC09951, test49 on DSC09970) DO close the panel at the
+    // end so the following eagle test correctly takes the slow path and
+    // re-selects DSC09969.
 
     func test41_ToggleOpensPanelWithAssignedSpecies() {
         openPanelOnEagle()
         XCTAssertTrue(Self.app.buttons[A11y.speciesEditRemove("baleag")].waitForExistence(timeout: 2))
-        ensurePanelClosed()
     }
 
     func test43_CandidatesListShowsNonAssignedTop5() {
@@ -180,7 +310,6 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         openPanelOnEagle()
         XCTAssertTrue(app.buttons[A11y.speciesEditAdd("goleag")].waitForExistence(timeout: 3))
         XCTAssertTrue(app.buttons[A11y.speciesEditAdd("osprey")].exists)
-        ensurePanelClosed()
     }
 
     func test44_AddCandidateMovesToAssigned() {
@@ -197,10 +326,8 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         XCTAssertFalse(app.buttons[A11y.speciesEditAdd("goleag")].exists)
 
         tapButton(remove)
-        // Verify we actually returned to the initial state so test45 starts clean.
         XCTAssertTrue(app.buttons[A11y.speciesEditAdd("goleag")].waitForExistence(timeout: 2),
                       "After Remove_goleag click, goleag should be back in Candidates (Add_goleag present)")
-        ensurePanelClosed()
     }
 
     func test45_RemoveSecondarySpecies() {
@@ -214,47 +341,42 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
 
         XCTAssertTrue(app.buttons[A11y.speciesEditAdd("goleag")].waitForExistence(timeout: 2))
         XCTAssertFalse(app.buttons[A11y.speciesEditRemove("goleag")].exists)
-        ensurePanelClosed()
     }
 
     func test46_SearchFieldAcceptsInput() {
-        let app = Self.app!
         openPanelOnEagle()
 
-        let field = focusSearchField()
-        app.typeText("robin")
-        Thread.sleep(forTimeInterval: 0.4)
-        XCTAssertTrue(fieldValueContains(field, "robin"),
+        guard let field = focusSearchField() else { return }
+        XCTAssertTrue(typeAndWaitFor(field, "robin"),
                       "SearchField should contain 'robin' after typing " +
                       "(value=\(String(describing: field.value)))")
 
         clearSearchField()
-        ensurePanelClosed()
     }
 
     func test47_UnmatchedSearchReturnIsIgnored() {
         let app = Self.app!
         openPanelOnEagle()
 
-        let field = focusSearchField()
+        guard let field = focusSearchField() else { return }
         let garbage = "MyCustomSpeciesXYZ"
-        app.typeText(garbage)
-        // Verify the text landed before pressing Return; if it didn't, the
-        // Return-doesn't-add invariant isn't testable in this run.
-        guard fieldValueContains(field, garbage) else {
+        guard typeAndWaitFor(field, garbage) else {
             XCTFail("SearchField did not receive input; cannot verify Return behaviour")
-            ensurePanelClosed()
+            clearSearchField()
             return
         }
         app.typeKey(.return, modifierFlags: [])
-        Thread.sleep(forTimeInterval: 0.5)
+        // Testing an absence (Return must not add a custom species); there
+        // is no positive signal to poll for, so briefly dwell before the
+        // negative assertion. 0.3 s is well above the observed SwiftUI
+        // action dispatch latency on the CI runner.
+        Thread.sleep(forTimeInterval: 0.3)
 
         XCTAssertFalse(app.buttons[A11y.speciesEditRemove(garbage)].exists,
                        "Unmatched Return must not add a custom species")
         XCTAssertTrue(app.buttons[A11y.speciesEditRemove("baleag")].exists)
 
         clearSearchField()
-        ensurePanelClosed()
     }
 
     func test48_EmptyAssignedStateShown() {
@@ -267,6 +389,9 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         scrollPanelToBottom()
         XCTAssertTrue(app.staticTexts[A11y.speciesEditPanelEmptyAssigned].waitForExistence(timeout: 2))
         XCTAssertFalse(app.buttons[A11y.speciesEditRemove("baleag")].exists)
+        // Close so the next test (test49) starts from a known-closed state
+        // — leaving the panel open on DSC09951 would force test49's
+        // openPanelOnEagle() to take the slow path anyway (different photo).
         ensurePanelClosed()
     }
 
@@ -274,15 +399,12 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         let app = Self.app!
         // Reset any lingering filter so the thumbnail strip shows every photo.
         app.typeKey("0", modifierFlags: .command)
-        Thread.sleep(forTimeInterval: 0.3)
         openPanelOnEagle()
 
-        let field = focusSearchField()
-        app.typeText("robin")
-        Thread.sleep(forTimeInterval: 0.3)
-        guard fieldValueContains(field, "robin") else {
+        guard let field = focusSearchField() else { return }
+        guard typeAndWaitFor(field, "robin") else {
             XCTFail("SearchField did not receive input; cannot verify clear-on-photo-change")
-            ensurePanelClosed()
+            clearSearchField()
             return
         }
 
@@ -296,11 +418,14 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         scrollPanelToBottom()
 
         let newField = app.textFields[A11y.speciesEditPanelSearchField]
-        _ = newField.waitForExistence(timeout: 2)
+        XCTAssertTrue(newField.waitForExistence(timeout: 2))
         XCTAssertFalse(fieldValueContains(newField, "robin"),
                        "Search field should clear on photo change " +
                        "(value=\(String(describing: newField.value)))")
 
+        // Close so the next eagle test re-selects DSC09969 via the slow
+        // path (panelIsOpenOnEagle returns false when currentPhotoFilename
+        // tracks DSC09970).
         ensurePanelClosed()
     }
 
@@ -321,13 +446,8 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         XCTAssertTrue(app.buttons[A11y.speciesEditRemove("goleag")].exists)
         XCTAssertFalse(app.buttons[A11y.speciesEditMakePrimary("goleag")].exists,
                        "Golden should now be primary (no MakePrimary button)")
-
-        // Restore state for later tests.
-        tapButton(app.buttons[A11y.speciesEditRemove("goleag")])
-        _ = app.buttons[A11y.speciesEditAdd("goleag")].waitForExistence(timeout: 2)
-        tapButton(app.buttons[A11y.speciesEditAdd("baleag")])
-        _ = app.buttons[A11y.speciesEditRemove("baleag")].waitForExistence(timeout: 2)
-        ensurePanelClosed()
+        // State restoration is handled by `resetEagleSpeciesToBaleagOnly()`
+        // at the start of the next test — no need to undo the edits here.
     }
 
     func test51_MakePrimaryReordersAssigned() {
@@ -346,11 +466,8 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         XCTAssertFalse(app.buttons[A11y.speciesEditMakePrimary("goleag")].exists)
         XCTAssertTrue(app.buttons[A11y.speciesEditRemove("goleag")].exists)
         XCTAssertTrue(app.buttons[A11y.speciesEditRemove("baleag")].exists)
-
-        // Restore: remove goleag so subsequent tests see the default primary.
-        tapButton(app.buttons[A11y.speciesEditRemove("goleag")])
-        _ = app.buttons[A11y.speciesEditAdd("goleag")].waitForExistence(timeout: 2)
-        ensurePanelClosed()
+        // State restoration is handled by `resetEagleSpeciesToBaleagOnly()`
+        // at the start of the next test.
     }
 
     func test52_CandidateRowsShowLevelAndConfidence() {
@@ -359,7 +476,6 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         XCTAssertTrue(app.buttons[A11y.speciesEditAdd("goleag")].waitForExistence(timeout: 3))
         XCTAssertTrue(app.staticTexts["12%"].exists, "Confidence percentage should render")
         XCTAssertTrue(app.staticTexts["Region"].exists, "thresholdUsed=country → 'Region' label")
-        ensurePanelClosed()
     }
 
     func test53_SpeciesEditWritesToXMPSidecar() {
@@ -383,7 +499,6 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
                                      timeout: 3))
         let afterRemove = (try? String(contentsOfFile: sidecarPath)) ?? ""
         XCTAssertTrue(afterRemove.contains("Bald Eagle"))
-        ensurePanelClosed()
     }
 
     // Regression: the EXIF panel's `.task(id:)` was keyed only on photo.id,
@@ -409,7 +524,7 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         if !app.scrollViews[A11y.exifPanel].exists {
             exifToggleButton.click()
         }
-        _ = app.scrollViews[A11y.exifPanel].waitForExistence(timeout: 3)
+        XCTAssertTrue(app.scrollViews[A11y.exifPanel].waitForExistence(timeout: 3))
         scrollPanelToBottom()
         resetEagleSpeciesToBaleagOnly()
 
@@ -428,10 +543,7 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
         XCTAssertTrue(poll(timeout: 4) { !app.staticTexts[A11y.exifKeyword("Golden Eagle")].exists },
                       "Keyword should drop after removal")
 
-        ensurePanelClosed()
-        if baldKeyword.exists {
-            exifToggleButton.click()
-            Thread.sleep(forTimeInterval: 0.3)
-        }
+        // Final test in the class — class-level tearDown terminates the
+        // app, so no panel close needed here.
     }
 }


### PR DESCRIPTION
Fixes #50

## Summary
Trim the species XCUITest shard's per-test overhead by (a) replacing
fixed `Thread.sleep` delays with poll-based waits on specific UI
outcomes, and (b) adding a same-photo fast path to `openPanelOnEagle`
so consecutive eagle tests skip the close/reselect/reopen toggle
cycle. Scope is bounded to `SpeciesEditPanelUITests.swift` and its
private helpers; the shared base class and app helpers are untouched.

## Acceptance criteria

- [ ] **Species shard CI wall-clock < 2m across ≥2 runs** — NOT FULLY
      MET. On the macos-15 runner for commit 3730ad2 (CI run
      [24908065692][run]), `xcodebuild test-without-building`
      reported `IDETestOperationsObserverDebug: 125.990 elapsed` =
      **2m 5.99s**. That is a **~31 s / ~20% improvement** over the
      baseline `main` timing of ~156.978 s (2m 37 s), but it is 6
      seconds over the literal <2 m bar at the `xcodebuild` level.
      The species job wall-clock (including `actions/checkout`,
      artifact download, simulator/runner housekeeping) is **2m 30s**
      (vs ~2m 53s baseline). Operator judgment requested on whether
      the intent of the criterion is met.
- [x] **All 13 existing `test4x_`/`test5x_` cases still run and still
      pass** — verified on CI run 24908065692 species job: all 13
      tests passed. *Note: file contains 13 tests (test41, test43–
      test54). The plan referenced 14; test42 appears to have been
      removed in a prior PR. All 13 present tests are exercised.*
- [x] **Every existing assertion is still exercised** —
      `SpeciesEditPanelUITests.swift` covers toggle opens panel,
      candidates list, add→assigned, remove secondary, search input,
      unmatched-Return ignore, empty-assigned state,
      photo-change-clears-search, remove-primary promotes,
      make-primary reorders, candidate row level/confidence,
      XMP sidecar writes, EXIF keyword refresh on species edit.
- [x] **Remaining `Thread.sleep` calls are documented** — all
      surviving sleeps in the diff carry inline `// …` comments
      explaining the specific race each one absorbs (thumbnail
      selection settle, scroll-then-observe dwell, focus-click
      propagation, test47 absence dwell, poll tick).
- [x] **Lint / typecheck / unit / full XCUITest all green** —
      every required check on run 24908065692 is `SUCCESS`:
      `Swift Build & Test (L1)`, `Build for UI Testing`,
      `XCUITest / chrome`, `XCUITest / processing`,
      `XCUITest / culling`, `XCUITest / species`.

[run]: https://github.com/halfhacked/SuperPickyMac/actions/runs/24908065692

## Test evidence

Latest CI run on this branch: **run [24908065692][run]**
(commit 3730ad2):

| Job | Result | Wall |
|---|---|---|
| Swift Build & Test (L1) | pass | 2m 17s |
| Build for UI Testing | pass | 3m 15s |
| XCUITest / chrome | pass | 2m 22s |
| XCUITest / culling | pass | 2m 25s |
| XCUITest / processing | pass | 1m 36s |
| XCUITest / species | pass | 2m 30s |

Species `xcodebuild` self-reported elapsed:
`IDETestOperationsObserverDebug: 125.990 elapsed -- Testing started completed.`
= **2m 5.99s**.

Baseline on `main` (`xcodebuild` self-reported) was ~156.978s
= 2m 37s. Improvement: ~31s / ~20%.

## Screenshots / visual evidence
N/A — perf change to XCUITest file, no user-visible surface.

## Deferred items filed
none

## Implementation notes

- **Fast path** (`panelIsOpenOnEagle()`): when the previous eagle
  test already left the panel open on DSC09969, subsequent eagle
  tests skip `ensurePanelClosed → selectEaglePhoto → exifToggleButton
  .click → waitForExistence(panel) → scrollPanelToBottom` and only
  run `resetEagleSpeciesToBaleagOnly`. The first eagle test in the
  shard still pays full cost; subsequent ones reap the savings. This
  is confirmed per-test in the species log (e.g., test43 fell from
  ~6.4 s → ~1.7 s).

- **`resetEagleSpeciesToBaleagOnly()`** now adds `baleag` **before**
  removing `goleag`. After `test50` demotes `baleag` the eagle photo
  is left with `goleag` as the only assigned species, and the app's
  `Remove` action refuses to clear the last assigned species on a
  bird-detected photo. Adding `baleag` first guarantees `goleag`'s
  removal always leaves ≥1 assigned species.

- **Poll-based waits** replace fixed sleeps around search-field
  typing: `typeAndWaitFor` polls `field.value` until it contains the
  expected text (up to 2 s); `clearSearchField` polls until the
  field empties. These are positive-signal polls, not sleeps.

- **Retained sleeps** (each annotated inline):
  - `selectThumbnail` trailing 0.3 s — settle after arrow-to-target
    to avoid racing in-flight thumb-switch against the next click.
  - `scrollPanelToBottom` trailing 0.3 s — dwell after scroll event
    to let the candidate list re-layout (no accessible post-scroll
    signal).
  - `focusSearchField` two 0.15 s ticks — propagate focus events
    between blind-click and hover (the search field does not expose
    a "focused" a11y attribute).
  - `test47` 0.3 s after Return — positive-signal-free absence
    check (asserting the search text was *ignored*).
  - `poll` helper tick at 0.15 s.

- **`scroll(byDeltaX: 0, deltaY: -600)` delta preserved** — the
  original proven-on-CI value. Larger deltas over-scroll past the
  panel's content bottom, causing XCTest to report "Unable to find
  hit point for ScrollView" and abort the test.

- **Trailing `ensurePanelClosed()` dropped** on eagle tests
  (41, 43–47, 50–54) to feed the `panelIsOpenOnEagle()` fast path.
  Photo-switching tests (48 on DSC09951, 49 on DSC09970) still close
  the panel implicitly via the next test's slow path re-selecting
  DSC09969.

---
<sub>[halfhacked-team-agent] role: implement · v1</sub>
