### PR TITLE
fix(strip): 4-sided selection border renders (real fix for #48)

### DIFF
--- a/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
+++ b/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
@@ -28,7 +28,7 @@ struct ThumbnailStripView: View {
                     }
                 }
                 .padding(.horizontal, 4)
-                .padding(.vertical, 4)
+                .padding(.vertical, 6)
             }
             .background(ScrollWheelRedirector())
             .background(.bar)

--- a/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
+++ b/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
@@ -69,8 +69,8 @@ struct ThumbnailCell: View {
                     .foregroundStyle(.orange)
                     .padding(3)
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 2))
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                     .padding(2)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                     .transition(.opacity)
                     .accessibilityIdentifier("PickFlag_\(photo.filename)")
             }
@@ -82,22 +82,20 @@ struct ThumbnailCell: View {
                     .foregroundStyle(.yellow)
                     .padding(3)
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 2))
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                     .padding(2)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             }
 
             // Stars bottom-left
             StarRatingView(rating: photo.starRating)
                 .padding(2)
                 .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 2))
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
                 .padding(2)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         }
         .animation(.easeInOut(duration: 0.2), value: photo.isPick)
         .clipShape(RoundedRectangle(cornerRadius: 4))
         .overlay(
-            // `strokeBorder` (not `stroke`) so the full line renders inside
-            // the frame — otherwise the outer half is clipped (issue #48).
             RoundedRectangle(cornerRadius: 4)
                 .strokeBorder(isSelected ? Color.accentColor : (photo.isPick ? Color.orange.opacity(0.6) : .clear), lineWidth: 2)
         )

--- a/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
+++ b/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
@@ -56,6 +56,12 @@ struct ThumbnailCell: View {
         return photoBurstGroupID != selected
     }
 
+    private var borderColor: Color {
+        if isSelected { return .accentColor }
+        if photo.isPick { return .orange.opacity(0.6) }
+        return .clear
+    }
+
     var body: some View {
         ZStack {
             AsyncThumbnailImage(filePath: photo.filePath)
@@ -96,8 +102,10 @@ struct ThumbnailCell: View {
         .animation(.easeInOut(duration: 0.2), value: photo.isPick)
         .clipShape(RoundedRectangle(cornerRadius: 4))
         .overlay(
+            // strokeBorder draws inside the frame; plain stroke would center
+            // on the edge and clip the outer half.
             RoundedRectangle(cornerRadius: 4)
-                .strokeBorder(isSelected ? Color.accentColor : (photo.isPick ? Color.orange.opacity(0.6) : .clear), lineWidth: 2)
+                .strokeBorder(borderColor, lineWidth: 2)
         )
         .opacity(isDimmed ? 0.4 : 1.0)
         .animation(.easeInOut(duration: 0.15), value: isDimmed)

--- a/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
+++ b/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
@@ -28,7 +28,7 @@ struct ThumbnailStripView: View {
                     }
                 }
                 .padding(.horizontal, 4)
-                .padding(.vertical, 2)
+                .padding(.vertical, 4)
             }
             .background(ScrollWheelRedirector())
             .background(.bar)
@@ -69,8 +69,8 @@ struct ThumbnailCell: View {
                     .foregroundStyle(.orange)
                     .padding(3)
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 2))
-                    .padding(2)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .padding(2)
                     .transition(.opacity)
                     .accessibilityIdentifier("PickFlag_\(photo.filename)")
             }
@@ -82,16 +82,16 @@ struct ThumbnailCell: View {
                     .foregroundStyle(.yellow)
                     .padding(3)
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 2))
-                    .padding(2)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                    .padding(2)
             }
 
             // Stars bottom-left
             StarRatingView(rating: photo.starRating)
                 .padding(2)
                 .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 2))
-                .padding(2)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+                .padding(2)
         }
         .animation(.easeInOut(duration: 0.2), value: photo.isPick)
         .clipShape(RoundedRectangle(cornerRadius: 4))


### PR DESCRIPTION
## Summary

- #49's `.stroke` → `.strokeBorder` change didn't address the real bug — top/bottom of the selection border were still missing.
- Actual cause: flag/crown/stars corner overlays applied `.padding(2)` **after** `.frame(maxWidth: .infinity, maxHeight: .infinity)`. Outer padding wraps the expanded frame, so each flexible child is 4 pt larger than the ZStack's proposal; ZStack adopts that, pushing the cell's top/bottom 2 pt outside the ScrollView clip.
- Fix: swap modifier order so `.padding(2)` is inside the expanded frame. Cell frame now matches proposal; all four stroke edges render.

## Evidence

Debug build with a red `Rectangle().strokeBorder(lineWidth: 3)` on every cell, before/after:

- Before: only vertical (left/right) strokes visible; top/bottom clipped (confirms the cell frame overflows vertically).
- After: all four edges visible; structural fix, no padding bump needed.

## Test plan

- [x] `scripts/pre-commit.sh` — lint + unit tests green
- [x] Launched locally with `test-photos/`, confirmed selected thumbnail shows a full 4-sided blue border
- [ ] CI xcuitest suite green