### PR TITLE
fix(sidebar): match Tags row font size to Ratings/Species

### DIFF
--- a/apps/mac-client/SuperPickyApp/SourceListView.swift
+++ b/apps/mac-client/SuperPickyApp/SourceListView.swift
@@ -96,7 +96,6 @@ struct SourceListView: View {
                         Spacer()
                         Text("\(flyingCount)")
                             .foregroundStyle(.secondary)
-                            .font(.caption)
                     }
                 } icon: {
                     Image(systemName: "bird")
@@ -109,7 +108,6 @@ struct SourceListView: View {
                         Spacer()
                         Text("\(picksCount)")
                             .foregroundStyle(.secondary)
-                            .font(.caption)
                     }
                 } icon: {
                     Image(systemName: "flag.fill")


### PR DESCRIPTION
## Summary
- The `In Flight` and `Picks` rows applied `.font(.caption)` to their count Text, while every other count in the sidebar (Ratings, Species, Burst, Singles) uses the default sidebar font. That asymmetry made the two Tags rows render visibly smaller and less prominent than peer rows.
- Drop the two `.font(.caption)` modifiers in `SourceListView.swift` so Tags renders consistently with the rest of the sidebar.

## Test plan
- [x] `xcodebuild build -scheme SuperPicky -destination 'platform=macOS'` succeeds locally
- [ ] CI green
- [ ] Visual check: Tags rows render at same font size as Ratings/Species rows