### PR TITLE
chore: rebrand bundle id to com.halfhacked.superpicky

### DIFF
--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -1608,7 +1608,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 0.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.superpicky.SuperPicky;
+				PRODUCT_BUNDLE_IDENTIFIER = com.halfhacked.superpicky;
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -1624,7 +1624,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.superpicky.SuperPickyTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.halfhacked.superpicky.tests;
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SuperPicky.app/Contents/MacOS/SuperPicky";
 			};
@@ -1641,7 +1641,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.superpicky.SuperPickyUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.halfhacked.superpicky.uitests;
 				SDKROOT = macosx;
 				TEST_TARGET_NAME = SuperPicky;
 			};
@@ -1665,7 +1665,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.superpicky.SuperPickyInference;
+				PRODUCT_BUNDLE_IDENTIFIER = com.halfhacked.superpicky.inference;
 				SDKROOT = macosx;
 				SKIP_INSTALL = NO;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1682,12 +1682,13 @@
 				CURRENT_PROJECT_VERSION = 3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDevelopmentRegion = en;
+				INFOPLIST_KEY_CFBundleDisplayName = "SuperPicky Debug";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 0.0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.superpicky.SuperPicky;
+				PRODUCT_BUNDLE_IDENTIFIER = com.halfhacked.superpicky.debug;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -1710,7 +1711,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.superpicky.SuperPickyInference;
+				PRODUCT_BUNDLE_IDENTIFIER = com.halfhacked.superpicky.inference;
 				SDKROOT = macosx;
 				SKIP_INSTALL = NO;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1796,7 +1797,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.superpicky.SuperPickyTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.halfhacked.superpicky.tests;
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SuperPicky.app/Contents/MacOS/SuperPicky";
 			};
@@ -1874,7 +1875,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.superpicky.SuperPickyUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.halfhacked.superpicky.uitests;
 				SDKROOT = macosx;
 				TEST_TARGET_NAME = SuperPicky;
 			};

--- a/apps/mac-client/SuperPickyApp/AppState.swift
+++ b/apps/mac-client/SuperPickyApp/AppState.swift
@@ -65,7 +65,7 @@ struct BurstGroupEntry: Identifiable {
 
 @Observable
 final class AppState {
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "AppState")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "AppState")
 
     var sidebarSelection: SidebarSelection?
     var selectedPhotoID: UUID?

--- a/apps/mac-client/SuperPickyApp/CoreMLInferenceClient.swift
+++ b/apps/mac-client/SuperPickyApp/CoreMLInferenceClient.swift
@@ -23,7 +23,7 @@ final class CoreMLInferenceClient: InferenceClient, @unchecked Sendable {
     private let speciesDB: SpeciesDatabase?
     private let aestheticsModel: AestheticsModel?
     private let speciesFilter: SpeciesFilter?
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "CoreMLInference")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "CoreMLInference")
 
     private static let oseaTemperature = InferenceConstants.oseaTemperature
     // Match preen: drop only near-zero noise; the user's birdIdConfidence

--- a/apps/mac-client/SuperPickyApp/Logger.swift
+++ b/apps/mac-client/SuperPickyApp/Logger.swift
@@ -1,8 +1,8 @@
 import os
 
 extension Logger {
-    static let pipeline = Logger(subsystem: "com.superpicky.mac", category: "Pipeline")
-    static let inference = Logger(subsystem: "com.superpicky.mac", category: "Inference")
-    static let database = Logger(subsystem: "com.superpicky.mac", category: "Database")
-    static let ui = Logger(subsystem: "com.superpicky.mac", category: "UI")
+    static let pipeline = Logger(subsystem: "com.halfhacked.superpicky", category: "Pipeline")
+    static let inference = Logger(subsystem: "com.halfhacked.superpicky", category: "Inference")
+    static let database = Logger(subsystem: "com.halfhacked.superpicky", category: "Database")
+    static let ui = Logger(subsystem: "com.halfhacked.superpicky", category: "UI")
 }

--- a/apps/mac-client/SuperPickyApp/MainView.swift
+++ b/apps/mac-client/SuperPickyApp/MainView.swift
@@ -351,7 +351,7 @@ struct MainView: View {
         startProcessing(folder: url)
     }
 
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "MainView")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "MainView")
 
     /// Auto-resume if the folder has more files than the DB has rows
     /// (crash-interrupted run or user dropped in new photos).

--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -14,7 +14,7 @@ final class PipelineCoordinator: @unchecked Sendable {
     private let rawConverter = RAWConverter()
     private let scanner = DirectoryScanner()
     private let reverseGeocoder = ReverseGeocoder()
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "Pipeline")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "Pipeline")
 
     var totalCount = 0
     var processedCount = 0

--- a/apps/mac-client/SuperPickyInference/Data/SpeciesDatabase.swift
+++ b/apps/mac-client/SuperPickyInference/Data/SpeciesDatabase.swift
@@ -26,7 +26,7 @@ public final class SpeciesDatabase: Sendable {
     /// `byClassID` but in a form that's cheap to iterate without materializing
     /// the dictionary's values on each search call.
     private let all: [SpeciesEntry]
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "SpeciesDB")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "SpeciesDB")
 
     public init(url: URL, ebirdByClassID: [Int: String] = [:]) throws {
         var db: OpaquePointer?

--- a/apps/mac-client/SuperPickyInference/Data/SpeciesFilter.swift
+++ b/apps/mac-client/SuperPickyInference/Data/SpeciesFilter.swift
@@ -37,7 +37,7 @@ public final class SpeciesFilter: @unchecked Sendable {
         for (code, id) in classIDByEbirdCode { out[id] = code }
         return out
     }
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "SpeciesFilter")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "SpeciesFilter")
 
     /// Long-lived SQLite handle. nil if the DB file wasn't present at init
     /// (offline first-launch). SQLITE_OPEN_FULLMUTEX makes the connection

--- a/apps/mac-client/SuperPickyInference/Download/ModelManager.swift
+++ b/apps/mac-client/SuperPickyInference/Download/ModelManager.swift
@@ -45,7 +45,7 @@ public actor ModelManager {
     private let rootDir: URL
     private let bundle: Bundle
     private var observers: [AsyncStream<State>.Continuation] = []
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "ModelManager")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "ModelManager")
 
     // MARK: - Init
 

--- a/apps/mac-client/SuperPickyInference/Models/AestheticsModel.swift
+++ b/apps/mac-client/SuperPickyInference/Models/AestheticsModel.swift
@@ -27,7 +27,7 @@ public final class AestheticsModel: @unchecked Sendable {
     private static let outputName = "dist_score"
 
     private let model: MLModel
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "AestheticsModel")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "AestheticsModel")
 
     public init(url: URL, configuration: MLModelConfiguration = .init()) throws {
         // CFANet/TOPIQ uses transformer attention layers — GPU beats ANE

--- a/apps/mac-client/SuperPickyInference/Models/OSEAClassifier.swift
+++ b/apps/mac-client/SuperPickyInference/Models/OSEAClassifier.swift
@@ -35,7 +35,7 @@ public final class OSEAClassifier: @unchecked Sendable {
 
     // MARK: - State
     private let model: MLModel
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "OSEAClassifier")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "OSEAClassifier")
 
     // MARK: - Init
 

--- a/apps/mac-client/SuperPickyInference/Models/YOLOBirdDetector.swift
+++ b/apps/mac-client/SuperPickyInference/Models/YOLOBirdDetector.swift
@@ -54,7 +54,7 @@ public final class YOLOBirdDetector: @unchecked Sendable {
     // MARK: - State
 
     private let model: MLModel
-    private let logger = Logger(subsystem: "com.superpicky.mac", category: "YOLODetector")
+    private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "YOLODetector")
 
     // MARK: - Init
 


### PR DESCRIPTION
## Summary

Enables side-by-side install of the GitHub Release and a local Debug build. Previously both used `com.superpicky.SuperPicky`, so they shared NSUserDefaults, LaunchServices registration, and notification prefs — installing the Release stomped on local Debug state and vice versa.

## Changes

- **App Release** bundle id → `com.halfhacked.superpicky`
- **App Debug** bundle id → `com.halfhacked.superpicky.debug`, with `CFBundleDisplayName = \"SuperPicky Debug\"` so the Dock / menu bar disambiguates
- **Tests** target → `com.halfhacked.superpicky.tests`
- **UITests** target → `com.halfhacked.superpicky.uitests`
- **Inference framework** target → `com.halfhacked.superpicky.inference`
- **os.Logger subsystem** renamed to `com.halfhacked.superpicky` across 14 call sites (11 .swift files) for consistency with the new identity

## What stays unchanged (deliberate)

- **Model cache path** (`~/Library/Application Support/com.superpicky.mac/ModelCache`) — keeping it means existing v0.0.3 users do **not** re-download 350 MB of weights on upgrade, and both Release + local Debug continue to share the cache. `ModelManager` checksum-verifies every download so cross-build coexistence is safe.

## Tradeoff to flag

Existing local Debug user defaults (under the old domain `com.superpicky.SuperPicky`) become stranded after this lands — devs will see language / theme / window state reset on first launch of the new Debug build. Acceptable for a forward-only dev-side switch.

## Test plan

- [x] `xcodebuild build -scheme SuperPicky -destination 'platform=macOS'` (Debug) succeeds
- [x] `xcodebuild build -scheme SuperPicky -configuration Release -destination 'platform=macOS'` succeeds
- [x] L1 unit tests pass: `xcodebuild test -scheme SuperPicky -destination 'platform=macOS' -only-testing:SuperPickyTests` → 451 tests in 48 suites, all green locally in 3.0s
- [x] Built Debug bundle confirms identity: `CFBundleIdentifier = com.halfhacked.superpicky.debug`, `CFBundleDisplayName = SuperPicky Debug`, code-sign identifier matches
- [x] Built Release bundle confirms identity: `CFBundleIdentifier = com.halfhacked.superpicky`
- [ ] CI green (XCUITest matrix shards: chrome / processing / culling / species)