### PR TITLE
ci: add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build & publish release
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive version from tag
+        id: v
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          BUILD=$(git rev-list --count HEAD)
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "build=$BUILD"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build (Release)
+        working-directory: apps/mac-client
+        run: |
+          xcodebuild build \
+            -scheme SuperPicky \
+            -configuration Release \
+            -destination 'platform=macOS' \
+            -derivedDataPath build \
+            MARKETING_VERSION="${{ steps.v.outputs.version }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.v.outputs.build }}"
+
+      - name: Package .app into zip
+        working-directory: apps/mac-client
+        run: |
+          APP="build/Build/Products/Release/SuperPicky.app"
+          ZIP="SuperPicky-${{ steps.v.outputs.tag }}-mac.zip"
+          ditto -c -k --sequesterRsrc --keepParent "$APP" "$ZIP"
+          echo "ZIP_PATH=apps/mac-client/$ZIP" >> "$GITHUB_ENV"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.v.outputs.tag }}" \
+            --title "${{ steps.v.outputs.tag }}" \
+            --generate-notes \
+            "$ZIP_PATH"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml`. Pushing a `v*` tag now builds the Release-config app, zips it with `ditto`, and publishes a GitHub release with auto-generated notes — replacing the manual `xcodebuild → zip → gh release create` flow used for v0.0.1–v0.0.3.

## How it works

1. Tag `vX.Y.Z` is pushed → workflow fires
2. Version derived: tag minus `v` → `MARKETING_VERSION` (e.g. `v0.0.4` → `0.0.4`)
3. Build number derived: `git rev-list --count HEAD` → `CURRENT_PROJECT_VERSION` (always monotonic)
4. `xcodebuild build -configuration Release` with both passed as build-setting overrides — pbxproj is **not** modified
5. `ditto -c -k --sequesterRsrc --keepParent` zips the .app (preserves bundle metadata + signature; `zip -r` would corrupt)
6. `gh release create --generate-notes` uploads the zip and auto-generates the body from PR titles since the previous tag

## Why no version-bump commit?

`MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` are passed to `xcodebuild` as command-line overrides, which take precedence over the pbxproj values for that build only. The pbxproj stays at whatever the local Debug version is — irrelevant for releases.

## Test plan

- [x] YAML parses cleanly (`yaml.safe_load`)
- [x] Workflow shape verified: 1 job, macos-15, trigger=`push` to `tags: ['v*']`, 5 steps
- [x] CI on this PR (existing `ci.yml` jobs continue to gate the change; the new workflow only runs on tag push, not PR)
- [ ] First real exercise: push tag `v0.0.4` after merge → verify the workflow produces `SuperPicky-v0.0.4-mac.zip` on a new release page