### PR TITLE
chore(test): remove sidebar a11y diagnostic

### DIFF
--- a/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -18,58 +18,6 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         continueAfterFailure = true
     }
 
-    // MARK: - 00: Diagnostic (temporary)
-
-    /// Diagnostic-only: dump sidebar a11y composition so we can see why
-    /// `app.staticTexts["Bald Eagle"]` and `label CONTAINS "Bald Eagle"`
-    /// both return zero matches in CI even though the species rows should
-    /// fit inside the 1020x700 TEST_MODE window. Always passes; output
-    /// goes to the test log. Remove once the species-row a11y exposure
-    /// is understood.
-    func test00_DiagSidebarA11y() {
-        let app = Self.app!
-        XCTAssertTrue(app.outlines.firstMatch.waitForExistence(timeout: 10))
-        XCTAssertTrue(app.images[A11y.photoPreview].waitForExistence(timeout: 10))
-
-        func emit(_ tag: String, _ value: String) {
-            // Both stdout and NSLog so the line shows up in Xcode and the
-            // raw GitHub Actions log regardless of capture mode.
-            print("DIAG/\(tag) \(value)")
-            NSLog("DIAG/%@ %@", tag, value)
-        }
-
-        emit("window", "frame=\(app.windows.firstMatch.frame)")
-
-        emit("staticTexts.count", "\(app.staticTexts.count)")
-        for (i, st) in app.staticTexts.allElementsBoundByIndex.enumerated() {
-            emit("staticText[\(i)]",
-                 "label=\(st.label.debugDescription) value=\(String(describing: st.value)) frame=\(st.frame)")
-        }
-
-        let outline = app.outlines.firstMatch
-        emit("outline.cells.count", "\(outline.cells.count)")
-        for (i, cell) in outline.cells.allElementsBoundByIndex.enumerated() {
-            emit("outlineCell[\(i)]",
-                 "label=\(cell.label.debugDescription) elementType=\(cell.elementType.rawValue) frame=\(cell.frame)")
-        }
-
-        emit("eagle.matches", "")
-        for (i, el) in app.descendants(matching: .any)
-            .matching(NSPredicate(format: "label CONTAINS 'Eagle'"))
-            .allElementsBoundByIndex.enumerated() {
-            emit("eagle[\(i)]",
-                 "type=\(el.elementType.rawValue) label=\(el.label.debugDescription) frame=\(el.frame)")
-        }
-
-        emit("hummingbird.matches", "")
-        for (i, el) in app.descendants(matching: .any)
-            .matching(NSPredicate(format: "label CONTAINS 'Hummingbird'"))
-            .allElementsBoundByIndex.enumerated() {
-            emit("hummingbird[\(i)]",
-                 "type=\(el.elementType.rawValue) label=\(el.label.debugDescription) frame=\(el.frame)")
-        }
-    }
-
     // MARK: - 01-09: UI Elements
 
     func test01_SidebarRatingLabels() {


### PR DESCRIPTION
## What we learned

PR #64's \`test00_DiagSidebarA11y\` dumped the sidebar a11y tree at initial state. Key findings:

\`\`\`
staticText[71] label="Anna's Hummingbird, 0/11" frame=(27.0, 477.0, 177.0, 18.0)
staticText[72] label="Bald Eagle, 0/11"         frame=(27.0, 505.0, 177.0, 18.0)
staticText[73] label="Folders"                  frame=(14.0, 79.5, 191.0, 14.0)
staticText[74] label="Ratings"                  frame=(14.0, 139.5, 42.0, 14.0)
staticText[75] label="Tags"                     frame=(14.0, 339.5, 26.0, 14.0)
\`\`\`

- Sidebar species rows ARE in the a11y tree as \`XCUIElementTypeStaticText\`.
- Frame x=27 puts them well inside the 1020x700 TEST_MODE window. **"Below the fold" was wrong.**
- Label format is \`"Species Name, count/total"\` (SwiftUI \`List\` + \`DisclosureGroup\` + \`Label\` composes the inner Text+Spacer+Text into one comma-joined cell label).
- PR #62's predicate \`label CONTAINS "Bald Eagle"\` *should* match \`"Bald Eagle, 0/11"\`. The actual reason it failed at test09 is unclear — likely sequence-dependent state from the 8 prior tests. The diag captured initial state, not test09's state.
- Most other SwiftUI Texts in the app expose content via \`value\`, not \`label\` — only \`List\` cells get populated labels. Useful general-purpose finding.

## Decision

Keep test09's rating-row workaround (PR #63). v3 ships green deterministically and tests the same \`applyFilter → reconcile → auto-select-first\` invariant.

## What's in this PR

Just remove \`test00_DiagSidebarA11y\` (the diag we landed in PR #64).

## Test plan

- [x] \`xcodebuild build\` clean.
- [ ] CI: deletion-only — every job should still pass.