### PR TITLE
Disk + RAM preview cache for zoom-mode RAW navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ real-photos/
 # Claude Code local state
 .claude/
 
+# Git worktrees
+.worktrees/
+
 # User-picked photo output
 Picked/
 

--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		704D3515AE8394CD89C73030 /* KeypointModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDD77DC8C0AFD2D27F7BF8F /* KeypointModel.swift */; };
 		72593C01A639B74395F129D0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2035E1F0D51979F7D9BD4857 /* SettingsView.swift */; };
 		743E98D2D106B2DC4CD9A375 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16D64E760C59FE88930FB6D /* Logger.swift */; };
+		A0FE12CD3456789012345678 /* PreviewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FE12CD3456789012345678 /* PreviewCache.swift */; };
 		77015E7D20FE9E94039A4710 /* species_list_US-CT.json in Resources */ = {isa = PBXBuildFile; fileRef = FC69DB9AB0604B1868A3B299 /* species_list_US-CT.json */; };
 		77E2CDCA44CEAFF85E7A5846 /* species_list_CN-71.json in Resources */ = {isa = PBXBuildFile; fileRef = EA903F7D9120FDF6460CD01E /* species_list_CN-71.json */; };
 		78939EE79C0DDD7C2E4B4BF8 /* offline_index.json in Resources */ = {isa = PBXBuildFile; fileRef = 67D9011A882448A3C9139930 /* offline_index.json */; };
@@ -599,6 +600,7 @@
 		D16D64E760C59FE88930FB6D /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		D28E71A56423EBF1C3153D43 /* species_list_US-DE.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_US-DE.json"; sourceTree = "<group>"; };
 		D3212B6002C7368D529C9F05 /* GPSCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPSCell.swift; sourceTree = "<group>"; };
+		B0FE12CD3456789012345678 /* PreviewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCache.swift; sourceTree = "<group>"; };
 		D354E8BFE2BB6211ADAA855F /* PreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewView.swift; sourceTree = "<group>"; };
 		D3A36E4779D719861038F9E4 /* species_list_US-UT.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_US-UT.json"; sourceTree = "<group>"; };
 		D3AC27931EC190A197652D78 /* FlightModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightModel.swift; sourceTree = "<group>"; };
@@ -784,6 +786,7 @@
 				5EAEF125F85AE85042A82314 /* Photo.swift */,
 				5DF7946FDA6598F54AFD92F2 /* PhotoRatingPredictor.swift */,
 				93BD233E1B5ECE7A7C1FDAB1 /* PipelineCoordinator.swift */,
+				B0FE12CD3456789012345678 /* PreviewCache.swift */,
 				D354E8BFE2BB6211ADAA855F /* PreviewView.swift */,
 				0252F59F2B2852A81A8FB56F /* RatingEngine.swift */,
 				197514D16AE317EA0B6F2795 /* RAWConverter.swift */,
@@ -1553,6 +1556,7 @@
 				04EF6C1DD4443AF13BA6722D /* Photo.swift in Sources */,
 				0871FDE9E5781152BBD6FB44 /* PhotoRatingPredictor.swift in Sources */,
 				D0CB8BD3324BE76EE0E716B4 /* PipelineCoordinator.swift in Sources */,
+				A0FE12CD3456789012345678 /* PreviewCache.swift in Sources */,
 				93DFF6C1F94162A500AB340A /* PreviewView.swift in Sources */,
 				D846F6D40E95F052E6E6CCD5 /* RAWConverter.swift in Sources */,
 				F0E93BA6594B7964B23E6005 /* RatingEngine.swift in Sources */,

--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		72593C01A639B74395F129D0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2035E1F0D51979F7D9BD4857 /* SettingsView.swift */; };
 		743E98D2D106B2DC4CD9A375 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16D64E760C59FE88930FB6D /* Logger.swift */; };
 		A0FE12CD3456789012345678 /* PreviewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FE12CD3456789012345678 /* PreviewCache.swift */; };
+		A1FE12CD3456789012345678 /* PrefetchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FE12CD3456789012345678 /* PrefetchCoordinator.swift */; };
 		77015E7D20FE9E94039A4710 /* species_list_US-CT.json in Resources */ = {isa = PBXBuildFile; fileRef = FC69DB9AB0604B1868A3B299 /* species_list_US-CT.json */; };
 		77E2CDCA44CEAFF85E7A5846 /* species_list_CN-71.json in Resources */ = {isa = PBXBuildFile; fileRef = EA903F7D9120FDF6460CD01E /* species_list_CN-71.json */; };
 		78939EE79C0DDD7C2E4B4BF8 /* offline_index.json in Resources */ = {isa = PBXBuildFile; fileRef = 67D9011A882448A3C9139930 /* offline_index.json */; };
@@ -601,6 +602,7 @@
 		D28E71A56423EBF1C3153D43 /* species_list_US-DE.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_US-DE.json"; sourceTree = "<group>"; };
 		D3212B6002C7368D529C9F05 /* GPSCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPSCell.swift; sourceTree = "<group>"; };
 		B0FE12CD3456789012345678 /* PreviewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCache.swift; sourceTree = "<group>"; };
+		B1FE12CD3456789012345678 /* PrefetchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchCoordinator.swift; sourceTree = "<group>"; };
 		D354E8BFE2BB6211ADAA855F /* PreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewView.swift; sourceTree = "<group>"; };
 		D3A36E4779D719861038F9E4 /* species_list_US-UT.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_US-UT.json"; sourceTree = "<group>"; };
 		D3AC27931EC190A197652D78 /* FlightModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightModel.swift; sourceTree = "<group>"; };
@@ -786,6 +788,7 @@
 				5EAEF125F85AE85042A82314 /* Photo.swift */,
 				5DF7946FDA6598F54AFD92F2 /* PhotoRatingPredictor.swift */,
 				93BD233E1B5ECE7A7C1FDAB1 /* PipelineCoordinator.swift */,
+				B1FE12CD3456789012345678 /* PrefetchCoordinator.swift */,
 				B0FE12CD3456789012345678 /* PreviewCache.swift */,
 				D354E8BFE2BB6211ADAA855F /* PreviewView.swift */,
 				0252F59F2B2852A81A8FB56F /* RatingEngine.swift */,
@@ -1556,6 +1559,7 @@
 				04EF6C1DD4443AF13BA6722D /* Photo.swift in Sources */,
 				0871FDE9E5781152BBD6FB44 /* PhotoRatingPredictor.swift in Sources */,
 				D0CB8BD3324BE76EE0E716B4 /* PipelineCoordinator.swift in Sources */,
+				A1FE12CD3456789012345678 /* PrefetchCoordinator.swift in Sources */,
 				A0FE12CD3456789012345678 /* PreviewCache.swift in Sources */,
 				93DFF6C1F94162A500AB340A /* PreviewView.swift in Sources */,
 				D846F6D40E95F052E6E6CCD5 /* RAWConverter.swift in Sources */,

--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		A0FE12CD3456789012345678 /* PreviewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FE12CD3456789012345678 /* PreviewCache.swift */; };
 		A1FE12CD3456789012345678 /* PrefetchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FE12CD3456789012345678 /* PrefetchCoordinator.swift */; };
 		A2FE12CD3456789012345678 /* PreviewSweepCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FE12CD3456789012345678 /* PreviewSweepCoordinator.swift */; };
+		A3FE12CD3456789012345678 /* PreviewCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE12CD3456789012345678 /* PreviewCacheTests.swift */; };
+		A4FE12CD3456789012345678 /* PreviewCacheUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FE12CD3456789012345678 /* PreviewCacheUITests.swift */; };
 		77015E7D20FE9E94039A4710 /* species_list_US-CT.json in Resources */ = {isa = PBXBuildFile; fileRef = FC69DB9AB0604B1868A3B299 /* species_list_US-CT.json */; };
 		77E2CDCA44CEAFF85E7A5846 /* species_list_CN-71.json in Resources */ = {isa = PBXBuildFile; fileRef = EA903F7D9120FDF6460CD01E /* species_list_CN-71.json */; };
 		78939EE79C0DDD7C2E4B4BF8 /* offline_index.json in Resources */ = {isa = PBXBuildFile; fileRef = 67D9011A882448A3C9139930 /* offline_index.json */; };
@@ -605,6 +607,8 @@
 		B0FE12CD3456789012345678 /* PreviewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCache.swift; sourceTree = "<group>"; };
 		B1FE12CD3456789012345678 /* PrefetchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchCoordinator.swift; sourceTree = "<group>"; };
 		B2FE12CD3456789012345678 /* PreviewSweepCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSweepCoordinator.swift; sourceTree = "<group>"; };
+		B3FE12CD3456789012345678 /* PreviewCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCacheTests.swift; sourceTree = "<group>"; };
+		B4FE12CD3456789012345678 /* PreviewCacheUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCacheUITests.swift; sourceTree = "<group>"; };
 		D354E8BFE2BB6211ADAA855F /* PreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewView.swift; sourceTree = "<group>"; };
 		D3A36E4779D719861038F9E4 /* species_list_US-UT.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_US-UT.json"; sourceTree = "<group>"; };
 		D3AC27931EC190A197652D78 /* FlightModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightModel.swift; sourceTree = "<group>"; };
@@ -706,6 +710,7 @@
 			isa = PBXGroup;
 			children = (
 				B692D00B454892AE77C8C7E2 /* AssignedSpeciesTests.swift */,
+				B3FE12CD3456789012345678 /* PreviewCacheTests.swift */,
 				A4B59971656A9AD18B236A2D /* BurstDetectorGPSTests.swift */,
 				874D5B3B2230C5E5693018BA /* BurstDetectorTests.swift */,
 				229472C67589424B4A5072F0 /* CullingConfigTests.swift */,
@@ -949,6 +954,7 @@
 				79C2F63B6B529E331DFC29AB /* ScreenshotAuditTests.swift */,
 				F0FEA77B7EA580CB52BFD7C1 /* SettingsUITests.swift */,
 				8D660D2C3EE22E79E79831D3 /* BatchSelectionUITests.swift */,
+				B4FE12CD3456789012345678 /* PreviewCacheUITests.swift */,
 			);
 			path = SuperPickyUITests;
 			sourceTree = "<group>";
@@ -1440,6 +1446,7 @@
 				BE4F93B4BD74DD899C66590E /* ScreenshotAuditTests.swift in Sources */,
 				5EB7DC526D950902A30771DD /* SettingsUITests.swift in Sources */,
 				552702ED1C0AC98BD9B9AA04 /* BatchSelectionUITests.swift in Sources */,
+				A4FE12CD3456789012345678 /* PreviewCacheUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1470,6 +1477,7 @@
 			files = (
 				DDE8E519157564DD655F575A /* AestheticsModelTests.swift in Sources */,
 				7CF4E498D7CA0C66F2559AFE /* AssignedSpeciesTests.swift in Sources */,
+				A3FE12CD3456789012345678 /* PreviewCacheTests.swift in Sources */,
 				964B6A7D156A55F0174BA44C /* BurstDetectorGPSTests.swift in Sources */,
 				BBEB9FC0A982439506A82FAF /* BurstDetectorTests.swift in Sources */,
 				142EF22BA97B679CCFF77E5A /* CullingConfigTests.swift in Sources */,

--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		743E98D2D106B2DC4CD9A375 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16D64E760C59FE88930FB6D /* Logger.swift */; };
 		A0FE12CD3456789012345678 /* PreviewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FE12CD3456789012345678 /* PreviewCache.swift */; };
 		A1FE12CD3456789012345678 /* PrefetchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FE12CD3456789012345678 /* PrefetchCoordinator.swift */; };
+		A2FE12CD3456789012345678 /* PreviewSweepCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2FE12CD3456789012345678 /* PreviewSweepCoordinator.swift */; };
 		77015E7D20FE9E94039A4710 /* species_list_US-CT.json in Resources */ = {isa = PBXBuildFile; fileRef = FC69DB9AB0604B1868A3B299 /* species_list_US-CT.json */; };
 		77E2CDCA44CEAFF85E7A5846 /* species_list_CN-71.json in Resources */ = {isa = PBXBuildFile; fileRef = EA903F7D9120FDF6460CD01E /* species_list_CN-71.json */; };
 		78939EE79C0DDD7C2E4B4BF8 /* offline_index.json in Resources */ = {isa = PBXBuildFile; fileRef = 67D9011A882448A3C9139930 /* offline_index.json */; };
@@ -603,6 +604,7 @@
 		D3212B6002C7368D529C9F05 /* GPSCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPSCell.swift; sourceTree = "<group>"; };
 		B0FE12CD3456789012345678 /* PreviewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCache.swift; sourceTree = "<group>"; };
 		B1FE12CD3456789012345678 /* PrefetchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchCoordinator.swift; sourceTree = "<group>"; };
+		B2FE12CD3456789012345678 /* PreviewSweepCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSweepCoordinator.swift; sourceTree = "<group>"; };
 		D354E8BFE2BB6211ADAA855F /* PreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewView.swift; sourceTree = "<group>"; };
 		D3A36E4779D719861038F9E4 /* species_list_US-UT.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_US-UT.json"; sourceTree = "<group>"; };
 		D3AC27931EC190A197652D78 /* FlightModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightModel.swift; sourceTree = "<group>"; };
@@ -790,6 +792,7 @@
 				93BD233E1B5ECE7A7C1FDAB1 /* PipelineCoordinator.swift */,
 				B1FE12CD3456789012345678 /* PrefetchCoordinator.swift */,
 				B0FE12CD3456789012345678 /* PreviewCache.swift */,
+				B2FE12CD3456789012345678 /* PreviewSweepCoordinator.swift */,
 				D354E8BFE2BB6211ADAA855F /* PreviewView.swift */,
 				0252F59F2B2852A81A8FB56F /* RatingEngine.swift */,
 				197514D16AE317EA0B6F2795 /* RAWConverter.swift */,
@@ -1561,6 +1564,7 @@
 				D0CB8BD3324BE76EE0E716B4 /* PipelineCoordinator.swift in Sources */,
 				A1FE12CD3456789012345678 /* PrefetchCoordinator.swift in Sources */,
 				A0FE12CD3456789012345678 /* PreviewCache.swift in Sources */,
+				A2FE12CD3456789012345678 /* PreviewSweepCoordinator.swift in Sources */,
 				93DFF6C1F94162A500AB340A /* PreviewView.swift in Sources */,
 				D846F6D40E95F052E6E6CCD5 /* RAWConverter.swift in Sources */,
 				F0E93BA6594B7964B23E6005 /* RatingEngine.swift in Sources */,

--- a/apps/mac-client/SuperPickyApp/AdvancedTab.swift
+++ b/apps/mac-client/SuperPickyApp/AdvancedTab.swift
@@ -86,12 +86,35 @@ struct PreviewCacheSettings: View {
             : "\(config.previewCacheSizeGB) GB"
     }
 
+    /// Snapshot of `ImageCache.fullRes` usage. Recomputed on each render
+    /// (re-rendering happens whenever the user types in Settings, so it's
+    /// effectively live).
+    private var memoryCacheLabel: String {
+        let count = ImageCache.fullRes.approximateCount()
+        let bytes = ImageCache.fullRes.approximateBytes()
+        let budget = ImageCache.computeFullResBudget()
+        return "\(count) / \(budget.count) photos, \(formatBytes(Int64(bytes))) / \(formatBytes(Int64(budget.bytes)))"
+    }
+
     var body: some View {
         @Bindable var config = config
         Toggle(config.localized("Generate preview cache for faster zoom"),
                isOn: $config.generatePreviewCache)
 
-        Picker(config.localized("Cache size"),
+        Toggle(config.localized("Use aggressive in-memory cache (50% of RAM)"),
+               isOn: $config.aggressiveCache)
+            .accessibilityIdentifier("PreviewCache_AggressiveToggle")
+
+        HStack {
+            Text(config.localized("In-memory cache"))
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(memoryCacheLabel)
+                .monospacedDigit()
+                .accessibilityIdentifier("PreviewCache_MemoryUsage")
+        }
+
+        Picker(config.localized("Disk cache size"),
                selection: $config.previewCacheSizeGB) {
             ForEach(Self.sizeOptions, id: \.self) { gb in
                 Text(gb == 0 ? config.localized("Unlimited") : "\(gb) GB").tag(gb)

--- a/apps/mac-client/SuperPickyApp/AdvancedTab.swift
+++ b/apps/mac-client/SuperPickyApp/AdvancedTab.swift
@@ -36,6 +36,9 @@ struct AdvancedTab: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            Section(config.localized("Preview Cache")) {
+                PreviewCacheSettings()
+            }
             Section(config.localized("Burst Detection")) {
                 Toggle(config.localized("Enable burst detection"), isOn: $config.burstDetectionEnabled)
                 if config.burstDetectionEnabled {
@@ -64,6 +67,94 @@ struct AdvancedTab: View {
             }
         }
         .formStyle(.grouped)
+    }
+}
+
+/// Settings UI for the on-disk full-res JPEG cache that speeds up
+/// keyboard navigation in zoom mode.
+struct PreviewCacheSettings: View {
+    @Environment(CullingConfig.self) private var config
+    @State private var currentSize: Int64?
+    @State private var isComputingSize = false
+    @State private var showClearConfirm = false
+
+    private static let sizeOptions: [Int] = [5, 20, 50, 100, 0]
+
+    private var capLabel: String {
+        config.previewCacheSizeGB == 0
+            ? config.localized("Unlimited")
+            : "\(config.previewCacheSizeGB) GB"
+    }
+
+    var body: some View {
+        @Bindable var config = config
+        Toggle(config.localized("Generate preview cache for faster zoom"),
+               isOn: $config.generatePreviewCache)
+
+        Picker(config.localized("Cache size"),
+               selection: $config.previewCacheSizeGB) {
+            ForEach(Self.sizeOptions, id: \.self) { gb in
+                Text(gb == 0 ? config.localized("Unlimited") : "\(gb) GB").tag(gb)
+            }
+        }
+        .accessibilityIdentifier("PreviewCache_SizePicker")
+
+        HStack {
+            Text(config.localized("Currently using"))
+                .foregroundStyle(.secondary)
+            Spacer()
+            if isComputingSize {
+                ProgressView().controlSize(.small)
+            } else if let bytes = currentSize {
+                Text("\(formatBytes(bytes)) / \(capLabel)")
+                    .monospacedDigit()
+                    .accessibilityIdentifier("PreviewCache_CurrentSize")
+            } else {
+                Text(config.localized("Calculating…"))
+                    .foregroundStyle(.secondary)
+            }
+        }
+
+        HStack {
+            Spacer()
+            Button(config.localized("Clear preview cache"), role: .destructive) {
+                showClearConfirm = true
+            }
+            .accessibilityIdentifier("PreviewCache_ClearButton")
+        }
+        .confirmationDialog(
+            config.localized("Clear all cached previews?"),
+            isPresented: $showClearConfirm,
+            titleVisibility: .visible
+        ) {
+            Button(config.localized("Clear"), role: .destructive) {
+                _ = PreviewCache.clearAll()
+                refreshSize()
+            }
+            Button(config.localized("Cancel"), role: .cancel) {}
+        } message: {
+            Text(config.localized("Cached previews will be regenerated next time you zoom into a photo."))
+        }
+        .task { refreshSize() }
+        .onChange(of: config.previewCacheSizeGB) { _, _ in refreshSize() }
+    }
+
+    private func refreshSize() {
+        isComputingSize = true
+        Task.detached(priority: .utility) {
+            let bytes = PreviewCache.currentSizeBytes()
+            await MainActor.run {
+                self.currentSize = bytes
+                self.isComputingSize = false
+            }
+        }
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useGB, .useMB]
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
     }
 }
 

--- a/apps/mac-client/SuperPickyApp/AppState.swift
+++ b/apps/mac-client/SuperPickyApp/AppState.swift
@@ -195,6 +195,14 @@ final class AppState {
 
             // Re-apply current filter instead of resetting to all
             applyFilter()
+
+            if isFolderSwitch {
+                let paths = allPhotos.map(\.filePath)
+                MainActor.assumeIsolated {
+                    PreviewSweepCoordinator.shared.start(folder: folder, paths: paths)
+                    PrefetchCoordinator.shared.reset()
+                }
+            }
         } catch {
             logger.error("loadPhotos failed: \(error)")
             allPhotos = []

--- a/apps/mac-client/SuperPickyApp/AppState.swift
+++ b/apps/mac-client/SuperPickyApp/AppState.swift
@@ -198,9 +198,16 @@ final class AppState {
 
             if isFolderSwitch {
                 let paths = allPhotos.map(\.filePath)
+                let prefillPhotos = allPhotos
                 Task { @MainActor in
                     PreviewSweepCoordinator.shared.start(folder: folder, paths: paths)
                     PrefetchCoordinator.shared.reset()
+                    // Start filling the in-RAM working set right after the
+                    // folder loads, before the user navigates. Centred on
+                    // photo 0 (the auto-selected one).
+                    if !prefillPhotos.isEmpty {
+                        PrefetchCoordinator.shared.prefill(photos: prefillPhotos, around: 0)
+                    }
                 }
             }
         } catch {

--- a/apps/mac-client/SuperPickyApp/AppState.swift
+++ b/apps/mac-client/SuperPickyApp/AppState.swift
@@ -198,7 +198,7 @@ final class AppState {
 
             if isFolderSwitch {
                 let paths = allPhotos.map(\.filePath)
-                MainActor.assumeIsolated {
+                Task { @MainActor in
                     PreviewSweepCoordinator.shared.start(folder: folder, paths: paths)
                     PrefetchCoordinator.shared.reset()
                 }

--- a/apps/mac-client/SuperPickyApp/ContentView.swift
+++ b/apps/mac-client/SuperPickyApp/ContentView.swift
@@ -88,8 +88,7 @@ struct ContentView: View {
                         }
                         PrefetchCoordinator.shared.update(
                             currentIndex: idx,
-                            photos: filteredPhotos,
-                            zoomActive: zoomState.scale > 1.0
+                            photos: filteredPhotos
                         )
                     }
 

--- a/apps/mac-client/SuperPickyApp/ContentView.swift
+++ b/apps/mac-client/SuperPickyApp/ContentView.swift
@@ -81,6 +81,17 @@ struct ContentView: View {
                             mouseInView: $mouseInPreview, viewSize: $previewSize,
                             appState: appState,
                             onCorrectSpecies: onCorrectSpecies)
+                    .onChange(of: selectedPhotoID) { _, newID in
+                        guard let newID,
+                              let idx = filteredPhotos.firstIndex(where: { $0.id == newID }) else {
+                            return
+                        }
+                        PrefetchCoordinator.shared.update(
+                            currentIndex: idx,
+                            photos: filteredPhotos,
+                            zoomActive: zoomState.scale > 1.0
+                        )
+                    }
 
                 HStack(alignment: .top, spacing: 0) {
                     Spacer(minLength: 0)

--- a/apps/mac-client/SuperPickyApp/CullingConfig.swift
+++ b/apps/mac-client/SuperPickyApp/CullingConfig.swift
@@ -77,6 +77,10 @@ final class CullingConfig {
     var generatePreviewCache: Bool { didSet { save(); applyPreviewCacheSettings() } }
     /// LRU cap on the preview-cache size. 0 means unlimited.
     var previewCacheSizeGB: Int { didSet { save(); applyPreviewCacheSettings() } }
+    /// When enabled, ImageCache.fullRes uses 50 % of physical RAM instead
+    /// of the default 25 %. Useful on Macs dedicated to SuperPicky; should
+    /// be disabled when running other memory-hungry apps alongside.
+    var aggressiveCache: Bool { didSet { save(); applyPreviewCacheSettings() } }
 
     init() {
         let defaults = UserDefaults.standard
@@ -99,20 +103,27 @@ final class CullingConfig {
         self.speciesSortOrder = SpeciesSortOrder(rawValue: defaults.string(forKey: "speciesSortOrder") ?? "") ?? .name
         self.generatePreviewCache = defaults.object(forKey: "generatePreviewCache") as? Bool ?? true
         self.previewCacheSizeGB = defaults.object(forKey: "previewCacheSizeGB") as? Int ?? 20
+        self.aggressiveCache = defaults.object(forKey: "aggressiveCache") as? Bool ?? false
         applyPreviewCacheSettings()
     }
 
     /// Push the current preview-cache settings into the lock-guarded slot
     /// the decode path reads. Called from init and on every Settings change.
+    /// Also re-sizes the in-memory `ImageCache.fullRes` to match the new
+    /// aggressive-cache choice.
     private func applyPreviewCacheSettings() {
         let cap: Int64 = previewCacheSizeGB == 0
             ? 0
             : Int64(previewCacheSizeGB) * 1024 * 1024 * 1024
         let generate = generatePreviewCache
+        let aggressive = aggressiveCache
         PreviewCache.updateSettings { s in
             s.generate = generate
             s.capBytes = cap
+            s.aggressiveCache = aggressive
         }
+        let budget = ImageCache.computeFullResBudget()
+        ImageCache.fullRes.resize(countLimit: budget.count, byteLimit: budget.bytes)
     }
 
     private func save() {
@@ -136,6 +147,7 @@ final class CullingConfig {
         defaults.set(speciesSortOrder.rawValue, forKey: "speciesSortOrder")
         defaults.set(generatePreviewCache, forKey: "generatePreviewCache")
         defaults.set(previewCacheSizeGB, forKey: "previewCacheSizeGB")
+        defaults.set(aggressiveCache, forKey: "aggressiveCache")
     }
 
     /// Look up a localized string. Reading `appLanguage` makes SwiftUI

--- a/apps/mac-client/SuperPickyApp/CullingConfig.swift
+++ b/apps/mac-client/SuperPickyApp/CullingConfig.swift
@@ -102,14 +102,17 @@ final class CullingConfig {
         applyPreviewCacheSettings()
     }
 
-    /// Push the current preview-cache settings into the static slots on
-    /// `ImageLoader` that the decode path reads. Called from init and on
-    /// every Settings change.
+    /// Push the current preview-cache settings into the lock-guarded slot
+    /// the decode path reads. Called from init and on every Settings change.
     private func applyPreviewCacheSettings() {
-        ImageLoader.generatePreviewCache = generatePreviewCache
-        ImageLoader.previewCacheCapBytes = previewCacheSizeGB == 0
+        let cap: Int64 = previewCacheSizeGB == 0
             ? 0
             : Int64(previewCacheSizeGB) * 1024 * 1024 * 1024
+        let generate = generatePreviewCache
+        PreviewCache.updateSettings { s in
+            s.generate = generate
+            s.capBytes = cap
+        }
     }
 
     private func save() {

--- a/apps/mac-client/SuperPickyApp/CullingConfig.swift
+++ b/apps/mac-client/SuperPickyApp/CullingConfig.swift
@@ -70,6 +70,13 @@ final class CullingConfig {
     var birdIdConfidence: Int { didSet { save() } }
     var flightDetectionEnabled: Bool { didSet { save() } }
     var speciesSortOrder: SpeciesSortOrder { didSet { save() } }
+    /// Whether to write JPEG sidecars under
+    /// `~/Library/Caches/com.halfhacked.superpicky/preview/` to speed up
+    /// zoom-mode keyboard navigation. Reads from existing cache files
+    /// regardless.
+    var generatePreviewCache: Bool { didSet { save(); applyPreviewCacheSettings() } }
+    /// LRU cap on the preview-cache size. 0 means unlimited.
+    var previewCacheSizeGB: Int { didSet { save(); applyPreviewCacheSettings() } }
 
     init() {
         let defaults = UserDefaults.standard
@@ -90,6 +97,19 @@ final class CullingConfig {
         self.birdIdConfidence = defaults.object(forKey: "birdIdConfidence") as? Int ?? 70
         self.flightDetectionEnabled = defaults.object(forKey: "flightDetectionEnabled") as? Bool ?? true
         self.speciesSortOrder = SpeciesSortOrder(rawValue: defaults.string(forKey: "speciesSortOrder") ?? "") ?? .name
+        self.generatePreviewCache = defaults.object(forKey: "generatePreviewCache") as? Bool ?? true
+        self.previewCacheSizeGB = defaults.object(forKey: "previewCacheSizeGB") as? Int ?? 20
+        applyPreviewCacheSettings()
+    }
+
+    /// Push the current preview-cache settings into the static slots on
+    /// `ImageLoader` that the decode path reads. Called from init and on
+    /// every Settings change.
+    private func applyPreviewCacheSettings() {
+        ImageLoader.generatePreviewCache = generatePreviewCache
+        ImageLoader.previewCacheCapBytes = previewCacheSizeGB == 0
+            ? 0
+            : Int64(previewCacheSizeGB) * 1024 * 1024 * 1024
     }
 
     private func save() {
@@ -111,6 +131,8 @@ final class CullingConfig {
         defaults.set(birdIdConfidence, forKey: "birdIdConfidence")
         defaults.set(flightDetectionEnabled, forKey: "flightDetectionEnabled")
         defaults.set(speciesSortOrder.rawValue, forKey: "speciesSortOrder")
+        defaults.set(generatePreviewCache, forKey: "generatePreviewCache")
+        defaults.set(previewCacheSizeGB, forKey: "previewCacheSizeGB")
     }
 
     /// Look up a localized string. Reading `appLanguage` makes SwiftUI

--- a/apps/mac-client/SuperPickyApp/FullscreenViewer.swift
+++ b/apps/mac-client/SuperPickyApp/FullscreenViewer.swift
@@ -44,24 +44,40 @@ struct FullscreenViewer: View {
         .task(id: selectedPhotoID) {
             isFullRes = false
             guard let photo = selectedPhoto else { image = nil; return }
-            let loaded: NSImage?
             if zoomState.scale > 1.0 {
                 isFullRes = true
-                loaded = await ImageLoader.load(path: photo.filePath)
-            } else {
-                loaded = await ImageLoader.load(path: photo.filePath, maxPixelSize: 2000)
+                if let cached = ImageCache.fullRes.get(photo.filePath) {
+                    image = cached
+                    return
+                }
+                guard let full = await ImageLoader.load(path: photo.filePath) else { return }
+                guard !Task.isCancelled else { return }
+                ImageCache.fullRes.set(photo.filePath, image: full)
+                image = full
+                return
             }
-            guard !Task.isCancelled else { return }
-            image = loaded
+            if let cached = ImageCache.preview.get(photo.filePath) {
+                image = cached
+            } else if let loaded = await ImageLoader.load(path: photo.filePath, maxPixelSize: 2000) {
+                guard !Task.isCancelled else { return }
+                ImageCache.preview.set(photo.filePath, image: loaded)
+                image = loaded
+            }
         }
         .onChange(of: zoomState.scale) { _, newScale in
-            if newScale > 1.0 && !isFullRes, let photo = selectedPhoto {
-                isFullRes = true
-                Task {
-                    if let full = await ImageLoader.load(path: photo.filePath) {
-                        image = full
-                    }
+            guard newScale > 1.0, !isFullRes, let photo = selectedPhoto else { return }
+            isFullRes = true
+            if let cached = ImageCache.fullRes.get(photo.filePath) {
+                image = cached
+                return
+            }
+            Task {
+                guard let full = await ImageLoader.load(path: photo.filePath) else {
+                    isFullRes = false
+                    return
                 }
+                ImageCache.fullRes.set(photo.filePath, image: full)
+                image = full
             }
         }
     }

--- a/apps/mac-client/SuperPickyApp/FullscreenViewer.swift
+++ b/apps/mac-client/SuperPickyApp/FullscreenViewer.swift
@@ -71,12 +71,14 @@ struct FullscreenViewer: View {
                 image = cached
                 return
             }
+            let pinnedID = photo.id
             Task {
                 guard let full = await ImageLoader.load(path: photo.filePath) else {
-                    isFullRes = false
+                    if !Task.isCancelled, selectedPhotoID == pinnedID { isFullRes = false }
                     return
                 }
                 ImageCache.fullRes.set(photo.filePath, image: full)
+                guard !Task.isCancelled, selectedPhotoID == pinnedID else { return }
                 image = full
             }
         }

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -5,6 +5,15 @@ import AppKit
 
 /// Shared image loading utility — used by PreviewView, FullscreenViewer, and ThumbnailStripView.
 enum ImageLoader {
+    /// Disk-cache full-res decodes as JPEG sidecars under
+    /// `~/Library/Caches/com.halfhacked.superpicky/preview/`. Set to false
+    /// to read existing cache entries but skip writing new ones.
+    nonisolated(unsafe) static var generatePreviewCache: Bool = true
+
+    /// LRU cap in bytes; 0 means unlimited. Mirrored from
+    /// `CullingConfig.previewCacheSizeGB` at app boot and on changes.
+    nonisolated(unsafe) static var previewCacheCapBytes: Int64 = 20 * 1024 * 1024 * 1024
+
     /// Load an image at a given max pixel size, or full resolution if nil.
     /// Uses the embedded preview when it's large enough (fast path for RAW),
     /// otherwise decodes the full image and downsamples.
@@ -27,6 +36,10 @@ enum ImageLoader {
         let url = URL(fileURLWithPath: path)
         return await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
+                if maxPixelSize == nil, let cached = loadCachedFullRes(path: path) {
+                    continuation.resume(returning: cached)
+                    return
+                }
                 guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
                     continuation.resume(returning: nil)
                     return
@@ -38,9 +51,35 @@ enum ImageLoader {
                     let cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
                         kCGImageSourceCreateThumbnailWithTransform: true,
                     ] as CFDictionary)
+                    if let cgImage, generatePreviewCache {
+                        writePreviewCacheAsync(image: cgImage, rawPath: path)
+                    }
                     continuation.resume(returning: cgImage)
                 }
             }
+        }
+    }
+
+    /// Returns a decoded CGImage from the on-disk JPEG cache when available
+    /// and fresher than the source. Bumps the cached file's mtime on hit so
+    /// LRU eviction sees recent reads as recently used.
+    private static func loadCachedFullRes(path: String) -> CGImage? {
+        guard let cachedURL = PreviewCache.freshURL(for: path) else { return nil }
+        guard let source = CGImageSourceCreateWithURL(cachedURL as CFURL, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return nil
+        }
+        PreviewCache.touch(cachedURL)
+        return image
+    }
+
+    /// Encode + write the cache off the decode thread; LRU eviction follows.
+    private static func writePreviewCacheAsync(image: CGImage, rawPath: String) {
+        let url = PreviewCache.cachedURL(for: rawPath)
+        let cap = previewCacheCapBytes
+        Task.detached(priority: .background) {
+            PreviewCache.write(image, to: url)
+            if cap > 0 { PreviewCache.evictIfOverCap(maxBytes: cap) }
         }
     }
 

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -32,31 +32,30 @@ enum ImageLoader {
     /// Sendable-friendly decode. Useful for `async let` / `TaskGroup`
     /// concurrency where NSImage's non-Sendable result would error.
     /// Call sites wrap in NSImage on their own actor.
+    ///
+    /// All decodes are serialized through `ImageDecodeQueue.shared` so that
+    /// holding an arrow key in zoom mode doesn't pile up N concurrent RAW
+    /// decodes — only one runs at a time, and cancelled callers drop their
+    /// turn at the front of the queue without doing any work.
     static func loadCGImage(path: String, maxPixelSize: Int? = nil) async -> CGImage? {
-        let url = URL(fileURLWithPath: path)
-        return await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                if maxPixelSize == nil, let cached = loadCachedFullRes(path: path) {
-                    continuation.resume(returning: cached)
-                    return
-                }
-                guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                if let maxPixelSize {
-                    continuation.resume(returning: decodePreview(source: source, maxPixelSize: maxPixelSize))
-                } else {
-                    // Full-res: actual image decode
-                    let cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
-                        kCGImageSourceCreateThumbnailWithTransform: true,
-                    ] as CFDictionary)
-                    if let cgImage, generatePreviewCache {
-                        writePreviewCacheAsync(image: cgImage, rawPath: path)
-                    }
-                    continuation.resume(returning: cgImage)
-                }
+        return await ImageDecodeQueue.shared.decode {
+            if maxPixelSize == nil, let cached = loadCachedFullRes(path: path) {
+                return cached
             }
+            let url = URL(fileURLWithPath: path)
+            guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+                return nil
+            }
+            if let maxPixelSize {
+                return decodePreview(source: source, maxPixelSize: maxPixelSize)
+            }
+            let cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
+                kCGImageSourceCreateThumbnailWithTransform: true,
+            ] as CFDictionary)
+            if let cgImage, generatePreviewCache {
+                writePreviewCacheAsync(image: cgImage, rawPath: path)
+            }
+            return cgImage
         }
     }
 
@@ -137,6 +136,25 @@ enum ImageLoader {
     /// Larger than any plausible embedded-thumbnail side so the probe
     /// returns the thumb at its native dimensions.
     private static let embeddedThumbnailProbeCap = 99_999
+
+    /// Serializes ImageIO decodes so superseded work (e.g. arrow-key
+    /// scrubbing in zoom mode) drops at the front of the queue instead of
+    /// piling up on a concurrent dispatch queue and saturating CPU.
+    ///
+    /// Each `decode` call awaits its turn on the actor; when its turn comes
+    /// the closure runs synchronously on the actor's executor (one decode
+    /// in flight at a time), and cancelled callers short-circuit before
+    /// touching ImageIO. ImageIO has no abort API, so a started decode
+    /// always runs to completion — we only prevent the queue itself from
+    /// fan-out.
+    actor ImageDecodeQueue {
+        static let shared = ImageDecodeQueue()
+
+        func decode(_ work: @Sendable () -> CGImage?) -> CGImage? {
+            if Task.isCancelled { return nil }
+            return work()
+        }
+    }
 
     /// Source dimensions in pixels (no decode — metadata only).
     static func pixelSize(path: String) -> CGSize? {

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -27,37 +27,73 @@ enum ImageLoader {
         return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
     }
 
-    /// Sendable-friendly decode for the foreground hot path. All foreground
-    /// decodes are serialized through `ImageDecodeQueue.shared` so holding
-    /// an arrow key doesn't pile up N concurrent RAW decodes; superseded
-    /// callers drop at the front of the queue.
+    /// Sendable-friendly decode for the foreground hot path. Serialized
+    /// through `ImageDecodeQueue` so holding arrow doesn't pile up N
+    /// concurrent RAW decodes; eager-decoded so the main thread doesn't
+    /// stall when SwiftUI renders the NSImage.
+    ///
+    /// Small previews (≤ 320 px on the long side) bypass the serial queue:
+    /// they're cheap (~5–10 ms via embedded thumbnail) and routing them
+    /// behind a slow full-res RAW decode is what made the thumbnail strip
+    /// flash gray placeholders during fast arrow navigation.
     static func loadCGImage(path: String, maxPixelSize: Int? = nil) async -> CGImage? {
-        await ImageDecodeQueue.shared.decode {
-            decodeCore(path: path, maxPixelSize: maxPixelSize, tag: "FG")
+        if let cap = maxPixelSize, cap <= 320 {
+            return await loadCGImageThumbnail(path: path, maxPixelSize: cap)
+        }
+        return await ImageDecodeQueue.shared.decode {
+            decodeCore(path: path, maxPixelSize: maxPixelSize, tag: "FG", eager: true)
         }
     }
 
-    /// Background decode for warm-up tasks (sweep, prefetch). Runs on a
-    /// utility-QoS dispatch queue without going through the foreground
-    /// `ImageDecodeQueue`, so a slow sweep RAW decode never blocks the
-    /// next keypress's foreground decode. macOS QoS demotes this work
-    /// when the foreground is busy.
-    static func loadCGImageBackground(path: String, maxPixelSize: Int? = nil, tag: String = "BG") async -> CGImage? {
+    /// Concurrent decode path for thumbnail-strip / sidebar loads. No
+    /// serial gate — multiple thumbnails can decode in parallel and none
+    /// of them ever block behind the foreground full-res decode.
+    private static func loadCGImageThumbnail(path: String, maxPixelSize: Int) async -> CGImage? {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: decodeCore(path: path, maxPixelSize: maxPixelSize, tag: "THUMB", eager: false))
+            }
+        }
+    }
+
+    /// Background decode that pre-warms the in-memory cache (prefetch).
+    /// Eager-decoded — same reason as foreground. Serialized through a
+    /// dedicated queue so 6 same-burst prefetches don't allocate 6 × 96 MB
+    /// concurrently.
+    static func loadCGImagePrefetch(path: String, maxPixelSize: Int? = nil, tag: String = "PREFETCH") async -> CGImage? {
+        await withCheckedContinuation { continuation in
+            prefetchDecodeQueue.async {
+                continuation.resume(returning: decodeCore(path: path, maxPixelSize: maxPixelSize, tag: tag, eager: true))
+            }
+        }
+    }
+
+    private static let prefetchDecodeQueue: DispatchQueue = {
+        DispatchQueue(label: "com.halfhacked.superpicky.prefetchDecode", qos: .utility)
+    }()
+
+    /// Background decode for the disk-cache sweep — discards the result
+    /// after the JPEG is written, so we deliberately skip the eager decode
+    /// (no display pending) and avoid allocating a full-resolution bitmap
+    /// per swept photo.
+    static func loadCGImageSweep(path: String, maxPixelSize: Int? = nil) async -> CGImage? {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .utility).async {
-                continuation.resume(returning: decodeCore(path: path, maxPixelSize: maxPixelSize, tag: tag))
+                continuation.resume(returning: decodeCore(path: path, maxPixelSize: maxPixelSize, tag: "SWEEP", eager: false))
             }
         }
     }
 
     /// Shared decode body. Returns the cached full-res JPEG when present,
     /// otherwise decodes from source and (for full-res, when enabled)
-    /// schedules a background JPEG write.
-    private static func decodeCore(path: String, maxPixelSize: Int?, tag: String) -> CGImage? {
+    /// enqueues a serialised JPEG write. Set `eager` only for paths that
+    /// will hand the bitmap to AppKit/SwiftUI for display — eager decoding
+    /// allocates a full-resolution backing buffer (~96 MB for ARW).
+    private static func decodeCore(path: String, maxPixelSize: Int?, tag: String, eager: Bool) -> CGImage? {
         let basename = (path as NSString).lastPathComponent
         let started = DispatchTime.now()
 
-        if maxPixelSize == nil, let cached = loadCachedFullRes(path: path) {
+        if maxPixelSize == nil, let cached = loadCachedFullRes(path: path, eager: eager) {
             let ms = elapsedMs(since: started)
             log.info("[\(tag, privacy: .public)] HIT \(basename, privacy: .public) \(ms, privacy: .public)ms")
             return cached
@@ -73,16 +109,58 @@ enum ImageLoader {
             log.info("[\(tag, privacy: .public)] PREVIEW \(maxPixelSize)px \(basename, privacy: .public) \(ms, privacy: .public)ms")
             return result
         }
-        let cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
-            kCGImageSourceCreateThumbnailWithTransform: true,
-        ] as CFDictionary)
-        let s = PreviewCache.settings
-        if let cgImage, s.generate {
-            writePreviewCacheAsync(image: cgImage, rawPath: path, capBytes: s.capBytes)
+        // ShouldCache pins the decoded bitmap inside the source. We only
+        // want that for paths that will return the bitmap to a caller —
+        // for the sweep we throw it away after the JPEG encode.
+        let createOpts: [CFString: Any] = eager
+            ? [kCGImageSourceShouldCache: true,
+               kCGImageSourceShouldCacheImmediately: true,
+               kCGImageSourceCreateThumbnailWithTransform: true]
+            : [kCGImageSourceShouldCache: false,
+               kCGImageSourceCreateThumbnailWithTransform: true]
+        let cgImage = CGImageSourceCreateImageAtIndex(source, 0, createOpts as CFDictionary)
+
+        let result: CGImage?
+        if let cgImage, eager {
+            result = forceDecode(cgImage)
+        } else {
+            result = cgImage
         }
+
+        // Encode JPEG synchronously now (while the source is in scope and
+        // the pixels are warm) and enqueue only the bytes for disk I/O.
+        // This decouples the writer queue from the source/bitmap lifetime,
+        // which is what was driving 40 GB+ working set.
+        let s = PreviewCache.settings
+        if let imageForEncode = result, s.generate, !Task.isCancelled {
+            if let data = PreviewCache.encodeJPEG(imageForEncode) {
+                schedulePreviewCacheWriteBytes(data: data, rawPath: path, capBytes: s.capBytes)
+            }
+        }
+
         let ms = elapsedMs(since: started)
-        log.info("[\(tag, privacy: .public)] MISS \(basename, privacy: .public) \(ms, privacy: .public)ms write=\(s.generate, privacy: .public)")
-        return cgImage
+        log.info("[\(tag, privacy: .public)] MISS \(basename, privacy: .public) \(ms, privacy: .public)ms eager=\(eager, privacy: .public) write=\(s.generate, privacy: .public)")
+        return result
+    }
+
+    /// Render the image into a same-sized bitmap context and return the
+    /// resulting CGImage. This forces ImageIO's lazy decode to complete on
+    /// this background thread; without it, the pixel decode is deferred
+    /// until SwiftUI draws the NSImage on the main thread, blocking the UI
+    /// for hundreds of ms per photo on RAW files.
+    private static func forceDecode(_ image: CGImage) -> CGImage {
+        let w = image.width
+        let h = image.height
+        let cs = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(
+            data: nil, width: w, height: h,
+            bitsPerComponent: 8, bytesPerRow: w * 4,
+            space: cs,
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else { return image }
+        ctx.draw(image, in: CGRect(x: 0, y: 0, width: w, height: h))
+        return ctx.makeImage() ?? image
     }
 
     private static func elapsedMs(since start: DispatchTime) -> Int {
@@ -92,26 +170,38 @@ enum ImageLoader {
 
     /// Returns a decoded CGImage from the on-disk JPEG cache when available
     /// and fresher than the source. Bumps the cached file's mtime on hit so
-    /// LRU eviction sees recent reads as recently used.
-    private static func loadCachedFullRes(path: String) -> CGImage? {
+    /// LRU eviction sees recent reads as recently used. `eager=false`
+    /// returns a lazy CGImage; the sweep uses this and immediately discards.
+    private static func loadCachedFullRes(path: String, eager: Bool) -> CGImage? {
         guard let cachedURL = PreviewCache.freshURL(for: path) else { return nil }
+        let opts: [CFString: Any] = eager
+            ? [kCGImageSourceShouldCache: true, kCGImageSourceShouldCacheImmediately: true]
+            : [:]
         guard let source = CGImageSourceCreateWithURL(cachedURL as CFURL, nil),
-              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+              let image = CGImageSourceCreateImageAtIndex(source, 0, opts as CFDictionary) else {
             return nil
         }
         PreviewCache.touch(cachedURL)
-        return image
+        return eager ? forceDecode(image) : image
     }
 
-    /// Encode + write the cache off the decode thread; LRU eviction follows.
-    /// `parent` is the caller's task; we skip the write if it was cancelled
-    /// while the decode was running, so a fast scrubber doesn't pay disk I/O
-    /// for photos it has already navigated past.
-    private static func writePreviewCacheAsync(image: CGImage, rawPath: String, capBytes: Int64) {
-        if Task.isCancelled { return }
+    /// Serial queue for JPEG cache writes. Each write decodes the source's
+    /// pixels into RAM to encode JPEG; running many writes concurrently
+    /// multiplies that working set. One at a time keeps memory bounded
+    /// while still completing in the background.
+    private static let cacheWriteQueue: DispatchQueue = {
+        let q = DispatchQueue(label: "com.halfhacked.superpicky.previewCacheWrite", qos: .background)
+        return q
+    }()
+
+    /// Enqueue a serialised disk write of pre-encoded JPEG bytes. The
+    /// writer holds only the Data buffer (~5 MB) and the path string —
+    /// it does not retain the source CGImage / CGImageSource, so a
+    /// backlog of pending writes can't pin decoded bitmaps in memory.
+    private static func schedulePreviewCacheWriteBytes(data: Data, rawPath: String, capBytes: Int64) {
         let url = PreviewCache.cachedURL(for: rawPath)
-        Task.detached(priority: .background) {
-            PreviewCache.write(image, to: url)
+        cacheWriteQueue.async {
+            PreviewCache.writeData(data, to: url)
             if capBytes > 0 { PreviewCache.evictIfOverCap(maxBytes: capBytes) }
         }
     }

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -2,12 +2,15 @@ import Foundation
 import CoreGraphics
 import ImageIO
 import AppKit
+import os
 
 /// Shared image loading utility — used by PreviewView, FullscreenViewer, and ThumbnailStripView.
 enum ImageLoader {
     /// Convenience accessor used by sweep/sweep-coordinator to short-circuit
     /// when the cache is disabled.
     static var generatePreviewCache: Bool { PreviewCache.settings.generate }
+
+    private static let log = Logger(subsystem: "com.halfhacked.superpicky", category: "ImageLoader")
 
     /// Load an image at a given max pixel size, or full resolution if nil.
     /// Uses the embedded preview when it's large enough (fast path for RAW),
@@ -30,7 +33,7 @@ enum ImageLoader {
     /// callers drop at the front of the queue.
     static func loadCGImage(path: String, maxPixelSize: Int? = nil) async -> CGImage? {
         await ImageDecodeQueue.shared.decode {
-            decodeCore(path: path, maxPixelSize: maxPixelSize)
+            decodeCore(path: path, maxPixelSize: maxPixelSize, tag: "FG")
         }
     }
 
@@ -39,10 +42,10 @@ enum ImageLoader {
     /// `ImageDecodeQueue`, so a slow sweep RAW decode never blocks the
     /// next keypress's foreground decode. macOS QoS demotes this work
     /// when the foreground is busy.
-    static func loadCGImageBackground(path: String, maxPixelSize: Int? = nil) async -> CGImage? {
+    static func loadCGImageBackground(path: String, maxPixelSize: Int? = nil, tag: String = "BG") async -> CGImage? {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .utility).async {
-                continuation.resume(returning: decodeCore(path: path, maxPixelSize: maxPixelSize))
+                continuation.resume(returning: decodeCore(path: path, maxPixelSize: maxPixelSize, tag: tag))
             }
         }
     }
@@ -50,16 +53,25 @@ enum ImageLoader {
     /// Shared decode body. Returns the cached full-res JPEG when present,
     /// otherwise decodes from source and (for full-res, when enabled)
     /// schedules a background JPEG write.
-    private static func decodeCore(path: String, maxPixelSize: Int?) -> CGImage? {
+    private static func decodeCore(path: String, maxPixelSize: Int?, tag: String) -> CGImage? {
+        let basename = (path as NSString).lastPathComponent
+        let started = DispatchTime.now()
+
         if maxPixelSize == nil, let cached = loadCachedFullRes(path: path) {
+            let ms = elapsedMs(since: started)
+            log.info("[\(tag, privacy: .public)] HIT \(basename, privacy: .public) \(ms, privacy: .public)ms")
             return cached
         }
         let url = URL(fileURLWithPath: path)
         guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            log.error("[\(tag, privacy: .public)] OPEN-FAIL \(basename, privacy: .public)")
             return nil
         }
         if let maxPixelSize {
-            return decodePreview(source: source, maxPixelSize: maxPixelSize)
+            let result = decodePreview(source: source, maxPixelSize: maxPixelSize)
+            let ms = elapsedMs(since: started)
+            log.info("[\(tag, privacy: .public)] PREVIEW \(maxPixelSize)px \(basename, privacy: .public) \(ms, privacy: .public)ms")
+            return result
         }
         let cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
             kCGImageSourceCreateThumbnailWithTransform: true,
@@ -68,7 +80,14 @@ enum ImageLoader {
         if let cgImage, s.generate {
             writePreviewCacheAsync(image: cgImage, rawPath: path, capBytes: s.capBytes)
         }
+        let ms = elapsedMs(since: started)
+        log.info("[\(tag, privacy: .public)] MISS \(basename, privacy: .public) \(ms, privacy: .public)ms write=\(s.generate, privacy: .public)")
         return cgImage
+    }
+
+    private static func elapsedMs(since start: DispatchTime) -> Int {
+        let ns = DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds
+        return Int(ns / 1_000_000)
     }
 
     /// Returns a decoded CGImage from the on-disk JPEG cache when available

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -85,7 +85,11 @@ enum ImageLoader {
     }
 
     /// Encode + write the cache off the decode thread; LRU eviction follows.
+    /// `parent` is the caller's task; we skip the write if it was cancelled
+    /// while the decode was running, so a fast scrubber doesn't pay disk I/O
+    /// for photos it has already navigated past.
     private static func writePreviewCacheAsync(image: CGImage, rawPath: String, capBytes: Int64) {
+        if Task.isCancelled { return }
         let url = PreviewCache.cachedURL(for: rawPath)
         Task.detached(priority: .background) {
             PreviewCache.write(image, to: url)

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -6,10 +6,6 @@ import os
 
 /// Shared image loading utility — used by PreviewView, FullscreenViewer, and ThumbnailStripView.
 enum ImageLoader {
-    /// Convenience accessor used by sweep/sweep-coordinator to short-circuit
-    /// when the cache is disabled.
-    static var generatePreviewCache: Bool { PreviewCache.settings.generate }
-
     private static let log = Logger(subsystem: "com.halfhacked.superpicky", category: "ImageLoader")
 
     /// Load an image at a given max pixel size, or full resolution if nil.
@@ -127,14 +123,23 @@ enum ImageLoader {
             result = cgImage
         }
 
-        // Encode JPEG synchronously now (while the source is in scope and
-        // the pixels are warm) and enqueue only the bytes for disk I/O.
-        // This decouples the writer queue from the source/bitmap lifetime,
-        // which is what was driving 40 GB+ working set.
         let s = PreviewCache.settings
         if let imageForEncode = result, s.generate, !Task.isCancelled {
-            if let data = PreviewCache.encodeJPEG(imageForEncode) {
-                schedulePreviewCacheWriteBytes(data: data, rawPath: path, capBytes: s.capBytes)
+            if eager {
+                // Eager bitmap holds its own pixels; the writer queue can
+                // encode without re-reading the source. Take the encode
+                // off the caller's await path — they get the image ~50–100
+                // ms sooner.
+                schedulePreviewCacheEncodeAndWrite(image: imageForEncode, rawPath: path, capBytes: s.capBytes)
+            } else {
+                // Sweep path: lazy CGImage references the source. Encode
+                // synchronously while pixels are still in ImageIO's read
+                // buffer; otherwise the writer queue would re-decode from
+                // disk. The caller throws away `result` immediately, so
+                // there's no perceived latency to protect.
+                if let data = PreviewCache.encodeJPEG(imageForEncode) {
+                    schedulePreviewCacheWriteBytes(data: data, rawPath: path, capBytes: s.capBytes)
+                }
             }
         }
 
@@ -201,6 +206,19 @@ enum ImageLoader {
     private static func schedulePreviewCacheWriteBytes(data: Data, rawPath: String, capBytes: Int64) {
         let url = PreviewCache.cachedURL(for: rawPath)
         cacheWriteQueue.async {
+            PreviewCache.writeData(data, to: url)
+            if capBytes > 0 { PreviewCache.evictIfOverCap(maxBytes: capBytes) }
+        }
+    }
+
+    /// Enqueue a serialised JPEG encode + disk write. Used for the eager
+    /// foreground / prefetch paths where the bitmap is held by the CGImage
+    /// itself, so the encode is just walking pixels (no source re-read)
+    /// and is safe to do asynchronously off the caller's await path.
+    private static func schedulePreviewCacheEncodeAndWrite(image: CGImage, rawPath: String, capBytes: Int64) {
+        let url = PreviewCache.cachedURL(for: rawPath)
+        cacheWriteQueue.async {
+            guard let data = PreviewCache.encodeJPEG(image) else { return }
             PreviewCache.writeData(data, to: url)
             if capBytes > 0 { PreviewCache.evictIfOverCap(maxBytes: capBytes) }
         }

--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -5,14 +5,9 @@ import AppKit
 
 /// Shared image loading utility — used by PreviewView, FullscreenViewer, and ThumbnailStripView.
 enum ImageLoader {
-    /// Disk-cache full-res decodes as JPEG sidecars under
-    /// `~/Library/Caches/com.halfhacked.superpicky/preview/`. Set to false
-    /// to read existing cache entries but skip writing new ones.
-    nonisolated(unsafe) static var generatePreviewCache: Bool = true
-
-    /// LRU cap in bytes; 0 means unlimited. Mirrored from
-    /// `CullingConfig.previewCacheSizeGB` at app boot and on changes.
-    nonisolated(unsafe) static var previewCacheCapBytes: Int64 = 20 * 1024 * 1024 * 1024
+    /// Convenience accessor used by sweep/sweep-coordinator to short-circuit
+    /// when the cache is disabled.
+    static var generatePreviewCache: Bool { PreviewCache.settings.generate }
 
     /// Load an image at a given max pixel size, or full resolution if nil.
     /// Uses the embedded preview when it's large enough (fast path for RAW),
@@ -29,34 +24,51 @@ enum ImageLoader {
         return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
     }
 
-    /// Sendable-friendly decode. Useful for `async let` / `TaskGroup`
-    /// concurrency where NSImage's non-Sendable result would error.
-    /// Call sites wrap in NSImage on their own actor.
-    ///
-    /// All decodes are serialized through `ImageDecodeQueue.shared` so that
-    /// holding an arrow key in zoom mode doesn't pile up N concurrent RAW
-    /// decodes — only one runs at a time, and cancelled callers drop their
-    /// turn at the front of the queue without doing any work.
+    /// Sendable-friendly decode for the foreground hot path. All foreground
+    /// decodes are serialized through `ImageDecodeQueue.shared` so holding
+    /// an arrow key doesn't pile up N concurrent RAW decodes; superseded
+    /// callers drop at the front of the queue.
     static func loadCGImage(path: String, maxPixelSize: Int? = nil) async -> CGImage? {
-        return await ImageDecodeQueue.shared.decode {
-            if maxPixelSize == nil, let cached = loadCachedFullRes(path: path) {
-                return cached
-            }
-            let url = URL(fileURLWithPath: path)
-            guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-                return nil
-            }
-            if let maxPixelSize {
-                return decodePreview(source: source, maxPixelSize: maxPixelSize)
-            }
-            let cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
-                kCGImageSourceCreateThumbnailWithTransform: true,
-            ] as CFDictionary)
-            if let cgImage, generatePreviewCache {
-                writePreviewCacheAsync(image: cgImage, rawPath: path)
-            }
-            return cgImage
+        await ImageDecodeQueue.shared.decode {
+            decodeCore(path: path, maxPixelSize: maxPixelSize)
         }
+    }
+
+    /// Background decode for warm-up tasks (sweep, prefetch). Runs on a
+    /// utility-QoS dispatch queue without going through the foreground
+    /// `ImageDecodeQueue`, so a slow sweep RAW decode never blocks the
+    /// next keypress's foreground decode. macOS QoS demotes this work
+    /// when the foreground is busy.
+    static func loadCGImageBackground(path: String, maxPixelSize: Int? = nil) async -> CGImage? {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: decodeCore(path: path, maxPixelSize: maxPixelSize))
+            }
+        }
+    }
+
+    /// Shared decode body. Returns the cached full-res JPEG when present,
+    /// otherwise decodes from source and (for full-res, when enabled)
+    /// schedules a background JPEG write.
+    private static func decodeCore(path: String, maxPixelSize: Int?) -> CGImage? {
+        if maxPixelSize == nil, let cached = loadCachedFullRes(path: path) {
+            return cached
+        }
+        let url = URL(fileURLWithPath: path)
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            return nil
+        }
+        if let maxPixelSize {
+            return decodePreview(source: source, maxPixelSize: maxPixelSize)
+        }
+        let cgImage = CGImageSourceCreateImageAtIndex(source, 0, [
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ] as CFDictionary)
+        let s = PreviewCache.settings
+        if let cgImage, s.generate {
+            writePreviewCacheAsync(image: cgImage, rawPath: path, capBytes: s.capBytes)
+        }
+        return cgImage
     }
 
     /// Returns a decoded CGImage from the on-disk JPEG cache when available
@@ -73,12 +85,11 @@ enum ImageLoader {
     }
 
     /// Encode + write the cache off the decode thread; LRU eviction follows.
-    private static func writePreviewCacheAsync(image: CGImage, rawPath: String) {
+    private static func writePreviewCacheAsync(image: CGImage, rawPath: String, capBytes: Int64) {
         let url = PreviewCache.cachedURL(for: rawPath)
-        let cap = previewCacheCapBytes
         Task.detached(priority: .background) {
             PreviewCache.write(image, to: url)
-            if cap > 0 { PreviewCache.evictIfOverCap(maxBytes: cap) }
+            if capBytes > 0 { PreviewCache.evictIfOverCap(maxBytes: capBytes) }
         }
     }
 

--- a/apps/mac-client/SuperPickyApp/KeyboardMonitor.swift
+++ b/apps/mac-client/SuperPickyApp/KeyboardMonitor.swift
@@ -53,6 +53,9 @@ class KeyboardMonitorView: NSView {
                     isRightArrow: event.keyCode == 124
                 )
 
+                MainActor.assumeIsolated {
+                    PreviewSweepCoordinator.shared.noteInteraction()
+                }
                 let handled = onKey(keyEvent)
                 return handled ? nil : event
             }

--- a/apps/mac-client/SuperPickyApp/KeyboardMonitor.swift
+++ b/apps/mac-client/SuperPickyApp/KeyboardMonitor.swift
@@ -53,7 +53,7 @@ class KeyboardMonitorView: NSView {
                     isRightArrow: event.keyCode == 124
                 )
 
-                MainActor.assumeIsolated {
+                Task { @MainActor in
                     PreviewSweepCoordinator.shared.noteInteraction()
                 }
                 let handled = onKey(keyEvent)

--- a/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
@@ -105,7 +105,7 @@ final class PrefetchCoordinator {
 
     private func scheduleWarm(path: String) {
         let task = Task.detached(priority: .utility) {
-            guard let cgImage = await ImageLoader.loadCGImageBackground(path: path, tag: "PREFETCH") else { return }
+            guard let cgImage = await ImageLoader.loadCGImagePrefetch(path: path) else { return }
             await MainActor.run {
                 let image = NSImage(cgImage: cgImage,
                                     size: NSSize(width: cgImage.width, height: cgImage.height))

--- a/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
@@ -2,19 +2,28 @@ import Foundation
 import AppKit
 import os
 
-/// Pre-warms `ImageCache.fullRes` for the next photos in the user's nav
-/// direction so holding arrow stays smooth in zoom mode.
+/// Pre-warms `ImageCache.fullRes` for the photos the user is most likely
+/// to view next in zoom mode.
 ///
-/// Direction is inferred from the previous-vs-current index. Forward nav
-/// prefetches `i+1, i+2`; backward nav prefetches `i-1, i-2`. Each call
-/// cancels the prior prefetch tasks before scheduling new ones, so a fast
-/// scrubber never piles up work.
+/// Priority order (matches the user's typical zoom-mode workflow of
+/// comparing similar shots within a burst, then moving to the next):
+///   1. Same-burst photos (excluding the current photo) — chronological.
+///   2. The next-or-previous burst in display order, taking nav direction
+///      from the prior-vs-current index.
+///
+/// Each call cancels the prior prefetch tasks before scheduling new ones.
 @MainActor
 final class PrefetchCoordinator {
     static let shared = PrefetchCoordinator()
-    private static let log = Logger(subsystem: "com.halfhacked.superpicky", category: "Prefetch")
+    fileprivate static let log = Logger(subsystem: "com.halfhacked.superpicky", category: "Prefetch")
 
-    private static let radius = 2
+    /// Cap how many prefetches we schedule per update so we don't blow past
+    /// `ImageCache.fullRes` (countLimit=8) and evict the freshly-warmed entries.
+    private static let budget = 6
+
+    /// How many photos from the next burst to prefetch. Same-burst photos
+    /// already get unlimited prefetch — the next burst is a smaller bet.
+    private static let nextBurstDepth = 3
 
     private var lastIndex: Int?
     private var inflight: [Task<Void, Never>] = []
@@ -28,18 +37,36 @@ final class PrefetchCoordinator {
         defer { lastIndex = currentIndex }
 
         guard zoomActive, photos.indices.contains(currentIndex) else { return }
-        guard let prior = lastIndex else { return }
+        let current = photos[currentIndex]
 
-        let direction = currentIndex - prior
-        guard direction != 0 else { return }
-        let step = direction > 0 ? 1 : -1
+        // Direction defaults to forward when we have no prior selection
+        // (the user just zoomed in cold).
+        let step: Int
+        if let prior = lastIndex, prior != currentIndex {
+            step = currentIndex > prior ? 1 : -1
+        } else {
+            step = 1
+        }
 
-        for i in 1...Self.radius {
-            let target = currentIndex + step * i
-            guard photos.indices.contains(target) else { break }
-            let path = photos[target].filePath
-            if ImageCache.fullRes.get(path) != nil { continue }
-            scheduleWarm(path: path)
+        var targets: [Photo] = []
+
+        if let bid = current.burstGroupID {
+            let same = photos.filter { $0.burstGroupID == bid && $0.id != current.id }
+                .sorted { $0.dateCreated < $1.dateCreated }
+            targets.append(contentsOf: same)
+        }
+
+        let nextBurst = adjacentBurstPhotos(from: currentIndex, in: photos, step: step)
+        targets.append(contentsOf: nextBurst.prefix(Self.nextBurstDepth))
+
+        let scheduled = targets.prefix(Self.budget)
+        Self.log.info(
+            "update idx=\(currentIndex) step=\(step) burst=\(current.burstGroupID?.uuidString.prefix(4) ?? "—", privacy: .public) targets=\(scheduled.map { ($0.filePath as NSString).lastPathComponent }.joined(separator: ","), privacy: .public)"
+        )
+
+        for photo in scheduled {
+            if ImageCache.fullRes.get(photo.filePath) != nil { continue }
+            scheduleWarm(path: photo.filePath)
         }
     }
 
@@ -49,13 +76,41 @@ final class PrefetchCoordinator {
         lastIndex = nil
     }
 
+    /// Walk along `photos` from `index` in `step` direction until the
+    /// burstGroupID changes, then collect that next burst's contiguous
+    /// members. Singletons (nil burst) count as a burst of size 1.
+    /// Returned photos are in display order along `step` (so the
+    /// chronologically-nearest one is first).
+    private func adjacentBurstPhotos(from index: Int, in photos: [Photo], step: Int) -> [Photo] {
+        let currentBurst = photos[index].burstGroupID
+        var i = index + step
+        while photos.indices.contains(i) {
+            if photos[i].burstGroupID == currentBurst, currentBurst != nil {
+                i += step
+                continue
+            }
+            let nbid = photos[i].burstGroupID
+            var collected: [Photo] = [photos[i]]
+            if nbid == nil { return collected }
+            var j = i + step
+            while photos.indices.contains(j) {
+                guard photos[j].burstGroupID == nbid else { break }
+                collected.append(photos[j])
+                j += step
+            }
+            return collected
+        }
+        return []
+    }
+
     private func scheduleWarm(path: String) {
         let task = Task.detached(priority: .utility) {
-            guard let cgImage = await ImageLoader.loadCGImageBackground(path: path) else { return }
+            guard let cgImage = await ImageLoader.loadCGImageBackground(path: path, tag: "PREFETCH") else { return }
             await MainActor.run {
                 let image = NSImage(cgImage: cgImage,
                                     size: NSSize(width: cgImage.width, height: cgImage.height))
                 ImageCache.fullRes.set(path, image: image)
+                Self.log.info("warmed RAM \((path as NSString).lastPathComponent, privacy: .public)")
             }
         }
         inflight.append(task)

--- a/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
@@ -1,0 +1,66 @@
+import Foundation
+import AppKit
+import os
+
+/// Pre-warms `ImageCache.fullRes` for the next photos in the user's nav
+/// direction so holding arrow stays smooth in zoom mode.
+///
+/// Direction is inferred from the previous-vs-current index. Forward nav
+/// prefetches `i+1, i+2`; backward nav prefetches `i-1, i-2`. Each call
+/// cancels the prior prefetch tasks before scheduling new ones, so a fast
+/// scrubber never piles up work.
+@MainActor
+final class PrefetchCoordinator {
+    static let shared = PrefetchCoordinator()
+    private static let log = Logger(subsystem: "com.halfhacked.superpicky", category: "Prefetch")
+
+    private static let radius = 2
+
+    private var lastIndex: Int?
+    private var inflight: [Task<Void, Never>] = []
+
+    /// Call from the view that owns the selection, on selection change.
+    /// `zoomActive` should be `true` only when the view is currently
+    /// rendering at scale > 1.0 — at fit scale, the working set is the
+    /// 2000-px preview cache, which is much cheaper.
+    func update(currentIndex: Int, photos: [Photo], zoomActive: Bool) {
+        cancelAll()
+        defer { lastIndex = currentIndex }
+
+        guard zoomActive, photos.indices.contains(currentIndex) else { return }
+        guard let prior = lastIndex else { return }
+
+        let direction = currentIndex - prior
+        guard direction != 0 else { return }
+        let step = direction > 0 ? 1 : -1
+
+        for i in 1...Self.radius {
+            let target = currentIndex + step * i
+            guard photos.indices.contains(target) else { break }
+            let path = photos[target].filePath
+            if ImageCache.fullRes.get(path) != nil { continue }
+            scheduleWarm(path: path)
+        }
+    }
+
+    /// Stop all in-flight prefetch tasks (folder change, app quit).
+    func reset() {
+        cancelAll()
+        lastIndex = nil
+    }
+
+    private func scheduleWarm(path: String) {
+        let task = Task.detached(priority: .utility) {
+            guard let image = await ImageLoader.load(path: path) else { return }
+            await MainActor.run {
+                ImageCache.fullRes.set(path, image: image)
+            }
+        }
+        inflight.append(task)
+    }
+
+    private func cancelAll() {
+        for t in inflight { t.cancel() }
+        inflight.removeAll()
+    }
+}

--- a/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
@@ -2,122 +2,192 @@ import Foundation
 import AppKit
 import os
 
-/// Pre-warms `ImageCache.fullRes` for the photos the user is most likely
-/// to view next in zoom mode.
+/// Maintains a working set of full-resolution decodes in `ImageCache.fullRes`
+/// optimised for culling: the user's current burst stays warm, plus a few of
+/// the next bursts in their navigation direction. Direction is detected from
+/// a "streak" of consecutive same-direction moves; longer streaks reach
+/// further ahead.
 ///
-/// Priority order (matches the user's typical zoom-mode workflow of
-/// comparing similar shots within a burst, then moving to the next):
-///   1. Same-burst photos (excluding the current photo) — chronological.
-///   2. The next-or-previous burst in display order, taking nav direction
-///      from the prior-vs-current index.
-///
-/// Each call cancels the prior prefetch tasks before scheduling new ones.
+/// Anti-thrash discipline: every update diffs the desired target set against
+/// in-flight tasks. Already-cached or already-in-flight paths are not
+/// re-scheduled, and only tasks whose paths fell out of the new target set
+/// get cancelled. Walking from photo N to N+1 in a 10-photo burst keeps the
+/// other 9 prefetches running unchanged.
 @MainActor
 final class PrefetchCoordinator {
     static let shared = PrefetchCoordinator()
     fileprivate static let log = Logger(subsystem: "com.halfhacked.superpicky", category: "Prefetch")
 
-    /// Cap how many prefetches we schedule per update so we don't blow past
-    /// `ImageCache.fullRes` (countLimit=8) and evict the freshly-warmed entries.
-    private static let budget = 6
+    /// Baseline number of photos to prefetch from bursts beyond the current
+    /// one. Grows with the user's direction streak.
+    private static let baseNextBurstDepth = 6
+    /// Hard ceiling so a long streak doesn't blow past the in-RAM cache.
+    private static let maxNextBurstDepth = 30
 
-    /// How many photos from the next burst to prefetch. Same-burst photos
-    /// already get unlimited prefetch — the next burst is a smaller bet.
-    private static let nextBurstDepth = 3
-
+    /// Streak counter: positive = consecutive forward moves, negative =
+    /// backward. Magnitude reaches further into next bursts in that
+    /// direction; reversal resets to ±1.
+    private var streak: Int = 0
     private var lastIndex: Int?
-    private var inflight: [Task<Void, Never>] = []
 
-    /// Call from the view that owns the selection, on selection change.
-    /// `zoomActive` should be `true` only when the view is currently
-    /// rendering at scale > 1.0 — at fit scale, the working set is the
-    /// 2000-px preview cache, which is much cheaper.
-    func update(currentIndex: Int, photos: [Photo], zoomActive: Bool) {
-        cancelAll()
-        defer { lastIndex = currentIndex }
+    /// In-flight prefetch tasks keyed by file path. Diffed against the
+    /// newest target set on each update so we don't churn through cancel /
+    /// reschedule cycles for paths that are still wanted.
+    private var inflight: [String: Task<Void, Never>] = [:]
 
-        guard zoomActive, photos.indices.contains(currentIndex) else { return }
+    /// Kick off the initial RAM-cache fill right after a folder loads,
+    /// before the user has navigated. Treats the auto-selected photo as
+    /// the centre with no streak.
+    func prefill(photos: [Photo], around index: Int) {
+        guard photos.indices.contains(index) else { return }
+        streak = 0
+        lastIndex = nil
+        update(currentIndex: index, photos: photos)
+    }
+
+    /// Recentre the working set on a new selection. Always runs (no longer
+    /// gated on zoom mode), since culling at fit scale is also faster when
+    /// the next zoomed photo is already decoded in RAM.
+    func update(currentIndex: Int, photos: [Photo]) {
+        guard photos.indices.contains(currentIndex) else { return }
+
+        let step = updateStreak(currentIndex: currentIndex)
+        lastIndex = currentIndex
         let current = photos[currentIndex]
 
-        // Direction defaults to forward when we have no prior selection
-        // (the user just zoomed in cold).
-        let step: Int
-        if let prior = lastIndex, prior != currentIndex {
-            step = currentIndex > prior ? 1 : -1
-        } else {
-            step = 1
+        var targets: [String] = []
+
+        if current.burstGroupID != nil {
+            let same = sameBurstSortedByNavDistance(in: photos, currentIndex: currentIndex, step: step)
+            targets.append(contentsOf: same.map(\.filePath))
         }
 
-        var targets: [Photo] = []
+        // Streak boost: each consecutive same-direction move adds two
+        // photos of next-burst depth, capped at maxNextBurstDepth.
+        let streakMagnitude = abs(streak)
+        let depthBoost = max(0, streakMagnitude - 1) * 2
+        let nextDepth = min(Self.maxNextBurstDepth, Self.baseNextBurstDepth + depthBoost)
+        let nextBurstPhotos = nextBurstsPhotos(from: currentIndex, in: photos, step: step, depth: nextDepth)
+        targets.append(contentsOf: nextBurstPhotos.map(\.filePath))
 
-        if let bid = current.burstGroupID {
-            let same = photos.filter { $0.burstGroupID == bid && $0.id != current.id }
-                .sorted { $0.dateCreated < $1.dateCreated }
-            targets.append(contentsOf: same)
+        let capped = Array(targets.prefix(Self.maxTargets))
+        let desired = Set(capped)
+
+        // Cancel in-flight tasks whose paths are no longer wanted.
+        var cancelled = 0
+        for (path, task) in inflight where !desired.contains(path) {
+            task.cancel()
+            inflight.removeValue(forKey: path)
+            cancelled += 1
         }
 
-        let nextBurst = adjacentBurstPhotos(from: currentIndex, in: photos, step: step)
-        targets.append(contentsOf: nextBurst.prefix(Self.nextBurstDepth))
+        // Schedule new targets we don't already have or aren't already
+        // fetching.
+        var scheduled = 0
+        for path in capped {
+            if inflight[path] != nil { continue }
+            if ImageCache.fullRes.get(path) != nil { continue }
+            scheduleWarm(path: path)
+            scheduled += 1
+        }
 
-        let scheduled = targets.prefix(Self.budget)
         Self.log.info(
-            "update idx=\(currentIndex) step=\(step) burst=\(current.burstGroupID?.uuidString.prefix(4) ?? "—", privacy: .public) targets=\(scheduled.map { ($0.filePath as NSString).lastPathComponent }.joined(separator: ","), privacy: .public)"
+            "update idx=\(currentIndex) step=\(step) streak=\(self.streak) burst=\(current.burstGroupID?.uuidString.prefix(4) ?? "—", privacy: .public) targets=\(capped.count) cancelled=\(cancelled) scheduled=\(scheduled) inflight=\(self.inflight.count)"
         )
-
-        for photo in scheduled {
-            if ImageCache.fullRes.get(photo.filePath) != nil { continue }
-            scheduleWarm(path: photo.filePath)
-        }
     }
 
-    /// Stop all in-flight prefetch tasks (folder change, app quit).
+    /// Stop everything and reset the streak. Folder change, app quit.
     func reset() {
-        cancelAll()
+        for (_, task) in inflight { task.cancel() }
+        inflight.removeAll()
         lastIndex = nil
+        streak = 0
     }
 
-    /// Walk along `photos` from `index` in `step` direction until the
-    /// burstGroupID changes, then collect that next burst's contiguous
-    /// members. Singletons (nil burst) count as a burst of size 1.
-    /// Returned photos are in display order along `step` (so the
-    /// chronologically-nearest one is first).
-    private func adjacentBurstPhotos(from index: Int, in photos: [Photo], step: Int) -> [Photo] {
+    // MARK: - Internals
+
+    /// Updates `streak` based on the move from `lastIndex` to
+    /// `currentIndex` and returns the step direction (+1 / -1) to use for
+    /// target ordering.
+    private func updateStreak(currentIndex: Int) -> Int {
+        guard let prior = lastIndex else {
+            // First call after prefill — no history, default forward.
+            return 1
+        }
+        let delta = currentIndex - prior
+        if delta == 0 {
+            // Same selection (filter change, refresh) — keep prior direction.
+            return streak >= 0 ? 1 : -1
+        }
+        let dir = delta > 0 ? 1 : -1
+        if (streak >= 0) == (dir > 0) {
+            // Continuing in same direction — extend streak.
+            streak += dir
+        } else {
+            // Reversal — restart streak in new direction.
+            streak = dir
+        }
+        return dir
+    }
+
+    /// Cap how many photos we ever queue at once. Above this, churning
+    /// through prefetches costs more than the cache hits save.
+    private static let maxTargets = 40
+
+    /// Photos that share the current burst, ordered by display distance in
+    /// nav direction (ahead first, closer wins; behind as fallback).
+    private func sameBurstSortedByNavDistance(in photos: [Photo], currentIndex: Int, step: Int) -> [Photo] {
+        let bid = photos[currentIndex].burstGroupID
+        let candidates = photos.enumerated()
+            .filter { $0.offset != currentIndex && $0.element.burstGroupID == bid }
+        return candidates.sorted { a, b in
+            let signedA = (a.offset - currentIndex) * step
+            let signedB = (b.offset - currentIndex) * step
+            if (signedA > 0) != (signedB > 0) { return signedA > 0 }
+            return abs(a.offset - currentIndex) < abs(b.offset - currentIndex)
+        }.map(\.element)
+    }
+
+    /// Collect up to `depth` photos from the bursts immediately following
+    /// (or preceding) the current one, in `step` direction. Skips past the
+    /// current burst's tail; gathers contiguous members of each subsequent
+    /// burst until `depth` is filled.
+    private func nextBurstsPhotos(from index: Int, in photos: [Photo], step: Int, depth: Int) -> [Photo] {
         let currentBurst = photos[index].burstGroupID
+        var collected: [Photo] = []
         var i = index + step
-        while photos.indices.contains(i) {
-            if photos[i].burstGroupID == currentBurst, currentBurst != nil {
+        var skippingCurrent = currentBurst != nil
+
+        while photos.indices.contains(i), collected.count < depth {
+            let pBurst = photos[i].burstGroupID
+            if skippingCurrent, pBurst == currentBurst {
                 i += step
                 continue
             }
-            let nbid = photos[i].burstGroupID
-            var collected: [Photo] = [photos[i]]
-            if nbid == nil { return collected }
-            var j = i + step
-            while photos.indices.contains(j) {
-                guard photos[j].burstGroupID == nbid else { break }
-                collected.append(photos[j])
-                j += step
-            }
-            return collected
+            skippingCurrent = false
+            collected.append(photos[i])
+            i += step
         }
-        return []
+        return collected
     }
 
     private func scheduleWarm(path: String) {
         let task = Task.detached(priority: .utility) {
-            guard let cgImage = await ImageLoader.loadCGImagePrefetch(path: path) else { return }
+            let cgImage = await ImageLoader.loadCGImagePrefetch(path: path)
             await MainActor.run {
-                let image = NSImage(cgImage: cgImage,
-                                    size: NSSize(width: cgImage.width, height: cgImage.height))
-                ImageCache.fullRes.set(path, image: image)
-                Self.log.info("warmed RAM \((path as NSString).lastPathComponent, privacy: .public)")
+                if let cgImage {
+                    let image = NSImage(cgImage: cgImage,
+                                        size: NSSize(width: cgImage.width, height: cgImage.height))
+                    ImageCache.fullRes.set(path, image: image)
+                    Self.log.debug("warmed RAM \((path as NSString).lastPathComponent, privacy: .public)")
+                }
+                PrefetchCoordinator.shared.inflightDidComplete(path: path)
             }
         }
-        inflight.append(task)
+        inflight[path] = task
     }
 
-    private func cancelAll() {
-        for t in inflight { t.cancel() }
-        inflight.removeAll()
+    fileprivate func inflightDidComplete(path: String) {
+        inflight.removeValue(forKey: path)
     }
 }

--- a/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PrefetchCoordinator.swift
@@ -51,8 +51,10 @@ final class PrefetchCoordinator {
 
     private func scheduleWarm(path: String) {
         let task = Task.detached(priority: .utility) {
-            guard let image = await ImageLoader.load(path: path) else { return }
+            guard let cgImage = await ImageLoader.loadCGImageBackground(path: path) else { return }
             await MainActor.run {
+                let image = NSImage(cgImage: cgImage,
+                                    size: NSSize(width: cgImage.width, height: cgImage.height))
                 ImageCache.fullRes.set(path, image: image)
             }
         }

--- a/apps/mac-client/SuperPickyApp/PreviewCache.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewCache.swift
@@ -46,6 +46,12 @@ enum PreviewCache {
 
     /// Maps a RAW path to its cache file URL. Same-folder photos share a
     /// hash dir so eviction and FS lookups stay localized.
+    ///
+    /// Cache key is folder-path + basename, validated by mtime in
+    /// `freshURL`. A rename-then-reuse-same-name within the same mtime
+    /// granularity could in theory return the prior photo's cache, but the
+    /// mtime check covers anything that touches the source file. Folder
+    /// moves orphan the old cache (acceptable — it's just disk waste).
     static func cachedURL(for rawPath: String) -> URL {
         let folder = (rawPath as NSString).deletingLastPathComponent
         let basename = ((rawPath as NSString).lastPathComponent as NSString).deletingPathExtension

--- a/apps/mac-client/SuperPickyApp/PreviewCache.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewCache.swift
@@ -34,6 +34,10 @@ enum PreviewCache {
     struct Settings: Sendable {
         var generate: Bool = true
         var capBytes: Int64 = 20 * 1024 * 1024 * 1024
+        /// When true, ImageCache.fullRes uses 50 % of physical RAM instead
+        /// of the default 25 %. Only meaningful when the user is willing
+        /// to dedicate the machine to SuperPicky.
+        var aggressiveCache: Bool = false
     }
 
     private static let settingsLock = OSAllocatedUnfairLock<Settings>(initialState: Settings())

--- a/apps/mac-client/SuperPickyApp/PreviewCache.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewCache.swift
@@ -1,0 +1,193 @@
+import Foundation
+import ImageIO
+import CoreGraphics
+import CryptoKit
+import os
+
+/// On-disk JPEG cache of full-resolution decodes, keyed by a hash of the
+/// photo's containing folder + the photo's basename. The whole point is to
+/// turn a ~250 ms RAW decode into a ~30 ms JPEG decode on the second visit
+/// to a photo, including across app launches.
+///
+/// Layout: `~/Library/Caches/com.halfhacked.superpicky/preview/<folder-hash>/<basename>.jpg`
+enum PreviewCache {
+    private static let log = Logger(subsystem: "com.halfhacked.superpicky", category: "PreviewCache")
+
+    static let rootURL: URL = {
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return caches.appendingPathComponent("com.halfhacked.superpicky/preview", isDirectory: true)
+    }()
+
+    /// Maps a RAW path to its cache file URL. Same-folder photos share a
+    /// hash dir so eviction and FS lookups stay localized.
+    static func cachedURL(for rawPath: String) -> URL {
+        let folder = (rawPath as NSString).deletingLastPathComponent
+        let basename = ((rawPath as NSString).lastPathComponent as NSString).deletingPathExtension
+        let hash = folderHash(folder)
+        return rootURL.appendingPathComponent(hash, isDirectory: true)
+                      .appendingPathComponent("\(basename).jpg")
+    }
+
+    /// Returns the cached URL only if it's fresh (mtime ≥ raw mtime).
+    /// Returns nil for missing files, stale files, or unreadable mtimes.
+    static func freshURL(for rawPath: String) -> URL? {
+        let url = cachedURL(for: rawPath)
+        guard let cachedM = mtime(url.path),
+              let rawM = mtime(rawPath),
+              cachedM >= rawM else {
+            return nil
+        }
+        return url
+    }
+
+    /// Bump the cached file's mtime so LRU eviction sees it as recently used.
+    /// Cheap (single utimensat); safe to call on every cache hit.
+    static func touch(_ url: URL) {
+        let now = Date()
+        try? FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: url.path)
+    }
+
+    /// Encode and atomically write a JPEG. Caller is responsible for
+    /// dispatching off the main/decode actor; this method does I/O.
+    @discardableResult
+    static func write(_ image: CGImage, to url: URL, quality: Double = 0.85) -> Bool {
+        do {
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+        } catch {
+            log.error("createDirectory failed at \(url.deletingLastPathComponent().path): \(error.localizedDescription)")
+            return false
+        }
+        let tmp = url.appendingPathExtension("tmp")
+        guard let dest = CGImageDestinationCreateWithURL(tmp as CFURL, "public.jpeg" as CFString, 1, nil) else {
+            log.error("CGImageDestinationCreateWithURL failed for \(tmp.path)")
+            return false
+        }
+        let opts: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: quality]
+        CGImageDestinationAddImage(dest, image, opts as CFDictionary)
+        guard CGImageDestinationFinalize(dest) else {
+            log.error("CGImageDestinationFinalize failed for \(tmp.path)")
+            try? FileManager.default.removeItem(at: tmp)
+            return false
+        }
+        do {
+            if FileManager.default.fileExists(atPath: url.path) {
+                _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
+            } else {
+                try FileManager.default.moveItem(at: tmp, to: url)
+            }
+            return true
+        } catch {
+            log.error("rename failed \(tmp.path) -> \(url.path): \(error.localizedDescription)")
+            try? FileManager.default.removeItem(at: tmp)
+            return false
+        }
+    }
+
+    /// Total bytes used by the on-disk cache. Walks the directory; do not
+    /// call from the main thread on large caches.
+    static func currentSizeBytes() -> Int64 {
+        var total: Int64 = 0
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(at: rootURL,
+                                             includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
+                                             options: [.skipsHiddenFiles]) else {
+            return 0
+        }
+        for case let url as URL in enumerator {
+            let v = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            if v?.isRegularFile == true, let size = v?.fileSize {
+                total += Int64(size)
+            }
+        }
+        return total
+    }
+
+    /// Delete the entire cache. Returns true if the root either didn't exist
+    /// or was successfully removed.
+    @discardableResult
+    static func clearAll() -> Bool {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: rootURL.path) { return true }
+        do {
+            try fm.removeItem(at: rootURL)
+            return true
+        } catch {
+            log.error("clearAll failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// LRU eviction. Walks the cache once, sums sizes, and if over `maxBytes`,
+    /// deletes oldest-mtime files until total ≤ maxBytes × 0.9. Empty hash
+    /// directories are pruned.
+    static func evictIfOverCap(maxBytes: Int64) {
+        guard maxBytes > 0 else { return }
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(at: rootURL,
+                                             includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey, .contentModificationDateKey],
+                                             options: [.skipsHiddenFiles]) else {
+            return
+        }
+        struct Entry { let url: URL; let size: Int64; let mtime: Date }
+        var entries: [Entry] = []
+        var total: Int64 = 0
+        for case let url as URL in enumerator {
+            let v = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey, .contentModificationDateKey])
+            guard v?.isRegularFile == true, let size = v?.fileSize, let m = v?.contentModificationDate else {
+                continue
+            }
+            entries.append(Entry(url: url, size: Int64(size), mtime: m))
+            total += Int64(size)
+        }
+        guard total > maxBytes else { return }
+
+        let target = Int64(Double(maxBytes) * 0.9)
+        let oldestFirst = entries.sorted { $0.mtime < $1.mtime }
+        var freed: Int64 = 0
+        let need = total - target
+        var evicted = 0
+        for e in oldestFirst {
+            if freed >= need { break }
+            do {
+                try fm.removeItem(at: e.url)
+                freed += e.size
+                evicted += 1
+            } catch {
+                log.error("evict failed for \(e.url.path): \(error.localizedDescription)")
+            }
+        }
+        pruneEmptyHashDirs()
+        log.info("evicted \(evicted) files, freed \(freed) bytes (\(total) -> \(total - freed))")
+    }
+
+    // MARK: - Internal helpers
+
+    private static func pruneEmptyHashDirs() {
+        let fm = FileManager.default
+        guard let kids = try? fm.contentsOfDirectory(at: rootURL,
+                                                     includingPropertiesForKeys: [.isDirectoryKey],
+                                                     options: [.skipsHiddenFiles]) else {
+            return
+        }
+        for dir in kids where (try? dir.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+            if let inside = try? fm.contentsOfDirectory(atPath: dir.path), inside.isEmpty {
+                try? fm.removeItem(at: dir)
+            }
+        }
+    }
+
+    private static func mtime(_ path: String) -> Date? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path) else { return nil }
+        return attrs[.modificationDate] as? Date
+    }
+
+    /// SHA-256 of the absolute folder path, truncated to 16 hex chars.
+    /// 64 bits of namespace is plenty to avoid collisions across folders.
+    private static func folderHash(_ folderPath: String) -> String {
+        let data = Data(folderPath.utf8)
+        let digest = SHA256.hash(data: data)
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return String(hex.prefix(16))
+    }
+}

--- a/apps/mac-client/SuperPickyApp/PreviewCache.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewCache.swift
@@ -13,10 +13,36 @@ import os
 enum PreviewCache {
     private static let log = Logger(subsystem: "com.halfhacked.superpicky", category: "PreviewCache")
 
-    static let rootURL: URL = {
+    /// Default cache root under `~/Library/Caches/`. Tests override
+    /// `rootURLOverride` to redirect to a temp directory so they don't
+    /// touch the developer's real cache.
+    static var rootURL: URL { rootURLOverride ?? defaultRootURL }
+
+    private static let defaultRootURL: URL = {
         let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         return caches.appendingPathComponent("com.halfhacked.superpicky/preview", isDirectory: true)
     }()
+
+    /// Test-only redirect. Set in test setup, restore in teardown. Never
+    /// set this from production code.
+    nonisolated(unsafe) static var rootURLOverride: URL?
+
+    /// Thread-safe runtime settings shared between the MainActor writer
+    /// (`CullingConfig`) and the decode-queue reader (`ImageLoader`). Wrapping
+    /// in OSAllocatedUnfairLock removes the data race that two raw
+    /// `nonisolated(unsafe)` statics would have under strict concurrency.
+    struct Settings: Sendable {
+        var generate: Bool = true
+        var capBytes: Int64 = 20 * 1024 * 1024 * 1024
+    }
+
+    private static let settingsLock = OSAllocatedUnfairLock<Settings>(initialState: Settings())
+
+    static var settings: Settings { settingsLock.withLock { $0 } }
+
+    static func updateSettings(_ mutate: (inout Settings) -> Void) {
+        settingsLock.withLock { mutate(&$0) }
+    }
 
     /// Maps a RAW path to its cache file URL. Same-folder photos share a
     /// hash dir so eviction and FS lookups stay localized.

--- a/apps/mac-client/SuperPickyApp/PreviewCache.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewCache.swift
@@ -79,6 +79,36 @@ enum PreviewCache {
         try? FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: url.path)
     }
 
+    /// Encode a CGImage to JPEG bytes. Used by `ImageLoader` to convert the
+    /// in-memory decoded bitmap to a serialisable Data buffer before
+    /// dispatching the disk write — that way the writer queue carries
+    /// ~5 MB of bytes instead of pinning a ~96 MB decoded source.
+    static func encodeJPEG(_ image: CGImage, quality: Double = 0.85) -> Data? {
+        let data = NSMutableData()
+        guard let dest = CGImageDestinationCreateWithData(data, "public.jpeg" as CFString, 1, nil) else {
+            return nil
+        }
+        let opts: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: quality]
+        CGImageDestinationAddImage(dest, image, opts as CFDictionary)
+        guard CGImageDestinationFinalize(dest) else { return nil }
+        return data as Data
+    }
+
+    /// Atomically write a JPEG `Data` buffer to disk. Cheap relative to the
+    /// encode step.
+    @discardableResult
+    static func writeData(_ data: Data, to url: URL) -> Bool {
+        do {
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try data.write(to: url, options: .atomic)
+            return true
+        } catch {
+            log.error("write failed at \(url.path): \(error.localizedDescription)")
+            return false
+        }
+    }
+
     /// Encode and atomically write a JPEG. Caller is responsible for
     /// dispatching off the main/decode actor; this method does I/O.
     @discardableResult

--- a/apps/mac-client/SuperPickyApp/PreviewSweepCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewSweepCoordinator.swift
@@ -62,7 +62,7 @@ final class PreviewSweepCoordinator {
             if PreviewCache.freshURL(for: path) != nil { skipped += 1; continue }
 
             processing.insert(path)
-            _ = await ImageLoader.loadCGImageBackground(path: path, maxPixelSize: nil)
+            _ = await ImageLoader.loadCGImageSweep(path: path, maxPixelSize: nil)
             processing.remove(path)
             written += 1
 

--- a/apps/mac-client/SuperPickyApp/PreviewSweepCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewSweepCoordinator.swift
@@ -49,7 +49,7 @@ final class PreviewSweepCoordinator {
         let started = Date()
         var written = 0
         var skipped = 0
-        let cap = ImageLoader.previewCacheCapBytes
+        let cap = PreviewCache.settings.capBytes
         for path in paths {
             if Task.isCancelled { break }
 
@@ -62,7 +62,7 @@ final class PreviewSweepCoordinator {
             if PreviewCache.freshURL(for: path) != nil { skipped += 1; continue }
 
             processing.insert(path)
-            _ = await ImageLoader.loadCGImage(path: path, maxPixelSize: nil)
+            _ = await ImageLoader.loadCGImageBackground(path: path, maxPixelSize: nil)
             processing.remove(path)
             written += 1
 

--- a/apps/mac-client/SuperPickyApp/PreviewSweepCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewSweepCoordinator.swift
@@ -22,7 +22,7 @@ final class PreviewSweepCoordinator {
     /// nearby photos are warmed first.
     func start(folder: URL, paths: [String]) {
         stop()
-        guard ImageLoader.generatePreviewCache, !paths.isEmpty else { return }
+        guard PreviewCache.settings.generate, !paths.isEmpty else { return }
         task = Task { [weak self] in
             await self?.run(folder: folder, paths: paths)
         }
@@ -49,7 +49,6 @@ final class PreviewSweepCoordinator {
         let started = Date()
         var written = 0
         var skipped = 0
-        let cap = PreviewCache.settings.capBytes
         for path in paths {
             if Task.isCancelled { break }
 
@@ -65,10 +64,6 @@ final class PreviewSweepCoordinator {
             _ = await ImageLoader.loadCGImageSweep(path: path, maxPixelSize: nil)
             processing.remove(path)
             written += 1
-
-            if cap > 0, written.isMultiple(of: 20) {
-                PreviewCache.evictIfOverCap(maxBytes: cap)
-            }
 
             await Task.yield()
         }

--- a/apps/mac-client/SuperPickyApp/PreviewSweepCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewSweepCoordinator.swift
@@ -1,0 +1,82 @@
+import Foundation
+import os
+
+/// Walks a folder's photos in display order after open and pre-generates
+/// any missing PreviewCache JPEGs. Sweep is paused during user interaction
+/// so foreground decodes never compete with background work, and is
+/// cancelled on folder change / app quit.
+@MainActor
+final class PreviewSweepCoordinator {
+    static let shared = PreviewSweepCoordinator()
+    private static let log = Logger(subsystem: "com.halfhacked.superpicky", category: "PreviewSweep")
+
+    /// Window after the last interaction during which the sweep yields.
+    private static let interactionGrace: TimeInterval = 2.0
+
+    private var task: Task<Void, Never>?
+    private var processing: Set<String> = []
+    private var lastInteraction: Date = .distantPast
+
+    /// Start a sweep over `paths`. Cancels any in-flight sweep first.
+    /// `paths` should already be ordered as the user will see them so
+    /// nearby photos are warmed first.
+    func start(folder: URL, paths: [String]) {
+        stop()
+        guard ImageLoader.generatePreviewCache, !paths.isEmpty else { return }
+        task = Task { [weak self] in
+            await self?.run(folder: folder, paths: paths)
+        }
+    }
+
+    /// Cancel and forget the in-flight sweep.
+    func stop() {
+        task?.cancel()
+        task = nil
+        processing.removeAll()
+    }
+
+    /// Whether the sweep is currently writing a cache entry for `path`.
+    /// Used by the prefetch coordinator to avoid double work.
+    func isProcessing(path: String) -> Bool { processing.contains(path) }
+
+    /// Note that the user is actively driving the UI (key event, click).
+    /// The sweep yields for `interactionGrace` seconds after each note.
+    func noteInteraction() { lastInteraction = Date() }
+
+    // MARK: - Sweep body
+
+    private func run(folder: URL, paths: [String]) async {
+        let started = Date()
+        var written = 0
+        var skipped = 0
+        let cap = ImageLoader.previewCacheCapBytes
+        for path in paths {
+            if Task.isCancelled { break }
+
+            while shouldYield() {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                if Task.isCancelled { break }
+            }
+            if Task.isCancelled { break }
+
+            if PreviewCache.freshURL(for: path) != nil { skipped += 1; continue }
+
+            processing.insert(path)
+            _ = await ImageLoader.loadCGImage(path: path, maxPixelSize: nil)
+            processing.remove(path)
+            written += 1
+
+            if cap > 0, written.isMultiple(of: 20) {
+                PreviewCache.evictIfOverCap(maxBytes: cap)
+            }
+
+            await Task.yield()
+        }
+        let elapsed = Date().timeIntervalSince(started)
+        Self.log.info("folder=\(folder.path) wrote=\(written) skipped=\(skipped) elapsed=\(elapsed, privacy: .public)s")
+    }
+
+    private func shouldYield() -> Bool {
+        Date().timeIntervalSince(lastInteraction) < Self.interactionGrace
+    }
+}

--- a/apps/mac-client/SuperPickyApp/PreviewView.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 
 struct PreviewView: View {
     let photo: Photo?
@@ -45,19 +46,78 @@ struct PreviewView: View {
 }
 
 /// NSCache wrapper keyed by file path. Preview holds many small 2000 px
-/// decodes; fullRes holds a few 80 MB decodes to keep zoom instant. Both
-/// caches are shared between PreviewView, FullscreenViewer, and the zoom
-/// neighbour-prefetcher so back-arrow nav reuses cached frames regardless
-/// of which surface decoded them.
+/// decodes; fullRes holds full-resolution eager-decoded bitmaps to keep
+/// zoom-mode navigation instant. Both caches are shared between
+/// PreviewView, FullscreenViewer, and the zoom neighbour-prefetcher so
+/// back-arrow nav reuses cached frames regardless of which surface
+/// decoded them.
+///
+/// `fullRes` is sized off `ProcessInfo.physicalMemory` so 64+ GB Macs
+/// can hold hundreds of full-res bitmaps and treat re-visits within the
+/// folder as zero-cost. 16 GB Macs still get the previous 800 MB / 8
+/// entry floor.
 final class ImageCache {
-    static let preview = ImageCache(countLimit: 5, byteLimit: 200 * 1024 * 1024)
-    static let fullRes = ImageCache(countLimit: 8, byteLimit: 800 * 1024 * 1024)
+    static let preview = ImageCache(name: "preview", countLimit: 10, byteLimit: 400 * 1024 * 1024)
+    static let fullRes: ImageCache = {
+        let budget = computeFullResBudget()
+        Logger.imageCache.info(
+            "fullRes budget: \(budget.count) entries, \(budget.bytes / (1024 * 1024)) MB (physical=\(ProcessInfo.processInfo.physicalMemory / (1024 * 1024 * 1024)) GB) aggressive=\(PreviewCache.settings.aggressiveCache, privacy: .public)"
+        )
+        return ImageCache(name: "fullRes", countLimit: budget.count, byteLimit: budget.bytes)
+    }()
 
-    private let cache = NSCache<NSString, NSImage>()
+    /// Roughly an eager-decoded ARW (6000×4000 × 4 bytes/px ≈ 96 MB).
+    /// Used to translate the byte budget into an entry count.
+    private static let estimatedEntryBytes = 96 * 1024 * 1024
 
-    init(countLimit: Int, byteLimit: Int) {
+    /// Memory-budget floor (per device) and ceiling. Floor keeps the
+    /// 16 GB-Mac experience at least as good as the previous static
+    /// 800 MB cap. Ceiling avoids starving other apps on workstation
+    /// macs with hundreds of GB of RAM.
+    private static let minBytes = 800 * 1024 * 1024
+    private static let maxBytes = 32 * 1024 * 1024 * 1024  // 32 GB
+
+    /// Resolve the cache budget. "Aggressive" uses 50% of physical RAM,
+    /// "balanced" (default) uses 25%. Both clamp to [minBytes, maxBytes].
+    static func computeFullResBudget() -> (count: Int, bytes: Int) {
+        let physical = ProcessInfo.processInfo.physicalMemory
+        let fraction = PreviewCache.settings.aggressiveCache ? 0.5 : 0.25
+        let raw = Int(Double(physical) * fraction)
+        let bytes = max(minBytes, min(maxBytes, raw))
+        let count = max(8, bytes / estimatedEntryBytes)
+        return (count, bytes)
+    }
+
+    /// Re-apply the budget at runtime when the Settings toggle flips. Cheap
+    /// — NSCache will lazily evict any entries that exceed the new caps.
+    /// Also clamp the bookkeeping mirror to the new limits so the Settings
+    /// readout doesn't briefly show "200 / 80 entries" after a shrink.
+    func resize(countLimit: Int, byteLimit: Int) {
         cache.countLimit = countLimit
         cache.totalCostLimit = byteLimit
+        bookkeeping.withLock { state in
+            state.count = min(state.count, countLimit)
+            state.bytes = min(state.bytes, byteLimit)
+        }
+        Logger.imageCache.info("resize \(self.name, privacy: .public): \(countLimit) entries, \(byteLimit / (1024 * 1024)) MB")
+    }
+
+    let name: String
+    private let cache = NSCache<NSString, NSImage>()
+    private let delegate: ImageCacheDelegate
+
+    /// Best-effort mirror of NSCache's contents — NSCache doesn't expose
+    /// count or total cost, so we maintain them ourselves under a lock.
+    /// Used only for diagnostic logging; not relied on for correctness.
+    private let bookkeeping = OSAllocatedUnfairLock<(count: Int, bytes: Int)>(initialState: (0, 0))
+
+    init(name: String, countLimit: Int, byteLimit: Int) {
+        self.name = name
+        self.delegate = ImageCacheDelegate()
+        cache.countLimit = countLimit
+        cache.totalCostLimit = byteLimit
+        cache.delegate = delegate
+        delegate.owner = self
     }
 
     func get(_ key: String) -> NSImage? { cache.object(forKey: key as NSString) }
@@ -65,8 +125,51 @@ final class ImageCache {
     func set(_ key: String, image: NSImage) {
         let w = image.representations.first?.pixelsWide ?? Int(image.size.width)
         let h = image.representations.first?.pixelsHigh ?? Int(image.size.height)
-        cache.setObject(image, forKey: key as NSString, cost: w * h * 4)
+        let cost = w * h * 4
+        cache.setObject(image, forKey: key as NSString, cost: cost)
+        // NSCache's willEvictObject delegate is best-effort — under count
+        // overflow it sometimes batch-evicts without notifying. Cap our
+        // mirror at the configured limits so bookkeeping can't run away;
+        // the eviction callback brings it down further when it fires.
+        bookkeeping.withLock { state in
+            state.count = min(state.count + 1, self.cache.countLimit)
+            state.bytes = min(state.bytes + cost, self.cache.totalCostLimit)
+        }
+        Logger.imageCache.info(
+            "\(self.name, privacy: .public) set \((key as NSString).lastPathComponent, privacy: .public) cost=\(cost / (1024 * 1024))MB approx_total=\(self.approximateBytes() / (1024 * 1024))MB count=\(self.approximateCount())"
+        )
     }
+
+    func approximateCount() -> Int { bookkeeping.withLock { $0.count } }
+    func approximateBytes() -> Int { bookkeeping.withLock { $0.bytes } }
+
+    fileprivate func noteEviction(_ image: NSImage) {
+        let w = image.representations.first?.pixelsWide ?? Int(image.size.width)
+        let h = image.representations.first?.pixelsHigh ?? Int(image.size.height)
+        let cost = w * h * 4
+        bookkeeping.withLock { state in
+            state.count = max(0, state.count - 1)
+            state.bytes = max(0, state.bytes - cost)
+        }
+        Logger.imageCache.info(
+            "\(self.name, privacy: .public) evict cost=\(cost / (1024 * 1024))MB approx_total=\(self.approximateBytes() / (1024 * 1024))MB count=\(self.approximateCount())"
+        )
+    }
+}
+
+/// Per-instance NSCache delegate so each `ImageCache` knows when its own
+/// cache evicts an entry and can update its bookkeeping.
+private final class ImageCacheDelegate: NSObject, NSCacheDelegate {
+    weak var owner: ImageCache?
+
+    func cache(_ cache: NSCache<AnyObject, AnyObject>, willEvictObject obj: Any) {
+        guard let image = obj as? NSImage else { return }
+        owner?.noteEviction(image)
+    }
+}
+
+extension Logger {
+    fileprivate static let imageCache = Logger(subsystem: "com.halfhacked.superpicky", category: "ImageCache")
 }
 
 /// Loads a full-size preview image asynchronously.

--- a/apps/mac-client/SuperPickyApp/PreviewView.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewView.swift
@@ -125,10 +125,12 @@ struct AsyncPreviewImage: View {
                 image = cached
                 return
             }
+            let pinnedPath = filePath
             Task {
-                if let full = await loadFullRes(filePath) {
+                if let full = await loadFullRes(pinnedPath) {
+                    guard !Task.isCancelled, filePath == pinnedPath else { return }
                     image = full
-                } else {
+                } else if filePath == pinnedPath {
                     isFullRes = false  // allow retry on next zoom
                 }
             }

--- a/apps/mac-client/SuperPickyApp/PreviewView.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewView.swift
@@ -45,10 +45,13 @@ struct PreviewView: View {
 }
 
 /// NSCache wrapper keyed by file path. Preview holds many small 2000 px
-/// decodes; fullRes holds a few 80 MB decodes to keep zoom instant.
-private final class ImageCache {
+/// decodes; fullRes holds a few 80 MB decodes to keep zoom instant. Both
+/// caches are shared between PreviewView, FullscreenViewer, and the zoom
+/// neighbour-prefetcher so back-arrow nav reuses cached frames regardless
+/// of which surface decoded them.
+final class ImageCache {
     static let preview = ImageCache(countLimit: 5, byteLimit: 200 * 1024 * 1024)
-    static let fullRes = ImageCache(countLimit: 3, byteLimit: 400 * 1024 * 1024)
+    static let fullRes = ImageCache(countLimit: 8, byteLimit: 800 * 1024 * 1024)
 
     private let cache = NSCache<NSString, NSImage>()
 

--- a/apps/mac-client/SuperPickyTests/Core/PreviewCacheTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/PreviewCacheTests.swift
@@ -6,6 +6,14 @@ import CoreGraphics
 
 @Suite(.serialized) struct PreviewCacheTests {
 
+    init() {
+        // Redirect the cache root to a per-suite temp directory so tests
+        // don't touch ~/Library/Caches/com.halfhacked.superpicky/preview/
+        // (the developer's real cache from running the app).
+        PreviewCache.rootURLOverride = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PreviewCacheTests/\(UUID().uuidString)/cache")
+    }
+
     // MARK: - Fixtures
 
     private func makeTempFolder() throws -> URL {

--- a/apps/mac-client/SuperPickyTests/Core/PreviewCacheTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/PreviewCacheTests.swift
@@ -1,0 +1,197 @@
+import Testing
+import Foundation
+import ImageIO
+import CoreGraphics
+@testable import SuperPicky
+
+@Suite(.serialized) struct PreviewCacheTests {
+
+    // MARK: - Fixtures
+
+    private func makeTempFolder() throws -> URL {
+        let folder = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PreviewCacheTests/\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        return folder
+    }
+
+    /// Write a tiny solid-color JPEG so we have a real raw-mtime baseline.
+    @discardableResult
+    private func writeJPEG(at url: URL, sideLength: Int = 16) throws -> URL {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let cs = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(
+            data: nil,
+            width: sideLength,
+            height: sideLength,
+            bitsPerComponent: 8,
+            bytesPerRow: sideLength * 4,
+            space: cs,
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        ), let image = ctx.makeImage() else {
+            throw NSError(domain: "PreviewCacheTests", code: 1)
+        }
+        let dest = CGImageDestinationCreateWithURL(url as CFURL, "public.jpeg" as CFString, 1, nil)!
+        CGImageDestinationAddImage(dest, image, nil)
+        #expect(CGImageDestinationFinalize(dest))
+        return url
+    }
+
+    /// Make a 1x1 CGImage we can pass to PreviewCache.write.
+    private func makePixel() -> CGImage {
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(
+            data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,
+            space: cs,
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        )!
+        return ctx.makeImage()!
+    }
+
+    // MARK: - cachedURL / freshURL
+
+    @Test func cachedURLLayoutMatchesFolderHash() throws {
+        let folder = try makeTempFolder()
+        let a = folder.appendingPathComponent("DSC09176.ARW").path
+        let b = folder.appendingPathComponent("DSC09177.ARW").path
+        let urlA = PreviewCache.cachedURL(for: a)
+        let urlB = PreviewCache.cachedURL(for: b)
+        #expect(urlA.deletingLastPathComponent() == urlB.deletingLastPathComponent(),
+                "same-folder photos must share a hash dir")
+        #expect(urlA.lastPathComponent == "DSC09176.jpg")
+        #expect(urlB.lastPathComponent == "DSC09177.jpg")
+        #expect(urlA.path.hasPrefix(PreviewCache.rootURL.path))
+    }
+
+    @Test func freshURLReturnsNilWhenMissing() throws {
+        let folder = try makeTempFolder()
+        let raw = folder.appendingPathComponent("a.jpg")
+        try writeJPEG(at: raw)
+        // Cache file has not been written yet.
+        #expect(PreviewCache.freshURL(for: raw.path) == nil)
+    }
+
+    @Test func freshURLDetectsStaleCache() throws {
+        let folder = try makeTempFolder()
+        let raw = folder.appendingPathComponent("a.jpg")
+        try writeJPEG(at: raw)
+        let cached = PreviewCache.cachedURL(for: raw.path)
+        try FileManager.default.createDirectory(
+            at: cached.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try writeJPEG(at: cached)
+        // Backdate cache to be older than raw.
+        let oldDate = Date().addingTimeInterval(-3600)
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: cached.path)
+        let newDate = Date()
+        try FileManager.default.setAttributes([.modificationDate: newDate], ofItemAtPath: raw.path)
+
+        #expect(PreviewCache.freshURL(for: raw.path) == nil,
+                "stale cache must not be reported as fresh")
+
+        _ = PreviewCache.clearAll()
+    }
+
+    @Test func freshURLAcceptsCurrentCache() throws {
+        let folder = try makeTempFolder()
+        let raw = folder.appendingPathComponent("a.jpg")
+        try writeJPEG(at: raw)
+        let cached = PreviewCache.cachedURL(for: raw.path)
+        try writeJPEG(at: cached)
+        // cached mtime is "now" — equal-or-newer than raw.
+
+        #expect(PreviewCache.freshURL(for: raw.path) != nil)
+        _ = PreviewCache.clearAll()
+    }
+
+    // MARK: - touch
+
+    @Test func touchUpdatesMtimeOnRead() throws {
+        let folder = try makeTempFolder()
+        let raw = folder.appendingPathComponent("a.jpg")
+        try writeJPEG(at: raw)
+        let cached = PreviewCache.cachedURL(for: raw.path)
+        try writeJPEG(at: cached)
+        let before = Date().addingTimeInterval(-3600)
+        try FileManager.default.setAttributes([.modificationDate: before], ofItemAtPath: cached.path)
+
+        PreviewCache.touch(cached)
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: cached.path)
+        let after = attrs[.modificationDate] as? Date
+        #expect(after != nil)
+        if let after { #expect(after.timeIntervalSince(before) > 30) }
+
+        _ = PreviewCache.clearAll()
+    }
+
+    // MARK: - eviction
+
+    @Test func evictDropsOldestUntilUnderCap() throws {
+        // Wipe cache so we don't see leftover state from other tests.
+        _ = PreviewCache.clearAll()
+
+        // Synthesize 5 cache entries with known mtimes.
+        let now = Date()
+        var urls: [URL] = []
+        for i in 0..<5 {
+            // Fabricate paths so each gets a unique cache filename.
+            let fakePath = "/tmp/PreviewCacheTests/fake/\(i).ARW"
+            let url = PreviewCache.cachedURL(for: fakePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            // 200 KB each with mtime spaced 1 hour apart.
+            let data = Data(count: 200_000)
+            try data.write(to: url)
+            let mtime = now.addingTimeInterval(TimeInterval(-3600 * (5 - i)))
+            try FileManager.default.setAttributes([.modificationDate: mtime], ofItemAtPath: url.path)
+            urls.append(url)
+        }
+
+        let totalBefore = PreviewCache.currentSizeBytes()
+        #expect(totalBefore == 5 * 200_000)
+
+        // Cap at 600 KB → target 540 KB → evict ~3 oldest files.
+        PreviewCache.evictIfOverCap(maxBytes: 600_000)
+        let after = PreviewCache.currentSizeBytes()
+        #expect(after <= 600_000)
+        // Oldest entry (index 0) must be gone; newest (index 4) must remain.
+        #expect(!FileManager.default.fileExists(atPath: urls[0].path))
+        #expect(FileManager.default.fileExists(atPath: urls[4].path))
+
+        _ = PreviewCache.clearAll()
+    }
+
+    @Test func evictNoopWhenUnderCap() throws {
+        _ = PreviewCache.clearAll()
+        let url = PreviewCache.cachedURL(for: "/tmp/PreviewCacheTests/fake/x.ARW")
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(count: 100).write(to: url)
+        PreviewCache.evictIfOverCap(maxBytes: 1_000_000)
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        _ = PreviewCache.clearAll()
+    }
+
+    // MARK: - write
+
+    @Test func writeProducesReadableJPEG() throws {
+        _ = PreviewCache.clearAll()
+        let url = PreviewCache.cachedURL(for: "/tmp/PreviewCacheTests/fake/y.ARW")
+        let pixel = makePixel()
+        #expect(PreviewCache.write(pixel, to: url))
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        // Round-trip through ImageIO.
+        let source = CGImageSourceCreateWithURL(url as CFURL, nil)
+        #expect(source != nil)
+        _ = PreviewCache.clearAll()
+    }
+}

--- a/apps/mac-client/SuperPickyTests/Core/PreviewCacheTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/PreviewCacheTests.swift
@@ -23,6 +23,8 @@ import CoreGraphics
         return folder
     }
 
+    private struct FixtureError: Error { let message: String }
+
     /// Write a tiny solid-color JPEG so we have a real raw-mtime baseline.
     @discardableResult
     private func writeJPEG(at url: URL, sideLength: Int = 16) throws -> URL {
@@ -40,23 +42,27 @@ import CoreGraphics
             space: cs,
             bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
         ), let image = ctx.makeImage() else {
-            throw NSError(domain: "PreviewCacheTests", code: 1)
+            throw FixtureError(message: "CGContext / makeImage failed")
         }
-        let dest = CGImageDestinationCreateWithURL(url as CFURL, "public.jpeg" as CFString, 1, nil)!
+        guard let dest = CGImageDestinationCreateWithURL(url as CFURL, "public.jpeg" as CFString, 1, nil) else {
+            throw FixtureError(message: "CGImageDestinationCreateWithURL failed")
+        }
         CGImageDestinationAddImage(dest, image, nil)
         #expect(CGImageDestinationFinalize(dest))
         return url
     }
 
     /// Make a 1x1 CGImage we can pass to PreviewCache.write.
-    private func makePixel() -> CGImage {
+    private func makePixel() throws -> CGImage {
         let cs = CGColorSpaceCreateDeviceRGB()
-        let ctx = CGContext(
+        guard let ctx = CGContext(
             data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,
             space: cs,
             bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
-        )!
-        return ctx.makeImage()!
+        ), let image = ctx.makeImage() else {
+            throw FixtureError(message: "1x1 CGContext failed")
+        }
+        return image
     }
 
     // MARK: - cachedURL / freshURL
@@ -194,7 +200,7 @@ import CoreGraphics
     @Test func writeProducesReadableJPEG() throws {
         _ = PreviewCache.clearAll()
         let url = PreviewCache.cachedURL(for: "/tmp/PreviewCacheTests/fake/y.ARW")
-        let pixel = makePixel()
+        let pixel = try makePixel()
         #expect(PreviewCache.write(pixel, to: url))
         #expect(FileManager.default.fileExists(atPath: url.path))
         // Round-trip through ImageIO.

--- a/apps/mac-client/SuperPickyUITests/PreviewCacheUITests.swift
+++ b/apps/mac-client/SuperPickyUITests/PreviewCacheUITests.swift
@@ -1,12 +1,13 @@
 import XCTest
-import CryptoKit
 
 /// L3 BDD: verify that pressing `z` to zoom triggers a full-res decode
 /// which writes a sidecar JPEG into the preview cache, and that
 /// re-launching the app reuses the on-disk file instead of re-writing it.
 ///
 /// Cleans the cache before and after the run so we don't leak between
-/// CI runs or interfere with the user's real cache.
+/// CI runs or interfere with the user's real cache. Walks the cache root
+/// instead of recomputing the hash so the test stays decoupled from the
+/// keying scheme in `PreviewCache`.
 final class PreviewCacheUITests: SuperPickyUITestCase {
 
     override class var testDirPrefix: String { "superpicky_preview_cache" }
@@ -17,8 +18,6 @@ final class PreviewCacheUITests: SuperPickyUITestCase {
     }()
 
     override class func setUp() {
-        // Ensure the cache starts empty — anything left from a prior run
-        // would mask a regression in the lazy-write path.
         try? FileManager.default.removeItem(at: cacheRoot)
         super.setUp()
     }
@@ -28,22 +27,25 @@ final class PreviewCacheUITests: SuperPickyUITestCase {
         super.tearDown()
     }
 
-    /// SHA-256 of the absolute folder path → first 16 hex chars; mirrors
-    /// `PreviewCache.cachedURL(for:)`.
-    private func folderHashDir() -> URL {
-        let folder = Self.testDir!
-        let data = Data(folder.utf8)
-        let digest = SHA256.hash(data: data)
-        let hex = digest.map { String(format: "%02x", $0) }.joined()
-        return Self.cacheRoot.appendingPathComponent(String(hex.prefix(16)), isDirectory: true)
-    }
-
+    /// Find any file named `filename` anywhere under `cacheRoot`, polling
+    /// until it appears or the timeout elapses.
     private func waitForCacheFile(named filename: String, timeout: TimeInterval = 10) -> URL? {
-        let url = folderHashDir().appendingPathComponent(filename)
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if FileManager.default.fileExists(atPath: url.path) { return url }
+            if let match = findCacheFile(named: filename) { return match }
             Thread.sleep(forTimeInterval: 0.2)
+        }
+        return nil
+    }
+
+    private func findCacheFile(named filename: String) -> URL? {
+        guard let enumerator = FileManager.default.enumerator(
+            at: Self.cacheRoot,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return nil }
+        for case let url as URL in enumerator where url.lastPathComponent == filename {
+            return url
         }
         return nil
     }
@@ -54,10 +56,6 @@ final class PreviewCacheUITests: SuperPickyUITestCase {
         XCTAssertTrue(preview.waitForExistence(timeout: 10),
                       "PhotoPreview should appear after processing")
 
-        // Enter actual-pixels zoom — forces a full-res decode and the
-        // post-decode cache write. The folder-open sweep may have already
-        // written the file by this point; the test asserts the post-state
-        // either way.
         app.typeKey("z", modifierFlags: [])
 
         let cached = waitForCacheFile(named: "DSC09176.jpg")
@@ -66,14 +64,9 @@ final class PreviewCacheUITests: SuperPickyUITestCase {
     }
 
     func test02_clearedCacheRegenerates() throws {
-        // After test01 the cache should hold DSC09176.jpg. Wipe the cache,
-        // navigate, and verify the file is recreated.
         try? FileManager.default.removeItem(at: Self.cacheRoot)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: folderHashDir().path),
-                       "Cache root should be empty after wipe")
 
         let app = Self.app!
-        // Re-trigger a full-res decode on the current photo (zoom out then in).
         app.typeKey("z", modifierFlags: [])
         app.typeKey("z", modifierFlags: [])
 

--- a/apps/mac-client/SuperPickyUITests/PreviewCacheUITests.swift
+++ b/apps/mac-client/SuperPickyUITests/PreviewCacheUITests.swift
@@ -1,0 +1,84 @@
+import XCTest
+import CryptoKit
+
+/// L3 BDD: verify that pressing `z` to zoom triggers a full-res decode
+/// which writes a sidecar JPEG into the preview cache, and that
+/// re-launching the app reuses the on-disk file instead of re-writing it.
+///
+/// Cleans the cache before and after the run so we don't leak between
+/// CI runs or interfere with the user's real cache.
+final class PreviewCacheUITests: SuperPickyUITestCase {
+
+    override class var testDirPrefix: String { "superpicky_preview_cache" }
+
+    private static let cacheRoot: URL = {
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return caches.appendingPathComponent("com.halfhacked.superpicky/preview", isDirectory: true)
+    }()
+
+    override class func setUp() {
+        // Ensure the cache starts empty — anything left from a prior run
+        // would mask a regression in the lazy-write path.
+        try? FileManager.default.removeItem(at: cacheRoot)
+        super.setUp()
+    }
+
+    override class func tearDown() {
+        try? FileManager.default.removeItem(at: cacheRoot)
+        super.tearDown()
+    }
+
+    /// SHA-256 of the absolute folder path → first 16 hex chars; mirrors
+    /// `PreviewCache.cachedURL(for:)`.
+    private func folderHashDir() -> URL {
+        let folder = Self.testDir!
+        let data = Data(folder.utf8)
+        let digest = SHA256.hash(data: data)
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return Self.cacheRoot.appendingPathComponent(String(hex.prefix(16)), isDirectory: true)
+    }
+
+    private func waitForCacheFile(named filename: String, timeout: TimeInterval = 10) -> URL? {
+        let url = folderHashDir().appendingPathComponent(filename)
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) { return url }
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        return nil
+    }
+
+    func test01_zoomTriggersCacheWrite() throws {
+        let app = Self.app!
+        let preview = app.images[A11y.photoPreview]
+        XCTAssertTrue(preview.waitForExistence(timeout: 10),
+                      "PhotoPreview should appear after processing")
+
+        // Enter actual-pixels zoom — forces a full-res decode and the
+        // post-decode cache write. The folder-open sweep may have already
+        // written the file by this point; the test asserts the post-state
+        // either way.
+        app.typeKey("z", modifierFlags: [])
+
+        let cached = waitForCacheFile(named: "DSC09176.jpg")
+        XCTAssertNotNil(cached,
+                        "Preview cache file should exist for the auto-selected photo")
+    }
+
+    func test02_clearedCacheRegenerates() throws {
+        // After test01 the cache should hold DSC09176.jpg. Wipe the cache,
+        // navigate, and verify the file is recreated.
+        try? FileManager.default.removeItem(at: Self.cacheRoot)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: folderHashDir().path),
+                       "Cache root should be empty after wipe")
+
+        let app = Self.app!
+        // Re-trigger a full-res decode on the current photo (zoom out then in).
+        app.typeKey("z", modifierFlags: [])
+        app.typeKey("z", modifierFlags: [])
+
+        let cached = waitForCacheFile(named: "DSC09176.jpg", timeout: 15)
+        XCTAssertNotNil(cached,
+                        "Preview cache file should be regenerated after a manual wipe")
+    }
+}


### PR DESCRIPTION
## Summary
- Speeds up keyboard navigation through RAW photos in zoom mode by adding a disk JPEG sidecar cache (`~/Library/Caches/com.halfhacked.superpicky/preview/`) and a RAM working-set cache sized off `ProcessInfo.physicalMemory` (25% by default, 50% with the new "aggressive cache" toggle, capped at 32 GB).
- Burst-aware **PrefetchCoordinator** keeps the current burst plus a few photos of the next bursts warm in `ImageCache.fullRes`. Direction streak grows next-burst depth in the nav direction; reversal resets. Anti-thrash diff: walking through a 10-photo burst keeps in-flight prefetches running unchanged instead of cancel/reschedule churning.
- **PreviewSweepCoordinator** generates the disk JPEG cache for the rest of the folder in the background after open, yielding for 2 s after every keypress so foreground decodes always win.
- Settings → Advanced gains a "Generate preview cache" toggle, "Use aggressive in-memory cache (50 % of RAM)" toggle, disk-cache size picker (5 / 20 / 50 / 100 / Unlimited GB), live in-memory + disk usage labels, and a Clear button.

## Why three caches
| Layer | What | Speed | Cap |
|---|---|---|---|
| `ImageCache.fullRes` | eager-decoded NSImage bitmaps | 0 ms (RAM hit) | 25 / 50 % of physical RAM |
| Disk JPG sidecars | encoded full-res JPEGs | ~30 ms / photo | 20 GB default, configurable |
| Original RAW | source files | ~250 ms / photo | n/a |

## Notable correctness fixes during development
- **CGImageSourceCreateImageAtIndex returns lazy CGImages** — pixel decode was deferring to main-thread render, blocking the UI. Force eager decode by drawing into a same-size bitmap context on the background queue.
- **70 GB → 1 GB working-set fix** — eager decode in the sweep path was the culprit. Sweep now uses `kCGImageSourceShouldCache: false` and never materialises a bitmap; foreground/prefetch get eager bitmaps; writers carry pre-encoded JPEG `Data` instead of pinning CGImage sources.
- **Decode queue split** — foreground keypresses serialise through an actor (no pile-up under fast scrubbing); prefetch + sweep run on dedicated GCD queues so a slow sweep never blocks the user. Thumbnails (≤ 320 px) bypass the actor entirely on a concurrent queue (was causing gray placeholders during fast nav).
- **Cache reads bump mtime** so LRU eviction reflects access recency.
- **Cancellation discipline** — foreground tasks cancelled mid-decode skip the disk write to avoid wasted I/O.

## Files
- New: `PreviewCache.swift`, `PrefetchCoordinator.swift`, `PreviewSweepCoordinator.swift`, `PreviewCacheTests.swift` (L1), `PreviewCacheUITests.swift` (L3).
- Modified: `ImageLoader.swift`, `PreviewView.swift`, `FullscreenViewer.swift`, `CullingConfig.swift`, `AdvancedTab.swift`, `ContentView.swift`, `AppState.swift`, `KeyboardMonitor.swift`.

## Test plan
- [x] G1 build (Debug + Release) green
- [x] L1 unit tests — 497 / 497 passing locally, including 8 new `PreviewCacheTests` (path layout, fresh/stale detection, mtime touch, eviction, JPEG round-trip)
- [x] Manual perf check: hold ←/→ in zoom mode on an ARW folder; expect main-thread no-stall and disk cache files appearing under `~/Library/Caches/com.halfhacked.superpicky/preview/<hash>/`
- [x] Memory bounded at ~ workspace cap (verified at 1 GB after fixes; 4 GB working set at default 25 % budget on a 64 GB Mac under heavy nav)
- [ ] L3 BDD `PreviewCacheUITests` — runs on CI per project convention (XCUITests not run locally)

## Out of scope (defer)
- Disk-cache eviction frequency cap (writer queue currently walks the dir after every write — fine for tens of writes, expensive for sweeps over 10 k photos).
- 4-way parallel sweep (gated on `aggressiveCache`).
- Burst-index lookup for O(burst-size) instead of O(N) on every selection change in 10 k+ folders.