### PR TITLE
fix(strip): chronological default + auto-center on list change

### DIFF
--- a/apps/mac-client/SuperPickyApp/BurstDetector.swift
+++ b/apps/mac-client/SuperPickyApp/BurstDetector.swift
@@ -95,7 +95,7 @@ struct BurstDetector: Sendable {
         return (parseTimestamp(from: props), GPSExtractor.gps(fromProperties: props))
     }
 
-    private static func parseTimestamp(from props: [String: Any]) -> Double? {
+    static func parseTimestamp(from props: [String: Any]) -> Double? {
         guard let exif = props["{Exif}"] as? [String: Any],
               let dateStr = exif["DateTimeOriginal"] as? String,
               let date = exifDateFormatter.date(from: dateStr) else { return nil }

--- a/apps/mac-client/SuperPickyApp/ContentView.swift
+++ b/apps/mac-client/SuperPickyApp/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
     @State private var minimumStars: Int = 0
     @State private var topBurstOnly: Bool = false
     @State private var pickedOnly: Bool = false
-    @State private var sortOrder: SortOrder = .filename
+    @State private var sortOrder: SortOrder = .captureDate
     @State private var sortAscending: Bool = true
     @State private var showExifPanel = true
     @State private var showFullscreen = false

--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -501,6 +501,13 @@ final class PipelineCoordinator: @unchecked Sendable {
            let h = props[kCGImagePropertyPixelHeight as String] as? Int {
             imageSizeOut = (w, h)
         }
+        // EXIF DateTimeOriginal + SubSecTimeOriginal — overrides the ingestion-
+        // time `Date()` set by Photo.init so the strip and the captureDate
+        // sort actually reflect when the shutter fired.
+        if let props = imageProps,
+           let ts = BurstDetector.parseTimestamp(from: props) {
+            photo.dateCreated = Date(timeIntervalSince1970: ts)
+        }
         // Perceptual hash for the burst-similarity check — reuse the already
         // decoded image instead of reopening the file for a 64px thumbnail.
         let pHashStart = DispatchTime.now()

--- a/apps/mac-client/SuperPickyApp/ReportDatabase.swift
+++ b/apps/mac-client/SuperPickyApp/ReportDatabase.swift
@@ -185,7 +185,7 @@ final class ReportDatabase: Sendable {
 
     func fetchAllPhotos() throws -> [Photo] {
         try dbQueue.read { db in
-            try Photo.fetchAll(db)
+            try Photo.order(Column("dateCreated")).fetchAll(db)
         }
     }
 

--- a/apps/mac-client/SuperPickyApp/ReportDatabase.swift
+++ b/apps/mac-client/SuperPickyApp/ReportDatabase.swift
@@ -185,7 +185,11 @@ final class ReportDatabase: Sendable {
 
     func fetchAllPhotos() throws -> [Photo] {
         try dbQueue.read { db in
-            try Photo.order(Column("dateCreated")).fetchAll(db)
+            // Filename tiebreaker — burst shots can share an EXIF
+            // DateTimeOriginal down to the SubSecTimeOriginal precision, and
+            // some camera bodies don't write SubSec at all. Without a stable
+            // tiebreaker the strip order would be arbitrary on those rows.
+            try Photo.order(Column("dateCreated"), Column("filename")).fetchAll(db)
         }
     }
 

--- a/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
+++ b/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 import AppKit
 
+/// Cheap O(1) fingerprint for `[Photo]` change detection in `onChange(of:)`.
+/// Misses pure mid-list reorders that preserve count + endpoints, but every
+/// real reorder path (filter switch, sort field/direction toggle) shifts at
+/// least the endpoints.
+private struct PhotoListSignature: Equatable {
+    let count: Int
+    let firstID: UUID?
+    let lastID: UUID?
+
+    init(_ photos: [Photo]) {
+        count = photos.count
+        firstID = photos.first?.id
+        lastID = photos.last?.id
+    }
+}
+
 struct ThumbnailStripView: View {
     let photos: [Photo]
     let selection: PhotoSelection
@@ -34,13 +50,25 @@ struct ThumbnailStripView: View {
             }
             .background(ScrollWheelRedirector())
             .background(.bar)
-            .onChange(of: selection.activeID) { _, newValue in
-                if let id = newValue {
-                    withAnimation {
-                        proxy.scrollTo(id, anchor: .center)
-                    }
-                }
+            .onChange(of: selection.activeID) { _, _ in
+                scrollActiveIntoView(proxy, animated: true)
             }
+            // Cheap signature: photos array changes through filter switches,
+            // sort changes, and reload — all of which shift either the count
+            // or the endpoints. Avoids materializing a [UUID] every diff.
+            .onChange(of: PhotoListSignature(photos)) { _, _ in
+                scrollActiveIntoView(proxy, animated: false)
+            }
+            .onAppear {
+                scrollActiveIntoView(proxy, animated: false)
+            }
+        }
+    }
+
+    private func scrollActiveIntoView(_ proxy: ScrollViewProxy, animated: Bool) {
+        guard let id = selection.activeID else { return }
+        withAnimation(animated ? .default : nil) {
+            proxy.scrollTo(id, anchor: .center)
         }
     }
 


### PR DESCRIPTION
## Summary

The thumbnail strip and the auto-selected photo could drift apart on launch and after filter/sort changes — preview showed one bird, strip showed a different one, with no thumbnail visibly highlighted in the viewport.

Two root causes, fixed together since they're the same UX bug seen from two angles:

- **Auto-select used DB row order** — `fetchAllPhotos` returned rows in insertion order, so `applyFilter()`'s `photos.first` (the auto-select fallback) was "first processed", which has nothing to do with the strip's display order.
- **Strip never re-scrolled when its list rebuilt** — the only auto-scroll hook was `onChange(of: selection.activeID)`, so a filter swap (e.g. species → all photos) that *kept* the active selection but rebuilt `photos` left the strip parked at offset 0 with the active photo off-screen.

## Changes

- **`ContentView.swift`** — default sort changed from `.filename` to `.captureDate` ascending. Matches shooting order, the most natural default for culling.
- **`ReportDatabase.swift`** — `fetchAllPhotos` now `ORDER BY dateCreated`. AppState's `allPhotos` and `applyFilter()`'s `photos.first` auto-select align with the strip's chronological default. Single source of ordering.
- **`ThumbnailStripView.swift`** — `scrollActiveIntoView(_:animated:)` helper, called from:
  - `onChange(of: selection.activeID)` — animated (user-initiated nav, smooth slide).
  - `onChange(of: PhotoListSignature(photos))` — non-animated (list rebuilt by filter/sort change, instant centering avoids long horizontal swooshes).
  - `onAppear` — non-animated (covers cases where active was set before the view subscribed).

## /simplify cleanup

Bundled in the same commit (per /go conventions):

- Change-detection signature is `PhotoListSignature(count, firstID, lastID)` instead of `photos.map(\.id)`. O(1) per render-diff vs O(n) UUID allocation; covers every realistic reorder path (filter switch, sort field/direction toggle).
- Animated/non-animated branches collapse into one `withAnimation(animated ? .default : nil)` call.

## Test plan

- [x] `xcodebuild build -scheme SuperPicky -destination 'platform=macOS'` — clean.
- [x] `xcodebuild test -scheme SuperPicky -destination 'platform=macOS' -only-testing:SuperPickyTests` — 538/538 pass.
- [x] `swiftlint lint --strict` — 0 violations.
- [x] App launches on saved DCIM folder; auto-selected photo = leftmost thumbnail.
- [x] Sidebar species filter → arrow into mid-list → switch back to folder: strip jumps to active in chronological order.
- [x] Sort menu Date → Filename: strip re-centers on active in new order, instantly.
- [x] Arrow-key nav: still smooth slide.