### PR TITLE
Sharpness + focus-point port gaps from superpicky

### DIFF
--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		D562D508BE9BC7F68F390C75 /* species_list_CN-41.json in Resources */ = {isa = PBXBuildFile; fileRef = 83CCD975564900EE5E75D5D4 /* species_list_CN-41.json */; };
 		D5780C7327D0F6E8E642EA4E /* EXIFOffsetReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DC1B03F94601690B7CEE70 /* EXIFOffsetReader.swift */; };
 		C3901B0082034877AE3BC55C /* SonyMakerNoteReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */; };
+		4ED691282A8C468A9D7BD925 /* TIFFIFDReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53C33BA781A440C9AE778D6 /* TIFFIFDReader.swift */; };
 		C411A16A447248E699F22041 /* SonyMakerNoteReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */; };
 		D6070A885F8DE451AE897CEE /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1508E6CA44451D6B09FAD8BF /* ImageLoader.swift */; };
 		D716E8F51325F58C77043E42 /* species_list_CN-91.json in Resources */ = {isa = PBXBuildFile; fileRef = 0840F652B0CB17459DB81648 /* species_list_CN-91.json */; };
@@ -468,6 +469,7 @@
 		54FECD0590A3C20869543AFA /* species_list_US-AK.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_US-AK.json"; sourceTree = "<group>"; };
 		55DC1B03F94601690B7CEE70 /* EXIFOffsetReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXIFOffsetReader.swift; sourceTree = "<group>"; };
 		DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonyMakerNoteReader.swift; sourceTree = "<group>"; };
+		B53C33BA781A440C9AE778D6 /* TIFFIFDReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TIFFIFDReader.swift; sourceTree = "<group>"; };
 		91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonyMakerNoteReaderTests.swift; sourceTree = "<group>"; };
 		55FD8383417E1258A87ACD4A /* species_list_FI.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = species_list_FI.json; sourceTree = "<group>"; };
 		56C47414BCC2DF0A9F491F21 /* RegionBounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionBounds.swift; sourceTree = "<group>"; };
@@ -798,6 +800,7 @@
 				D6D8E5ED328E7CA41C95BBD9 /* ExifFormatters.swift */,
 				55DC1B03F94601690B7CEE70 /* EXIFOffsetReader.swift */,
 				DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */,
+				B53C33BA781A440C9AE778D6 /* TIFFIFDReader.swift */,
 				8D61960564355CE428DB7AAB /* ExifPanelView.swift */,
 				75A29A263D346C79918EC367 /* EXIFReader.swift */,
 				C9D7B139DADC49E884F6DC14 /* ExportService.swift */,
@@ -1580,6 +1583,7 @@
 				2537E1B585BD0EFF83728969 /* DirectoryScanner.swift in Sources */,
 				D5780C7327D0F6E8E642EA4E /* EXIFOffsetReader.swift in Sources */,
 				C3901B0082034877AE3BC55C /* SonyMakerNoteReader.swift in Sources */,
+				4ED691282A8C468A9D7BD925 /* TIFFIFDReader.swift in Sources */,
 				E8A2927BC88504E05E879CEC /* EXIFReader.swift in Sources */,
 				AD9998180DB9935038EF3D5A /* ExifFormatters.swift in Sources */,
 				8D6EA52385D28EA1B9D1B25F /* ExifPanelView.swift in Sources */,

--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -270,6 +270,8 @@
 		D4B41663AF0FD67BBA6422DC /* species_list_CN-44.json in Resources */ = {isa = PBXBuildFile; fileRef = BEE856D59E22C64D1ACC4EB6 /* species_list_CN-44.json */; };
 		D562D508BE9BC7F68F390C75 /* species_list_CN-41.json in Resources */ = {isa = PBXBuildFile; fileRef = 83CCD975564900EE5E75D5D4 /* species_list_CN-41.json */; };
 		D5780C7327D0F6E8E642EA4E /* EXIFOffsetReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DC1B03F94601690B7CEE70 /* EXIFOffsetReader.swift */; };
+		C3901B0082034877AE3BC55C /* SonyMakerNoteReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */; };
+		C411A16A447248E699F22041 /* SonyMakerNoteReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */; };
 		D6070A885F8DE451AE897CEE /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1508E6CA44451D6B09FAD8BF /* ImageLoader.swift */; };
 		D716E8F51325F58C77043E42 /* species_list_CN-91.json in Resources */ = {isa = PBXBuildFile; fileRef = 0840F652B0CB17459DB81648 /* species_list_CN-91.json */; };
 		D7C44A0A7CB40C61F07B0E60 /* species_list_EC.json in Resources */ = {isa = PBXBuildFile; fileRef = 13F27D4ED0A3709B0C5A410D /* species_list_EC.json */; };
@@ -465,6 +467,8 @@
 		54A7888D696878AA3088420A /* StarFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarFilterTests.swift; sourceTree = "<group>"; };
 		54FECD0590A3C20869543AFA /* species_list_US-AK.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_US-AK.json"; sourceTree = "<group>"; };
 		55DC1B03F94601690B7CEE70 /* EXIFOffsetReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXIFOffsetReader.swift; sourceTree = "<group>"; };
+		DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonyMakerNoteReader.swift; sourceTree = "<group>"; };
+		91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonyMakerNoteReaderTests.swift; sourceTree = "<group>"; };
 		55FD8383417E1258A87ACD4A /* species_list_FI.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = species_list_FI.json; sourceTree = "<group>"; };
 		56C47414BCC2DF0A9F491F21 /* RegionBounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionBounds.swift; sourceTree = "<group>"; };
 		58AE30066FA590520817814A /* species_list_PE.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = species_list_PE.json; sourceTree = "<group>"; };
@@ -734,6 +738,7 @@
 				229472C67589424B4A5072F0 /* CullingConfigTests.swift */,
 				B2D4034E9FA4FAEA2BFB8D8D /* ExifFormattersTests.swift */,
 				1B0DFDEC10521C90189BDE9F /* EXIFOffsetReaderTests.swift */,
+				91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */,
 				CB9A3A9BD8A728146C3DDD2F /* EXIFReaderTests.swift */,
 				7B7DFAB7427E7D50B6C2F83D /* ExportServiceTests.swift */,
 				42EA84402A20D3F540816789 /* ExposureDetectorTests.swift */,
@@ -792,6 +797,7 @@
 				950F762228EBD7BA89B8B2C0 /* DirectoryScanner.swift */,
 				D6D8E5ED328E7CA41C95BBD9 /* ExifFormatters.swift */,
 				55DC1B03F94601690B7CEE70 /* EXIFOffsetReader.swift */,
+				DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */,
 				8D61960564355CE428DB7AAB /* ExifPanelView.swift */,
 				75A29A263D346C79918EC367 /* EXIFReader.swift */,
 				C9D7B139DADC49E884F6DC14 /* ExportService.swift */,
@@ -1508,6 +1514,7 @@
 				142EF22BA97B679CCFF77E5A /* CullingConfigTests.swift in Sources */,
 				A677967B8F5115A2BA4E50F7 /* DirectoryScannerTests.swift in Sources */,
 				C4C1B719F8B6A6E22DBB1B38 /* EXIFOffsetReaderTests.swift in Sources */,
+				C411A16A447248E699F22041 /* SonyMakerNoteReaderTests.swift in Sources */,
 				1F6EE45CD79999D1EF5491F3 /* EXIFReaderTests.swift in Sources */,
 				C8B71FD5634761985FC15545 /* ExifFormattersTests.swift in Sources */,
 				0248B7B5C0E566EFFBB63CCB /* ExifPanelTests.swift in Sources */,
@@ -1572,6 +1579,7 @@
 				2CF05E13A2B84DFB79CE7DD0 /* DetectionResult.swift in Sources */,
 				2537E1B585BD0EFF83728969 /* DirectoryScanner.swift in Sources */,
 				D5780C7327D0F6E8E642EA4E /* EXIFOffsetReader.swift in Sources */,
+				C3901B0082034877AE3BC55C /* SonyMakerNoteReader.swift in Sources */,
 				E8A2927BC88504E05E879CEC /* EXIFReader.swift in Sources */,
 				AD9998180DB9935038EF3D5A /* ExifFormatters.swift in Sources */,
 				8D6EA52385D28EA1B9D1B25F /* ExifPanelView.swift in Sources */,

--- a/apps/mac-client/SuperPickyApp/DetectionResult.swift
+++ b/apps/mac-client/SuperPickyApp/DetectionResult.swift
@@ -57,6 +57,13 @@ struct KeypointResult: Codable, Sendable {
         let t = InferenceConstants.keypointVisibilityThreshold
         return leftEye.visibility < t && rightEye.visibility < t && beak.visibility < t
     }
+
+    /// Maximum eye visibility — feeds RatingEngine's visibility-weight
+    /// degradation (`max(0.5, min(1.0, vis * 2))`). Mirrors superpicky's
+    /// `kp_result.best_eye_visibility` (`keypoint_detector.py:203`).
+    var bestEyeVisibility: Float {
+        max(leftEye.visibility, rightEye.visibility)
+    }
 }
 
 struct FlightResult: Codable, Sendable {

--- a/apps/mac-client/SuperPickyApp/EXIFOffsetReader.swift
+++ b/apps/mac-client/SuperPickyApp/EXIFOffsetReader.swift
@@ -24,10 +24,10 @@ enum EXIFOffsetReader {
     /// Pure-data entry point. Exposed `internal` for unit testing without
     /// touching the filesystem.
     static func readOffsetTimeOriginal(fromContainer data: Data) -> String? {
-        guard let tiffStart = locateTIFFStart(in: data) else { return nil }
+        guard let tiffStart = TIFFIFDReader.locateTIFFStart(in: data) else { return nil }
         guard data.count >= tiffStart + 8 else { return nil }
 
-        let byteOrder: ByteOrder
+        let byteOrder: TIFFIFDReader.ByteOrder
         switch (data[tiffStart], data[tiffStart + 1]) {
         case (0x49, 0x49): byteOrder = .little
         case (0x4D, 0x4D): byteOrder = .big
@@ -38,11 +38,13 @@ enum EXIFOffsetReader {
 
         let ifd0Offset = Int(byteOrder.read32(data, at: tiffStart + 4))
         // Follow IFD0 → ExifIFD pointer (tag 0x8769).
-        guard let exifIFDOffsetValue = findTagValueField(in: data,
-                                                         tiffStart: tiffStart,
-                                                         ifdRelativeOffset: ifd0Offset,
-                                                         tag: 0x8769,
-                                                         byteOrder: byteOrder) else {
+        guard let exifIFDOffsetValue = TIFFIFDReader.findTagValueField(
+            in: data,
+            tiffStart: tiffStart,
+            ifdRelativeOffset: ifd0Offset,
+            tag: 0x8769,
+            byteOrder: byteOrder
+        ) else {
             return nil
         }
         // Read OffsetTimeOriginal (tag 0x9011) from the ExifIFD.
@@ -53,66 +55,6 @@ enum EXIFOffsetReader {
                             byteOrder: byteOrder)
     }
 
-    // MARK: - Container detection
-
-    /// Offset of the TIFF header within `data`. Bare TIFF/ARW starts at 0;
-    /// JPEG files place the TIFF inside an `APP1` segment after `"Exif\0\0"`.
-    private static func locateTIFFStart(in data: Data) -> Int? {
-        guard data.count >= 4 else { return nil }
-        // Bare TIFF — byte order marker at offset 0.
-        if (data[0] == 0x49 && data[1] == 0x49) || (data[0] == 0x4D && data[1] == 0x4D) {
-            return 0
-        }
-        // JPEG — walk segments looking for APP1 with an Exif header.
-        guard data[0] == 0xFF, data[1] == 0xD8 else { return nil }
-        var cursor = 2
-        while cursor + 4 <= data.count {
-            guard data[cursor] == 0xFF else { return nil }
-            let marker = data[cursor + 1]
-            // SOS (Start of Scan) or EOI means we've passed all metadata.
-            if marker == 0xDA || marker == 0xD9 { return nil }
-            let segmentLength = Int(data[cursor + 2]) << 8 | Int(data[cursor + 3])
-            guard segmentLength >= 2 else { return nil }
-            if marker == 0xE1 {
-                let headerStart = cursor + 4
-                if headerStart + 6 <= data.count,
-                   data[headerStart]     == 0x45,   // 'E'
-                   data[headerStart + 1] == 0x78,   // 'x'
-                   data[headerStart + 2] == 0x69,   // 'i'
-                   data[headerStart + 3] == 0x66,   // 'f'
-                   data[headerStart + 4] == 0x00,
-                   data[headerStart + 5] == 0x00 {
-                    return headerStart + 6
-                }
-            }
-            cursor += 2 + segmentLength
-        }
-        return nil
-    }
-
-    // MARK: - IFD walk
-
-    /// Returns the raw 4-byte "value or offset" field for the given tag.
-    /// Used when we only need a scalar (e.g. the ExifIFD pointer at 0x8769).
-    private static func findTagValueField(in data: Data,
-                                          tiffStart: Int,
-                                          ifdRelativeOffset: Int,
-                                          tag: UInt16,
-                                          byteOrder: ByteOrder) -> UInt32? {
-        let ifdAbsolute = tiffStart + ifdRelativeOffset
-        guard ifdAbsolute + 2 <= data.count else { return nil }
-        let entryCount = Int(byteOrder.read16(data, at: ifdAbsolute))
-        let entriesStart = ifdAbsolute + 2
-        guard entriesStart + entryCount * 12 <= data.count else { return nil }
-        for index in 0..<entryCount {
-            let entry = entriesStart + index * 12
-            if byteOrder.read16(data, at: entry) == tag {
-                return byteOrder.read32(data, at: entry + 8)
-            }
-        }
-        return nil
-    }
-
     /// Returns the ASCII string value of an EXIF tag (type 2), stripping the
     /// trailing null byte(s) the EXIF spec requires. Values ≤ 4 bytes live
     /// inline in the entry; longer values are referenced via an offset from
@@ -121,52 +63,27 @@ enum EXIFOffsetReader {
                                      tiffStart: Int,
                                      ifdRelativeOffset: Int,
                                      tag: UInt16,
-                                     byteOrder: ByteOrder) -> String? {
-        let ifdAbsolute = tiffStart + ifdRelativeOffset
-        guard ifdAbsolute + 2 <= data.count else { return nil }
-        let entryCount = Int(byteOrder.read16(data, at: ifdAbsolute))
-        let entriesStart = ifdAbsolute + 2
-        guard entriesStart + entryCount * 12 <= data.count else { return nil }
-        for index in 0..<entryCount {
-            let entry = entriesStart + index * 12
-            if byteOrder.read16(data, at: entry) != tag { continue }
-            // Type 2 = ASCII. Reject anything else defensively.
-            guard byteOrder.read16(data, at: entry + 2) == 2 else { return nil }
-            let valueCount = Int(byteOrder.read32(data, at: entry + 4))
-            guard valueCount > 0 else { return nil }
-            let bytes: [UInt8]
-            if valueCount <= 4 {
-                bytes = (0..<valueCount).map { data[entry + 8 + $0] }
-            } else {
-                let payloadOffset = tiffStart + Int(byteOrder.read32(data, at: entry + 8))
-                guard payloadOffset + valueCount <= data.count else { return nil }
-                bytes = Array(data[payloadOffset..<(payloadOffset + valueCount)])
-            }
-            let trimmed = bytes.prefix(while: { $0 != 0 })
-            return String(decoding: trimmed, as: UTF8.self)
+                                     byteOrder: TIFFIFDReader.ByteOrder) -> String? {
+        guard let entry = TIFFIFDReader.findEntry(in: data,
+                                                    tiffStart: tiffStart,
+                                                    ifdRelativeOffset: ifdRelativeOffset,
+                                                    tag: tag,
+                                                    byteOrder: byteOrder) else {
+            return nil
         }
-        return nil
-    }
-
-    // MARK: - Byte order
-
-    enum ByteOrder {
-        case little, big
-
-        func read16(_ data: Data, at offset: Int) -> UInt16 {
-            let b0 = UInt16(data[offset])
-            let b1 = UInt16(data[offset + 1])
-            return self == .little ? (b1 << 8) | b0 : (b0 << 8) | b1
+        // Type 2 = ASCII. Reject anything else defensively.
+        guard byteOrder.read16(data, at: entry + 2) == 2 else { return nil }
+        let valueCount = Int(byteOrder.read32(data, at: entry + 4))
+        guard valueCount > 0 else { return nil }
+        let bytes: [UInt8]
+        if valueCount <= 4 {
+            bytes = (0..<valueCount).map { data[entry + 8 + $0] }
+        } else {
+            let payloadOffset = tiffStart + Int(byteOrder.read32(data, at: entry + 8))
+            guard payloadOffset + valueCount <= data.count else { return nil }
+            bytes = Array(data[payloadOffset..<(payloadOffset + valueCount)])
         }
-
-        func read32(_ data: Data, at offset: Int) -> UInt32 {
-            let b0 = UInt32(data[offset])
-            let b1 = UInt32(data[offset + 1])
-            let b2 = UInt32(data[offset + 2])
-            let b3 = UInt32(data[offset + 3])
-            return self == .little
-                ? (b3 << 24) | (b2 << 16) | (b1 << 8) | b0
-                : (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
-        }
+        let trimmed = bytes.prefix(while: { $0 != 0 })
+        return String(decoding: trimmed, as: UTF8.self)
     }
 }

--- a/apps/mac-client/SuperPickyApp/EyeCropSharpness.swift
+++ b/apps/mac-client/SuperPickyApp/EyeCropSharpness.swift
@@ -13,11 +13,18 @@ struct HeadSharpness {
 
     /// Compute head-region sharpness of the bird crop using a circular mask centered on the best eye.
     /// Returns nil if crop is too small to measure.
+    ///
+    /// `segMask`, when supplied, is a `birdCrop.width × birdCrop.height` byte
+    /// array (1 = bird, 0 = background) and is intersected with the head
+    /// circle, matching superpicky's
+    /// `cv2.bitwise_and(circle_mask, seg_mask)` in
+    /// `core/keypoint_detector.py:_calculate_head_sharpness`.
     static func score(
         birdCrop: CGImage,
         leftEyeX: Float?, leftEyeY: Float?, leftEyeVis: Float?,
         rightEyeX: Float?, rightEyeY: Float?, rightEyeVis: Float?,
-        beakX: Float?, beakY: Float?, beakVis: Float?
+        beakX: Float?, beakY: Float?, beakVis: Float?,
+        segMask: [UInt8]? = nil
     ) -> Float? {
         let w = birdCrop.width
         let h = birdCrop.height
@@ -71,11 +78,14 @@ struct HeadSharpness {
         }
         radius = max(10, min(radius, min(w, h) / 2))
 
-        // Compute masked Tenengrad
+        // Compute masked Tenengrad — intersect the head circle with the
+        // YOLO segmentation mask when available so background pixels (sky,
+        // foliage, water) don't contribute their gradient² to the average.
         let score = TenengradSharpness.maskedScore(
             image: birdCrop,
             centerX: eyePx.0, centerY: eyePx.1,
-            radius: radius
+            radius: radius,
+            extraMask: segMask
         )
 
         return bothHidden ? score * lowVisPenalty : score

--- a/apps/mac-client/SuperPickyApp/EyeCropSharpness.swift
+++ b/apps/mac-client/SuperPickyApp/EyeCropSharpness.swift
@@ -19,12 +19,20 @@ struct HeadSharpness {
     /// circle, matching superpicky's
     /// `cv2.bitwise_and(circle_mask, seg_mask)` in
     /// `core/keypoint_detector.py:_calculate_head_sharpness`.
+    ///
+    /// `birdBboxSize`, when supplied, is the `(width, height)` of the YOLO
+    /// detection bbox in inference-image pixels. It's used as the no-beak
+    /// fallback radius (`max(w, h) × 0.15`), preferred over the
+    /// `birdCrop` size which is ~15% larger because of the 1.15× smart-
+    /// square padding. Mirrors the `box` branch in superpicky's
+    /// `_calculate_head_sharpness:248-252,283-290`.
     static func score(
         birdCrop: CGImage,
         leftEyeX: Float?, leftEyeY: Float?, leftEyeVis: Float?,
         rightEyeX: Float?, rightEyeY: Float?, rightEyeVis: Float?,
         beakX: Float?, beakY: Float?, beakVis: Float?,
-        segMask: [UInt8]? = nil
+        segMask: [UInt8]? = nil,
+        birdBboxSize: (width: Int, height: Int)? = nil
     ) -> Float? {
         let w = birdCrop.width
         let h = birdCrop.height
@@ -67,12 +75,21 @@ struct HeadSharpness {
 
         let eyePx = (Int(eye.0 * Float(w)), Int(eye.1 * Float(h)))
 
-        // Compute radius from eye-beak distance × 1.2, or 15% of crop if no beak
+        // Compute radius. Three-branch fallback matches superpicky's
+        // _calculate_head_sharpness:
+        //   1. eye-beak distance × 1.2 (when beak is visible)
+        //   2. YOLO bbox max-side × 0.15 (when bbox is provided)
+        //   3. bird-crop max-side × 0.15 (last-resort fallback;
+        //      bird-crop is ~15% larger than the bbox because of the
+        //      1.15× smart-square padding, so this only matches Python
+        //      when both beak and bbox are absent)
         var radius: Int
         if beakVisible, let bx = beakX, let by = beakY {
             let beakPx = (Int(bx * Float(w)), Int(by * Float(h)))
             let dist = hypot(Float(eyePx.0 - beakPx.0), Float(eyePx.1 - beakPx.1))
             radius = Int(dist * radiusMultiplier)
+        } else if let box = birdBboxSize {
+            radius = Int(Float(max(box.width, box.height)) * noBeakRadiusRatio)
         } else {
             radius = Int(Float(max(w, h)) * noBeakRadiusRatio)
         }

--- a/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
+++ b/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
@@ -211,9 +211,7 @@ struct FocusPointDetector {
             return result
         }
         if (make.contains("OLYMPUS") || make.contains("OM DIGITAL")), let mn = makerNote,
-           let result = parseOlympusFocusPoint(makerNote: mn,
-                                                imageWidth: pixelWidth, imageHeight: pixelHeight,
-                                                orientation: orientation) {
+           let result = parseOlympusFocusPoint(makerNote: mn, orientation: orientation) {
             return result
         }
         if make.contains("FUJIFILM"), let mn = makerNote,
@@ -252,6 +250,20 @@ struct FocusPointDetector {
         return nil
     }
 
+    // MARK: - Brand-parser shared helpers
+
+    /// Returns true when MakerNote.FocusMode reads as manual focus.
+    /// Every brand's manual-focus probe is identical — uppercase the
+    /// FocusMode value and look for "MF"/"MANUAL". Sony adds the
+    /// numeric "1" sentinel, passed via `extraSentinels`.
+    private static func isManualFocus(_ makerNote: [String: Any],
+                                       extraSentinels: [String] = []) -> Bool {
+        guard let raw = makerNote["FocusMode"] else { return false }
+        let modeStr = String(describing: raw).uppercased()
+        if modeStr.contains("MF") || modeStr.contains("MANUAL") { return true }
+        return extraSentinels.contains(modeStr)
+    }
+
     // MARK: - Sony FocusLocation parsing (exposed for testing)
 
     /// Parse a Sony MakerNote dict into a focus point.
@@ -269,13 +281,9 @@ struct FocusPointDetector {
         makerNote: [String: Any],
         orientation: Int
     ) -> FocusPointResult? {
-        // Manual focus → no AF data
-        if let mode = makerNote["FocusMode"] {
-            let modeStr = String(describing: mode).uppercased()
-            if modeStr == "1" || modeStr.contains("MF") || modeStr.contains("MANUAL") {
-                return nil
-            }
-        }
+        // Sony's FocusMode tag uses the numeric sentinel "1" for MF in
+        // addition to the textual MF/MANUAL labels.
+        if isManualFocus(makerNote, extraSentinels: ["1"]) { return nil }
 
         guard let parts = sonyIntArray(makerNote["FocusLocation"]),
               parts.count >= 4 else {
@@ -324,14 +332,9 @@ struct FocusPointDetector {
     /// (`core/focus_point_detector.py:423-534`).
     static func parseOlympusFocusPoint(
         makerNote: [String: Any],
-        imageWidth: Int,
-        imageHeight: Int,
         orientation: Int
     ) -> FocusPointResult? {
-        if let mode = makerNote["FocusMode"] {
-            let modeStr = String(describing: mode).uppercased()
-            if modeStr.contains("MF") || modeStr.contains("MANUAL") { return nil }
-        }
+        if isManualFocus(makerNote) { return nil }
 
         // Path 1: AFPointSelected normalized
         if let raw = makerNote["AFPointSelected"] {
@@ -373,7 +376,6 @@ struct FocusPointDetector {
             return FocusPointResult(x: nx, y: ny, isFocused: true)
         }
 
-        _ = (imageWidth, imageHeight)  // reserved for future raw-px result
         return nil
     }
 
@@ -392,10 +394,7 @@ struct FocusPointDetector {
         imageHeight: Int,
         orientation: Int
     ) -> FocusPointResult? {
-        if let mode = makerNote["FocusMode"] {
-            let modeStr = String(describing: mode).uppercased()
-            if modeStr.contains("MF") || modeStr.contains("MANUAL") { return nil }
-        }
+        if isManualFocus(makerNote) { return nil }
         guard imageWidth > 0, imageHeight > 0,
               let parts = sonyIntArray(makerNote["FocusPixel"]),
               parts.count >= 2 else {
@@ -417,10 +416,7 @@ struct FocusPointDetector {
         makerNote: [String: Any],
         orientation: Int
     ) -> FocusPointResult? {
-        if let mode = makerNote["FocusMode"] {
-            let modeStr = String(describing: mode).uppercased()
-            if modeStr.contains("MF") || modeStr.contains("MANUAL") { return nil }
-        }
+        if isManualFocus(makerNote) { return nil }
         guard let raw = makerNote["AFPointPosition"] else { return nil }
         let str = String(describing: raw)
         if str.isEmpty || str.contains("4.194e") { return nil }
@@ -453,10 +449,7 @@ struct FocusPointDetector {
         model: String,
         orientation: Int
     ) -> FocusPointResult? {
-        if let mode = makerNote["FocusMode"] {
-            let modeStr = String(describing: mode).uppercased()
-            if modeStr.contains("MF") || modeStr.contains("MANUAL") { return nil }
-        }
+        if isManualFocus(makerNote) { return nil }
 
         guard let imgW = (makerNote["AFImageWidth"] as? Int)
                 ?? (makerNote["ExifImageWidth"] as? Int),

--- a/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
+++ b/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
@@ -192,6 +192,22 @@ struct FocusPointDetector {
            let result = parseCanonFocusPoint(makerNote: mn, model: model, orientation: orientation) {
             return result
         }
+        if (make.contains("OLYMPUS") || make.contains("OM DIGITAL")), let mn = makerNote,
+           let result = parseOlympusFocusPoint(makerNote: mn,
+                                                imageWidth: pixelWidth, imageHeight: pixelHeight,
+                                                orientation: orientation) {
+            return result
+        }
+        if make.contains("FUJIFILM"), let mn = makerNote,
+           let result = parseFujifilmFocusPoint(makerNote: mn,
+                                                 imageWidth: pixelWidth, imageHeight: pixelHeight,
+                                                 orientation: orientation) {
+            return result
+        }
+        if make.contains("PANASONIC"), let mn = makerNote,
+           let result = parsePanasonicFocusPoint(makerNote: mn, orientation: orientation) {
+            return result
+        }
         if make.contains("NIKON"), let mn = makerNote,
            let result = parseNikonFocusPoint(makerNote: mn, orientation: orientation) {
             return result
@@ -275,6 +291,127 @@ struct FocusPointDetector {
             return ints.isEmpty ? nil : ints
         }
         return nil
+    }
+
+    // MARK: - Olympus AF parsing (exposed for testing)
+
+    /// Parse an Olympus / OM System MakerNote dict into a focus point.
+    ///
+    /// Olympus exposes the AF point in two forms; we prefer the first:
+    /// 1. `AFPointSelected` — normalized `"x y"` (0.0-1.0). Sometimes wrapped
+    ///    as `"(50%,50%)"` on certain bodies.
+    /// 2. `AFFocusArea` (pixel `"x y w h"`) + `AFFrameSize` (`"w h"`).
+    ///
+    /// Mirrors superpicky's `_detect_olympus`
+    /// (`core/focus_point_detector.py:423-534`).
+    static func parseOlympusFocusPoint(
+        makerNote: [String: Any],
+        imageWidth: Int,
+        imageHeight: Int,
+        orientation: Int
+    ) -> FocusPointResult? {
+        if let mode = makerNote["FocusMode"] {
+            let modeStr = String(describing: mode).uppercased()
+            if modeStr.contains("MF") || modeStr.contains("MANUAL") { return nil }
+        }
+
+        // Path 1: AFPointSelected normalized
+        if let raw = makerNote["AFPointSelected"] {
+            let str = String(describing: raw)
+            if !str.isEmpty, str != "0 0" {
+                if str.contains("%") {
+                    // "(50%,50%)"
+                    let digits = str.split(whereSeparator: { !$0.isNumber })
+                                    .compactMap { Int($0) }
+                    if digits.count >= 2 {
+                        var nx = Float(digits[0]) / 100
+                        var ny = Float(digits[1]) / 100
+                        (nx, ny) = applyOrientationCorrection(x: nx, y: ny, orientation: orientation)
+                        return FocusPointResult(x: nx, y: ny, isFocused: true)
+                    }
+                } else {
+                    let parts = str.split(whereSeparator: { $0.isWhitespace })
+                                   .compactMap { Float($0) }
+                    if parts.count >= 2 {
+                        var nx = parts[0], ny = parts[1]
+                        (nx, ny) = applyOrientationCorrection(x: nx, y: ny, orientation: orientation)
+                        return FocusPointResult(x: nx, y: ny, isFocused: true)
+                    }
+                }
+            }
+        }
+
+        // Path 2: AFFocusArea pixel coords + AFFrameSize
+        if let area = sonyIntArray(makerNote["AFFocusArea"]),
+           let frame = sonyIntArray(makerNote["AFFrameSize"]),
+           area.count >= 4, frame.count >= 2 {
+            let (frameW, frameH) = (frame[0], frame[1])
+            guard frameW > 0, frameH > 0 else { return nil }
+            let centerX = area[0] + area[2] / 2
+            let centerY = area[1] + area[3] / 2
+            var nx = Float(centerX) / Float(frameW)
+            var ny = Float(centerY) / Float(frameH)
+            (nx, ny) = applyOrientationCorrection(x: nx, y: ny, orientation: orientation)
+            return FocusPointResult(x: nx, y: ny, isFocused: true)
+        }
+
+        _ = (imageWidth, imageHeight)  // reserved for future raw-px result
+        return nil
+    }
+
+    // MARK: - Fujifilm AF parsing (exposed for testing)
+
+    /// Parse a Fujifilm X / GFX MakerNote dict into a focus point.
+    ///
+    /// Fujifilm stores `FocusPixel` as `"x y"` in **embedded-JPEG-preview**
+    /// pixel coordinates (not the full RAW frame). The reference frame is
+    /// `ExifImageWidth` / `ExifImageHeight` from the EXIF dict — mirrors
+    /// the V3.9 fix in `superpicky/core/focus_point_detector.py:566-580`
+    /// where using `RawImageCroppedSize` instead caused a ~0.29 mis-norm.
+    static func parseFujifilmFocusPoint(
+        makerNote: [String: Any],
+        imageWidth: Int,
+        imageHeight: Int,
+        orientation: Int
+    ) -> FocusPointResult? {
+        if let mode = makerNote["FocusMode"] {
+            let modeStr = String(describing: mode).uppercased()
+            if modeStr.contains("MF") || modeStr.contains("MANUAL") { return nil }
+        }
+        guard imageWidth > 0, imageHeight > 0,
+              let parts = sonyIntArray(makerNote["FocusPixel"]),
+              parts.count >= 2 else {
+            return nil
+        }
+        let rawX = parts[0], rawY = parts[1]
+        var nx = Float(rawX) / Float(imageWidth)
+        var ny = Float(rawY) / Float(imageHeight)
+        (nx, ny) = applyOrientationCorrection(x: nx, y: ny, orientation: orientation)
+        return FocusPointResult(x: nx, y: ny, isFocused: true)
+    }
+
+    // MARK: - Panasonic AF parsing (exposed for testing)
+
+    /// Parse a Panasonic LUMIX S / G MakerNote dict into a focus point.
+    /// `AFPointPosition` is normalized `"x y"`; the value `4.194e+006`
+    /// is Panasonic's "no AF point" sentinel and must be rejected.
+    static func parsePanasonicFocusPoint(
+        makerNote: [String: Any],
+        orientation: Int
+    ) -> FocusPointResult? {
+        if let mode = makerNote["FocusMode"] {
+            let modeStr = String(describing: mode).uppercased()
+            if modeStr.contains("MF") || modeStr.contains("MANUAL") { return nil }
+        }
+        guard let raw = makerNote["AFPointPosition"] else { return nil }
+        let str = String(describing: raw)
+        if str.isEmpty || str.contains("4.194e") { return nil }
+        let parts = str.split(whereSeparator: { $0.isWhitespace })
+                       .compactMap { Float($0) }
+        guard parts.count >= 2 else { return nil }
+        var nx = parts[0], ny = parts[1]
+        (nx, ny) = applyOrientationCorrection(x: nx, y: ny, orientation: orientation)
+        return FocusPointResult(x: nx, y: ny, isFocused: true)
     }
 
     // MARK: - Canon AF parsing (exposed for testing)

--- a/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
+++ b/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreGraphics
 import ImageIO
+import SuperPickyInference
 
 /// Detects focus point from RAW EXIF and computes sharpness/aesthetics weights
 /// based on where the focus falls relative to the bird.
@@ -204,6 +205,32 @@ struct FocusPointDetector {
         }
 
         return nil  // No focus data → caller gets .unknown
+    }
+
+    // MARK: - Head radius (exposed for testing)
+
+    /// Compute the head-circle radius (as a fraction of `max(bbox.w, bbox.h)`)
+    /// for the .headFocus tier, mirroring HeadSharpness's radius logic:
+    ///
+    /// - `beak visible` → eye-beak distance × 1.2 (in bird-crop coordinates,
+    ///   used as a bbox-relative fraction by the existing `computeWeights`
+    ///   math).
+    /// - `beak hidden`  → 0.15, the no-beak fallback constant.
+    ///
+    /// Mirrors superpicky's `head_radius_val` derivation in
+    /// `keypoint_detector.py:282-290`.
+    static func headRadiusFraction(
+        beakVisibility: Float,
+        eye: (x: Float, y: Float),
+        beak: (x: Float, y: Float),
+        visibilityThreshold: Float = InferenceConstants.keypointVisibilityThreshold,
+        radiusMultiplier: Float = 1.2,
+        noBeakRatio: Float = 0.15
+    ) -> Float {
+        if beakVisibility >= visibilityThreshold {
+            return hypot(eye.x - beak.x, eye.y - beak.y) * radiusMultiplier
+        }
+        return noBeakRatio
     }
 
     // MARK: - SubjectArea parsing (exposed for testing)

--- a/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
+++ b/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
@@ -178,13 +178,18 @@ struct FocusPointDetector {
         let tiffDict = props["{TIFF}"] as? [String: Any]
         let orientation = (tiffDict?["Orientation"] as? Int) ?? 1
         let make = ((tiffDict?["Make"] as? String) ?? "").uppercased()
+        let model = (tiffDict?["Model"] as? String) ?? ""
 
         let makerNote = props["{MakerNote}"] as? [String: Any]
 
         // Brand-specific MakerNote parsers (matches superpicky's
-        // _detect_sony / _detect_nikon dispatch in focus_point_detector.py).
+        // _detect_<brand> dispatch in focus_point_detector.py).
         if make.contains("SONY"), let mn = makerNote,
            let result = parseSonyFocusPoint(makerNote: mn, orientation: orientation) {
+            return result
+        }
+        if make.contains("CANON"), let mn = makerNote,
+           let result = parseCanonFocusPoint(makerNote: mn, model: model, orientation: orientation) {
             return result
         }
         if make.contains("NIKON"), let mn = makerNote,
@@ -270,6 +275,86 @@ struct FocusPointDetector {
             return ints.isEmpty ? nil : ints
         }
         return nil
+    }
+
+    // MARK: - Canon AF parsing (exposed for testing)
+
+    /// Parse a Canon MakerNote dict into a focus point.
+    ///
+    /// Canon stores AF point positions as **offsets from image center**:
+    /// - `AFAreaXPositions` / `AFAreaYPositions` — space-separated ints,
+    ///   one entry per AF point.
+    /// - `AFImageWidth` / `AFImageHeight` — reference frame for the offsets.
+    /// - `AFPointsInFocus` — bitmask ("1 0 0 0 …") or comma-separated
+    ///   indices ("0,1") indicating which AF points actually locked.
+    /// - Y axis is inverted on EOS bodies (DSLR/mirrorless) and normal on
+    ///   compact bodies (PowerShot/IXUS/ELPH); detected from the `Model` tag.
+    /// - `FocusMode` containing "MF"/"MANUAL" → manual focus, no AF data.
+    ///
+    /// Mirrors superpicky's `_detect_canon` in
+    /// `core/focus_point_detector.py:307-421`.
+    static func parseCanonFocusPoint(
+        makerNote: [String: Any],
+        model: String,
+        orientation: Int
+    ) -> FocusPointResult? {
+        if let mode = makerNote["FocusMode"] {
+            let modeStr = String(describing: mode).uppercased()
+            if modeStr.contains("MF") || modeStr.contains("MANUAL") { return nil }
+        }
+
+        guard let imgW = (makerNote["AFImageWidth"] as? Int)
+                ?? (makerNote["ExifImageWidth"] as? Int),
+              let imgH = (makerNote["AFImageHeight"] as? Int)
+                ?? (makerNote["ExifImageHeight"] as? Int),
+              imgW > 0, imgH > 0 else {
+            return nil
+        }
+
+        guard let xList = sonyIntArray(makerNote["AFAreaXPositions"]),
+              let yList = sonyIntArray(makerNote["AFAreaYPositions"]),
+              !xList.isEmpty, !yList.isEmpty else {
+            return nil
+        }
+
+        // Resolve which AF point locked. Two encodings:
+        //   "1 0 0 0 …"  → bitmask, indices where value==1 are in focus
+        //   "0,1"        → comma-separated index list
+        var focusIndices: [Int] = []
+        if let raw = makerNote["AFPointsInFocus"] {
+            let str = String(describing: raw).trimmingCharacters(in: .whitespaces)
+            if !str.isEmpty {
+                if str.contains(",") {
+                    focusIndices = str.split(separator: ",")
+                        .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+                } else {
+                    let parts = str.split(whereSeparator: { $0.isWhitespace })
+                    focusIndices = parts.enumerated()
+                        .filter { $1 == "1" || $1 == "1.0" }
+                        .map { $0.offset }
+                }
+            }
+        }
+        let idx = (focusIndices.first.flatMap { $0 < xList.count ? $0 : nil }) ?? 0
+        guard idx < yList.count else { return nil }
+
+        // Y axis: EOS bodies invert, compact bodies don't.
+        let modelUpper = model.uppercased()
+        let isCompact = modelUpper.contains("POWERSHOT")
+            || modelUpper.contains("IXUS")
+            || modelUpper.contains("ELPH")
+        let yDirection = isCompact ? 1 : -1
+
+        let rawX = imgW / 2 + xList[idx]
+        let rawY = imgH / 2 + yList[idx] * yDirection
+
+        var normX = Float(rawX) / Float(imgW)
+        var normY = Float(rawY) / Float(imgH)
+        (normX, normY) = applyOrientationCorrection(x: normX, y: normY, orientation: orientation)
+
+        // Locked iff at least one AFPointsInFocus index resolved.
+        let isFocused = !focusIndices.isEmpty
+        return FocusPointResult(x: normX, y: normY, isFocused: isFocused)
     }
 
     // MARK: - Nikon AF parsing (exposed for testing)

--- a/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
+++ b/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
@@ -72,8 +72,11 @@ struct FocusPointDetector {
     /// Variant that consumes a pre-loaded `CGImageSource` properties dict,
     /// so the pipeline can open the file once per photo and fan the dict
     /// out to every consumer (EXIFReader, this detector, …).
+    /// `filePath` is optional; when provided it enables raw-byte fallbacks
+    /// for tags ImageIO drops (Sony MakerNote in particular).
     static func computeWeights(
         properties: [String: Any],
+        filePath: String? = nil,
         birdBbox: CGRect,
         eyeCenter: (x: Float, y: Float)?,
         headRadiusFraction: Float,
@@ -81,7 +84,7 @@ struct FocusPointDetector {
         maskWidth: Int = 0,
         maskHeight: Int = 0
     ) -> FocusWeights {
-        guard let focusResult = readFocusPoint(properties: properties) else {
+        guard let focusResult = readFocusPoint(properties: properties, filePath: filePath) else {
             return .unknown
         }
         return computeWeights(
@@ -161,17 +164,22 @@ struct FocusPointDetector {
     /// Read focus point from image EXIF.
     /// Brand-dispatches by `{TIFF}.Make`:
     /// - **Sony**: parses MakerNote `FocusLocation` ("imgW imgH x y") and
-    ///   `FocusFrameSize` for the focus-validity flag.
+    ///   `FocusFrameSize` for the focus-validity flag. Apple's ImageIO
+    ///   doesn't surface Sony MakerNote, so we fall back to a raw IFD
+    ///   walker (`SonyMakerNoteReader`) on the file bytes.
     /// - **Nikon**: parses MakerNote `AFAreaXPosition` / `AFImageWidth`.
     /// - **Other / unknown**: falls through to standard EXIF `SubjectArea`.
     /// Returns nil when no AF data is available.
     static func readFocusPoint(filePath: String) -> FocusPointResult? {
         guard let props = ImageProperties.load(filePath: filePath) else { return nil }
-        return readFocusPoint(properties: props)
+        return readFocusPoint(properties: props, filePath: filePath)
     }
 
     /// Parse the focus point from a pre-loaded properties dict.
-    static func readFocusPoint(properties props: [String: Any]) -> FocusPointResult? {
+    /// `filePath`, when supplied, enables raw-byte fallbacks for tags
+    /// Apple's ImageIO doesn't surface (e.g. Sony MakerNote).
+    static func readFocusPoint(properties props: [String: Any],
+                               filePath: String? = nil) -> FocusPointResult? {
         let pixelWidth = (props["PixelWidth"] as? Int) ?? 0
         let pixelHeight = (props["PixelHeight"] as? Int) ?? 0
 
@@ -184,9 +192,19 @@ struct FocusPointDetector {
 
         // Brand-specific MakerNote parsers (matches superpicky's
         // _detect_<brand> dispatch in focus_point_detector.py).
-        if make.contains("SONY"), let mn = makerNote,
-           let result = parseSonyFocusPoint(makerNote: mn, orientation: orientation) {
-            return result
+        if make.contains("SONY") {
+            // ImageIO surfaces Sony MakerNote on some macOS versions but
+            // not others; try the dict first, then fall back to a raw
+            // TIFF IFD walker on the file bytes.
+            if let mn = makerNote,
+               let result = parseSonyFocusPoint(makerNote: mn, orientation: orientation) {
+                return result
+            }
+            if let path = filePath,
+               let mn = SonyMakerNoteReader.readFocusData(from: path),
+               let result = parseSonyFocusPoint(makerNote: mn, orientation: orientation) {
+                return result
+            }
         }
         if make.contains("CANON"), let mn = makerNote,
            let result = parseCanonFocusPoint(makerNote: mn, model: model, orientation: orientation) {

--- a/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
+++ b/apps/mac-client/SuperPickyApp/FocusPointDetector.swift
@@ -159,7 +159,11 @@ struct FocusPointDetector {
     // MARK: - EXIF reading
 
     /// Read focus point from image EXIF.
-    /// Supports: Sony (SubjectArea), Nikon (MakerNote AF), generic SubjectArea.
+    /// Brand-dispatches by `{TIFF}.Make`:
+    /// - **Sony**: parses MakerNote `FocusLocation` ("imgW imgH x y") and
+    ///   `FocusFrameSize` for the focus-validity flag.
+    /// - **Nikon**: parses MakerNote `AFAreaXPosition` / `AFImageWidth`.
+    /// - **Other / unknown**: falls through to standard EXIF `SubjectArea`.
     /// Returns nil when no AF data is available.
     static func readFocusPoint(filePath: String) -> FocusPointResult? {
         guard let props = ImageProperties.load(filePath: filePath) else { return nil }
@@ -171,27 +175,30 @@ struct FocusPointDetector {
         let pixelWidth = (props["PixelWidth"] as? Int) ?? 0
         let pixelHeight = (props["PixelHeight"] as? Int) ?? 0
 
-        // Get orientation for rotation correction
         let tiffDict = props["{TIFF}"] as? [String: Any]
         let orientation = (tiffDict?["Orientation"] as? Int) ?? 1
+        let make = ((tiffDict?["Make"] as? String) ?? "").uppercased()
 
-        // Try MakerNote (brand-specific AF data)
-        if let makerNote = props["{MakerNote}"] as? [String: Any] {
-            // Nikon: AFAreaXPosition/AFAreaYPosition + AFImageWidth/AFImageHeight
-            if let afX = makerNote["AFAreaXPosition"] as? Int,
-               let afY = makerNote["AFAreaYPosition"] as? Int,
-               let afW = makerNote["AFImageWidth"] as? Int,
-               let afH = makerNote["AFImageHeight"] as? Int,
-               afW > 0, afH > 0 {
-                var normX = Float(afX) / Float(afW)
-                var normY = Float(afY) / Float(afH)
-                (normX, normY) = applyOrientationCorrection(x: normX, y: normY, orientation: orientation)
-                let focusResult = makerNote["FocusResult"] as? Int
-                return FocusPointResult(x: normX, y: normY, isFocused: focusResult != 0)
-            }
+        let makerNote = props["{MakerNote}"] as? [String: Any]
+
+        // Brand-specific MakerNote parsers (matches superpicky's
+        // _detect_sony / _detect_nikon dispatch in focus_point_detector.py).
+        if make.contains("SONY"), let mn = makerNote,
+           let result = parseSonyFocusPoint(makerNote: mn, orientation: orientation) {
+            return result
+        }
+        if make.contains("NIKON"), let mn = makerNote,
+           let result = parseNikonFocusPoint(makerNote: mn, orientation: orientation) {
+            return result
+        }
+        // Generic Nikon match for files where Make is missing but the
+        // MakerNote layout is Nikon's — covers older NEFs.
+        if let mn = makerNote,
+           let result = parseNikonFocusPoint(makerNote: mn, orientation: orientation) {
+            return result
         }
 
-        // Try EXIF SubjectArea (standard field: [x, y] or [x, y, d] or [x, y, w, h])
+        // Standard EXIF SubjectArea fallback ([x, y] / [x, y, d] / [x, y, w, h]).
         if let exif = props["{Exif}"] as? [String: Any],
            let subjectArea = exif["SubjectArea"] as? [NSNumber], subjectArea.count >= 2 {
             let values = subjectArea.map { $0.intValue }
@@ -199,12 +206,93 @@ struct FocusPointDetector {
                 var normX = parsed.x
                 var normY = parsed.y
                 (normX, normY) = applyOrientationCorrection(x: normX, y: normY, orientation: orientation)
-                // SubjectArea presence implies AF was used; assume focused unless other indicators
                 return FocusPointResult(x: normX, y: normY, isFocused: true)
             }
         }
 
-        return nil  // No focus data → caller gets .unknown
+        return nil
+    }
+
+    // MARK: - Sony FocusLocation parsing (exposed for testing)
+
+    /// Parse a Sony MakerNote dict into a focus point.
+    ///
+    /// Sony A1/A7Rx/A9 expose:
+    /// - `FocusLocation` — `"imgW imgH focusX focusY"` (4 ints, image-pixel coords)
+    /// - `FocusFrameSize` — `"width height validity"` (3 ints; validity 0 → AF didn't lock)
+    /// - `FocusMode` — `"1"` or string containing `MF`/`MANUAL` → manual focus, no AF data
+    ///
+    /// Both string and array bridgings are accepted because ImageIO and
+    /// exiftool surface these tags in different shapes depending on macOS version.
+    /// Mirrors superpicky's `_detect_sony` in
+    /// `core/focus_point_detector.py:237-305`.
+    static func parseSonyFocusPoint(
+        makerNote: [String: Any],
+        orientation: Int
+    ) -> FocusPointResult? {
+        // Manual focus → no AF data
+        if let mode = makerNote["FocusMode"] {
+            let modeStr = String(describing: mode).uppercased()
+            if modeStr == "1" || modeStr.contains("MF") || modeStr.contains("MANUAL") {
+                return nil
+            }
+        }
+
+        guard let parts = sonyIntArray(makerNote["FocusLocation"]),
+              parts.count >= 4 else {
+            return nil
+        }
+        let imgW = parts[0], imgH = parts[1]
+        let rawX = parts[2], rawY = parts[3]
+        guard imgW > 0, imgH > 0 else { return nil }
+
+        var normX = Float(rawX) / Float(imgW)
+        var normY = Float(rawY) / Float(imgH)
+        (normX, normY) = applyOrientationCorrection(x: normX, y: normY, orientation: orientation)
+
+        // FocusFrameSize[2] != 0 → AF locked. Default focused=true when the
+        // tag is absent (Python's "no flag → conservative assume focused").
+        var isFocused = true
+        if let frame = sonyIntArray(makerNote["FocusFrameSize"]), frame.count >= 3 {
+            isFocused = frame[2] != 0
+        }
+        return FocusPointResult(x: normX, y: normY, isFocused: isFocused)
+    }
+
+    /// Tolerant int-array bridging for Sony MakerNote tags, which surface
+    /// as either a space-separated string (exiftool form) or an `[NSNumber]`
+    /// (ImageIO form depending on macOS version).
+    private static func sonyIntArray(_ value: Any?) -> [Int]? {
+        if let arr = value as? [NSNumber] { return arr.map { $0.intValue } }
+        if let str = value as? String {
+            let parts = str.split(whereSeparator: { $0.isWhitespace })
+            let ints = parts.compactMap { Int($0) }
+            return ints.isEmpty ? nil : ints
+        }
+        return nil
+    }
+
+    // MARK: - Nikon AF parsing (exposed for testing)
+
+    /// Parse a Nikon MakerNote dict into a focus point.
+    /// Nikon stores `AFAreaXPosition`/`AFAreaYPosition` against
+    /// `AFImageWidth`/`AFImageHeight`; `FocusResult != 0` indicates lock.
+    static func parseNikonFocusPoint(
+        makerNote: [String: Any],
+        orientation: Int
+    ) -> FocusPointResult? {
+        guard let afX = makerNote["AFAreaXPosition"] as? Int,
+              let afY = makerNote["AFAreaYPosition"] as? Int,
+              let afW = makerNote["AFImageWidth"] as? Int,
+              let afH = makerNote["AFImageHeight"] as? Int,
+              afW > 0, afH > 0 else {
+            return nil
+        }
+        var normX = Float(afX) / Float(afW)
+        var normY = Float(afY) / Float(afH)
+        (normX, normY) = applyOrientationCorrection(x: normX, y: normY, orientation: orientation)
+        let focusResult = makerNote["FocusResult"] as? Int
+        return FocusPointResult(x: normX, y: normY, isFocused: focusResult != 0)
     }
 
     // MARK: - Head radius (exposed for testing)

--- a/apps/mac-client/SuperPickyApp/LaplacianSharpness.swift
+++ b/apps/mac-client/SuperPickyApp/LaplacianSharpness.swift
@@ -18,10 +18,18 @@ enum TenengradSharpness {
     }
 
     /// Sharpness within a circular mask (for head-region measurement).
-    static func maskedScore(image: CGImage, centerX: Int, centerY: Int, radius: Int) -> Float {
+    ///
+    /// `extraMask`, when supplied, must be a `width × height` row-major byte
+    /// array; pixels with a zero entry are skipped. Used to intersect the
+    /// head circle with the YOLO segmentation mask so background pixels
+    /// outside the bird body don't contribute, mirroring superpicky's
+    /// `cv2.bitwise_and(circle_mask, seg_mask)`.
+    static func maskedScore(image: CGImage, centerX: Int, centerY: Int, radius: Int,
+                            extraMask: [UInt8]? = nil) -> Float {
         let w = image.width
         let h = image.height
         guard w > 2 && h > 2 && radius > 1 else { return 0 }
+        if let m = extraMask, m.count != w * h { return 0 }
 
         guard let src = grayscaleFloats(from: image) else { return 0 }
 
@@ -42,6 +50,7 @@ enum TenengradSharpness {
             for x in xMin...xMax {
                 let dx = x - centerX
                 guard dx * dx + dy * dy <= r2 else { continue }
+                if let m = extraMask, m[row0 + x] == 0 { continue }
 
                 let gx = -src[rowM + x - 1] + src[rowM + x + 1]
                        + -2 * src[row0 + x - 1] + 2 * src[row0 + x + 1]

--- a/apps/mac-client/SuperPickyApp/PhotoRatingPredictor.swift
+++ b/apps/mac-client/SuperPickyApp/PhotoRatingPredictor.swift
@@ -21,11 +21,18 @@ enum PhotoRatingPredictor {
             sharpness: photo.sharpnessScore ?? 0,
             aesthetics: photo.aestheticsScore,
             allKeypointsHidden: allKeypointsHidden(photo),
+            bestEyeVisibility: bestEyeVisibility(photo),
             isOverexposed: photo.exposureStatus == ExposureStatus.overexposed.rawValue,
             isUnderexposed: photo.exposureStatus == ExposureStatus.underexposed.rawValue,
             isFlying: photo.isFlying,
             config: config
         ).rating
+    }
+
+    /// `max(leftEyeVis, rightEyeVis)` — feeds RatingEngine's visibility
+    /// degradation. Nil eye visibilities are treated as 0.
+    static func bestEyeVisibility(_ photo: Photo) -> Float {
+        max(photo.leftEyeVis ?? 0, photo.rightEyeVis ?? 0)
     }
 
     /// Every keypoint visibility (nil treated as 0) falls below the

--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -586,7 +586,17 @@ final class PipelineCoordinator: @unchecked Sendable {
         photo.isFlying = flight.isFlying
         photo.flightConfidence = flight.confidence
 
-        // Head-region sharpness (circular mask around eye, matches superpicky)
+        // Head-region sharpness (circular mask around eye, matches superpicky).
+        // Build a bird-crop-aligned segmentation mask so the head circle is
+        // intersected with the YOLO seg mask, matching the
+        // `cv2.bitwise_and(circle_mask, seg_mask)` step in
+        // `superpicky/core/keypoint_detector.py:_calculate_head_sharpness`.
+        let birdCropSegMask = Self.birdCropAlignedSegMask(
+            yoloMask: bird.mask,
+            inferImage: image,
+            bbox: bird.bbox,
+            birdCropSize: birdCrop.width
+        )
         let headSharpness = HeadSharpness.score(
             birdCrop: birdCrop,
             leftEyeX: keypoints.leftEye.x, leftEyeY: keypoints.leftEye.y,
@@ -594,7 +604,8 @@ final class PipelineCoordinator: @unchecked Sendable {
             rightEyeX: keypoints.rightEye.x, rightEyeY: keypoints.rightEye.y,
             rightEyeVis: keypoints.rightEye.visibility,
             beakX: keypoints.beak.x, beakY: keypoints.beak.y,
-            beakVis: keypoints.beak.visibility
+            beakVis: keypoints.beak.visibility,
+            segMask: birdCropSegMask
         ) ?? TenengradSharpness.score(image: birdCrop) // fallback to full-crop
 
         // `imageProps` (loaded at the top) also feeds the ISO sharpness
@@ -689,6 +700,96 @@ final class PipelineCoordinator: @unchecked Sendable {
         guard let iso, iso > Int(isoBase) else { return 1.0 }
         let penalty = isoPenaltyFactor * log2(Float(iso) / isoBase)
         return max(isoMinFactor, 1.0 - penalty)
+    }
+
+    /// Build a binary segmentation mask aligned with the bird crop produced
+    /// by `image.smartSquareBirdCrop(bbox:)`. Each output byte is 1 iff the
+    /// corresponding bird-crop pixel maps to a bird-pixel in the 160×160 YOLO
+    /// seg mask, accounting for letterboxing in both directions.
+    ///
+    /// Parity reference: superpicky's
+    /// `bird_crop_mask = bird_mask_orig[y_orig:y_orig+h, x_orig:x_orig+w]`
+    /// (`core/photo_processor.py:1742`). The Python path nearest-neighbor
+    /// upsamples the 160×160 YOLO mask to the original image resolution and
+    /// slices by bbox; we sample per pixel here so we can reuse the existing
+    /// `bird.mask` blob without an intermediate full-resolution buffer.
+    ///
+    /// Returns nil if mask data is malformed or the bird crop geometry is
+    /// degenerate.
+    static func birdCropAlignedSegMask(
+        yoloMask: Data,
+        inferImage: CGImage,
+        bbox: CGRect,
+        birdCropSize: Int,
+        paddingRatio: CGFloat = 0.15
+    ) -> [UInt8]? {
+        guard !yoloMask.isEmpty, birdCropSize > 0 else { return nil }
+        let maskSide = Int(Double(yoloMask.count).squareRoot().rounded())
+        guard maskSide > 0, maskSide * maskSide == yoloMask.count else { return nil }
+
+        let imgW = inferImage.width
+        let imgH = inferImage.height
+        guard imgW > 0, imgH > 0 else { return nil }
+
+        // Replicate `smartSquareBirdCrop`'s integer geometry so we can map
+        // bird-crop pixels back to inference-image pixels exactly.
+        let px1 = Int((bbox.origin.x * CGFloat(imgW)).rounded(.down))
+        let py1 = Int((bbox.origin.y * CGFloat(imgH)).rounded(.down))
+        let px2 = Int(((bbox.origin.x + bbox.size.width)  * CGFloat(imgW)).rounded(.up))
+        let py2 = Int(((bbox.origin.y + bbox.size.height) * CGFloat(imgH)).rounded(.up))
+        let bboxW = px2 - px1, bboxH = py2 - py1
+        guard bboxW > 0, bboxH > 0 else { return nil }
+        let maxSide = max(bboxW, bboxH)
+        let targetSide = Int(Double(maxSide) * (1.0 + Double(paddingRatio)))
+        let cx = (px1 + px2) / 2, cy = (py1 + py2) / 2
+        let half = targetSide / 2
+        let cropX1 = max(0, cx - half), cropY1 = max(0, cy - half)
+        let cropX2 = min(imgW, cx + half), cropY2 = min(imgH, cy + half)
+        let cropW = cropX2 - cropX1, cropH = cropY2 - cropY1
+        guard cropW > 0, cropH > 0 else { return nil }
+        let sqSize = max(cropW, cropH)
+        // Sanity-check against the actual CGImage we got back from
+        // smartSquareBirdCrop — drift here would silently desynchronize the
+        // mask from the pixels.
+        guard sqSize == birdCropSize else { return nil }
+        let offX = (sqSize - cropW) / 2, offY = (sqSize - cropH) / 2
+
+        // YOLO letterbox params: inference image is scaled to fit a
+        // `yoloInputSize × yoloInputSize` square with symmetric padding,
+        // and the mask is at `maskSide` resolution (160×160 by default,
+        // i.e. yoloInputSize/4).
+        let yoloSize = Float(InferenceConstants.yoloInputSize)
+        let origW = Float(imgW), origH = Float(imgH)
+        let scale = min(yoloSize / origW, yoloSize / origH)
+        let padLeft = (yoloSize - origW * scale) / 2
+        let padTop  = (yoloSize - origH * scale) / 2
+        let maskScale = Float(maskSide) / yoloSize
+
+        var out = [UInt8](repeating: 0, count: sqSize * sqSize)
+        yoloMask.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            let mask = raw.bindMemory(to: UInt8.self)
+            for y in 0..<sqSize {
+                let inCanvasY = y - offY
+                if inCanvasY < 0 || inCanvasY >= cropH { continue }
+                let infY = Float(cropY1 + inCanvasY)
+                let yoloY = infY * scale + padTop
+                let my = Int((yoloY * maskScale).rounded(.down))
+                guard my >= 0, my < maskSide else { continue }
+                let mRow = my * maskSide
+                let outRow = y * sqSize
+                for x in 0..<sqSize {
+                    let inCanvasX = x - offX
+                    if inCanvasX < 0 || inCanvasX >= cropW { continue }
+                    let infX = Float(cropX1 + inCanvasX)
+                    let yoloX = infX * scale + padLeft
+                    let mx = Int((yoloX * maskScale).rounded(.down))
+                    if mx >= 0, mx < maskSide {
+                        out[outRow + x] = mask[mRow + mx]
+                    }
+                }
+            }
+        }
+        return out
     }
 
     /// JSON-encode a value to a UTF-8 string for storage in the

--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -664,6 +664,7 @@ final class PipelineCoordinator: @unchecked Sendable {
             if let props = imageProps {
                 return FocusPointDetector.computeWeights(
                     properties: props,
+                    filePath: fileURL.path,
                     birdBbox: bird.bbox,
                     eyeCenter: bestEye,
                     headRadiusFraction: headRadiusFraction,

--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -597,6 +597,13 @@ final class PipelineCoordinator: @unchecked Sendable {
             bbox: bird.bbox,
             birdCropSize: birdCrop.width
         )
+        // YOLO bbox in inference-image pixel space — feeds HeadSharpness's
+        // no-beak radius fallback (matches superpicky's `box[2]/box[3]`
+        // branch in keypoint_detector.py:248-252).
+        let bboxPx = (
+            width:  Int((bird.bbox.width  * CGFloat(image.width )).rounded()),
+            height: Int((bird.bbox.height * CGFloat(image.height)).rounded())
+        )
         let headSharpness = HeadSharpness.score(
             birdCrop: birdCrop,
             leftEyeX: keypoints.leftEye.x, leftEyeY: keypoints.leftEye.y,
@@ -605,7 +612,8 @@ final class PipelineCoordinator: @unchecked Sendable {
             rightEyeVis: keypoints.rightEye.visibility,
             beakX: keypoints.beak.x, beakY: keypoints.beak.y,
             beakVis: keypoints.beak.visibility,
-            segMask: birdCropSegMask
+            segMask: birdCropSegMask,
+            birdBboxSize: bboxPx
         ) ?? TenengradSharpness.score(image: birdCrop) // fallback to full-crop
 
         // `imageProps` (loaded at the top) also feeds the ISO sharpness

--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -672,6 +672,7 @@ final class PipelineCoordinator: @unchecked Sendable {
             sharpness: photo.sharpnessScore ?? 0,
             aesthetics: photo.aestheticsScore,
             allKeypointsHidden: keypoints.allKeypointsHidden,
+            bestEyeVisibility: keypoints.bestEyeVisibility,
             isOverexposed: photo.exposureStatus == ExposureStatus.overexposed.rawValue,
             isUnderexposed: photo.exposureStatus == ExposureStatus.underexposed.rawValue,
             focusSharpnessWeight: focusWeights.sharpness,

--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -642,6 +642,17 @@ final class PipelineCoordinator: @unchecked Sendable {
             return (keypoints.rightEye.x, keypoints.rightEye.y)
         }()
 
+        // Head-circle radius for the focus-point .headFocus tier. Mirrors
+        // the radius HeadSharpness uses: eye-beak distance × 1.2 when the
+        // beak is visible, otherwise the bbox max-side × 0.15 fallback.
+        // Without this, every photo got the no-beak constant (0.15) for
+        // its head circle, which over-triggered .headFocus on ~most shots.
+        let headRadiusFraction = FocusPointDetector.headRadiusFraction(
+            beakVisibility: keypoints.beak.visibility,
+            eye: bestEye,
+            beak: (x: keypoints.beak.x, y: keypoints.beak.y)
+        )
+
         // Seg mask: YOLO outputs a square mask at model resolution (e.g. 160x160).
         // Infer dimensions from data size (sqrt of byte count for square masks).
         let segMask: Data? = bird.mask.isEmpty ? nil : bird.mask
@@ -655,7 +666,7 @@ final class PipelineCoordinator: @unchecked Sendable {
                     properties: props,
                     birdBbox: bird.bbox,
                     eyeCenter: bestEye,
-                    headRadiusFraction: HeadSharpness.noBeakRadiusRatio,
+                    headRadiusFraction: headRadiusFraction,
                     segMask: segMask,
                     maskWidth: maskWidth,
                     maskHeight: maskHeight
@@ -667,7 +678,7 @@ final class PipelineCoordinator: @unchecked Sendable {
                 filePath: fileURL.path,
                 birdBbox: bird.bbox,
                 eyeCenter: bestEye,
-                headRadiusFraction: HeadSharpness.noBeakRadiusRatio,
+                headRadiusFraction: headRadiusFraction,
                 segMask: segMask,
                 maskWidth: maskWidth,
                 maskHeight: maskHeight

--- a/apps/mac-client/SuperPickyApp/SonyMakerNoteReader.swift
+++ b/apps/mac-client/SuperPickyApp/SonyMakerNoteReader.swift
@@ -40,10 +40,10 @@ enum SonyMakerNoteReader {
     /// Pure-data entry point. Exposed `internal` for tests that craft
     /// byte buffers without touching the filesystem.
     static func readFocusData(fromContainer data: Data) -> [String: Any]? {
-        guard let tiffStart = locateTIFFStart(in: data) else { return nil }
+        guard let tiffStart = TIFFIFDReader.locateTIFFStart(in: data) else { return nil }
         guard data.count >= tiffStart + 8 else { return nil }
 
-        let byteOrder: ByteOrder
+        let byteOrder: TIFFIFDReader.ByteOrder
         switch (data[tiffStart], data[tiffStart + 1]) {
         case (0x49, 0x49): byteOrder = .little
         case (0x4D, 0x4D): byteOrder = .big
@@ -53,18 +53,22 @@ enum SonyMakerNoteReader {
 
         // IFD0 → ExifIFD (tag 0x8769) → MakerNote (tag 0x927C).
         let ifd0Offset = Int(byteOrder.read32(data, at: tiffStart + 4))
-        guard let exifIFDPtr = findTagValueField(in: data,
-                                                  tiffStart: tiffStart,
-                                                  ifdRelativeOffset: ifd0Offset,
-                                                  tag: 0x8769,
-                                                  byteOrder: byteOrder) else {
+        guard let exifIFDPtr = TIFFIFDReader.findTagValueField(
+            in: data,
+            tiffStart: tiffStart,
+            ifdRelativeOffset: ifd0Offset,
+            tag: 0x8769,
+            byteOrder: byteOrder
+        ) else {
             return nil
         }
-        guard let makerNoteEntry = findEntry(in: data,
-                                              tiffStart: tiffStart,
-                                              ifdRelativeOffset: Int(exifIFDPtr),
-                                              tag: 0x927C,
-                                              byteOrder: byteOrder) else {
+        guard let makerNoteEntry = TIFFIFDReader.findEntry(
+            in: data,
+            tiffStart: tiffStart,
+            ifdRelativeOffset: Int(exifIFDPtr),
+            tag: 0x927C,
+            byteOrder: byteOrder
+        ) else {
             return nil
         }
         // MakerNote contents live at the value-offset; the count is the
@@ -128,84 +132,11 @@ enum SonyMakerNoteReader {
         return out.isEmpty ? nil : out
     }
 
-    // MARK: - Container detection
-
-    /// Same logic as `EXIFOffsetReader.locateTIFFStart` — bare TIFF/ARW
-    /// at offset 0, JPEG inside an APP1 segment after `"Exif\0\0"`.
-    private static func locateTIFFStart(in data: Data) -> Int? {
-        guard data.count >= 4 else { return nil }
-        if (data[0] == 0x49 && data[1] == 0x49) || (data[0] == 0x4D && data[1] == 0x4D) {
-            return 0
-        }
-        guard data[0] == 0xFF, data[1] == 0xD8 else { return nil }
-        var cursor = 2
-        while cursor + 4 <= data.count {
-            guard data[cursor] == 0xFF else { return nil }
-            let marker = data[cursor + 1]
-            if marker == 0xDA || marker == 0xD9 { return nil }
-            let segmentLength = Int(data[cursor + 2]) << 8 | Int(data[cursor + 3])
-            guard segmentLength >= 2 else { return nil }
-            if marker == 0xE1 {
-                let headerStart = cursor + 4
-                if headerStart + 6 <= data.count,
-                   data[headerStart]     == 0x45,   // 'E'
-                   data[headerStart + 1] == 0x78,   // 'x'
-                   data[headerStart + 2] == 0x69,   // 'i'
-                   data[headerStart + 3] == 0x66,   // 'f'
-                   data[headerStart + 4] == 0x00,
-                   data[headerStart + 5] == 0x00 {
-                    return headerStart + 6
-                }
-            }
-            cursor += 2 + segmentLength
-        }
-        return nil
-    }
-
-    // MARK: - IFD walking
-
-    /// Returns the absolute byte offset of the IFD entry for `tag`, or
-    /// nil when not present. The 12-byte entry layout is
-    /// `(tag:2)(type:2)(count:4)(value-or-offset:4)`.
-    private static func findEntry(in data: Data,
-                                  tiffStart: Int,
-                                  ifdRelativeOffset: Int,
-                                  tag: UInt16,
-                                  byteOrder: ByteOrder) -> Int? {
-        let ifdAbsolute = tiffStart + ifdRelativeOffset
-        guard ifdAbsolute >= 0, ifdAbsolute + 2 <= data.count else { return nil }
-        let entryCount = Int(byteOrder.read16(data, at: ifdAbsolute))
-        guard entryCount >= 0, entryCount < 4096 else { return nil }
-        let entriesStart = ifdAbsolute + 2
-        guard entriesStart + entryCount * 12 <= data.count else { return nil }
-        for index in 0..<entryCount {
-            let entry = entriesStart + index * 12
-            if byteOrder.read16(data, at: entry) == tag {
-                return entry
-            }
-        }
-        return nil
-    }
-
-    /// Convenience: read the `(value-or-offset)` field of an IFD entry.
-    private static func findTagValueField(in data: Data,
-                                          tiffStart: Int,
-                                          ifdRelativeOffset: Int,
-                                          tag: UInt16,
-                                          byteOrder: ByteOrder) -> UInt32? {
-        guard let entry = findEntry(in: data,
-                                     tiffStart: tiffStart,
-                                     ifdRelativeOffset: ifdRelativeOffset,
-                                     tag: tag,
-                                     byteOrder: byteOrder) else { return nil }
-        return byteOrder.read32(data, at: entry + 8)
-    }
-
     // MARK: - Typed value extraction
 
     /// Read a single BYTE-typed (type=1) tag value.
     private static func readByte(in data: Data, entry: Int,
-                                 tiffStart: Int, byteOrder: ByteOrder) -> UInt8? {
+                                 tiffStart: Int, byteOrder: TIFFIFDReader.ByteOrder) -> UInt8? {
         let type = byteOrder.read16(data, at: entry + 2)
         let count = Int(byteOrder.read32(data, at: entry + 4))
         guard type == 1 || type == 7, count >= 1 else { return nil }
@@ -218,7 +149,7 @@ enum SonyMakerNoteReader {
     /// the byte payload, then reinterpret as little/big-endian shorts.
     /// This handles the `undef[6] → int16u[3]` case for FocusFrameSize.
     private static func readUInt16Array(in data: Data, entry: Int,
-                                        tiffStart: Int, byteOrder: ByteOrder,
+                                        tiffStart: Int, byteOrder: TIFFIFDReader.ByteOrder,
                                         expectedType: UInt16?,
                                         expectedByteCount: Int? = nil) -> [UInt16]? {
         let type = byteOrder.read16(data, at: entry + 2)
@@ -262,25 +193,4 @@ enum SonyMakerNoteReader {
         return result
     }
 
-    // MARK: - Byte order
-
-    enum ByteOrder {
-        case little, big
-
-        func read16(_ data: Data, at offset: Int) -> UInt16 {
-            let b0 = UInt16(data[offset])
-            let b1 = UInt16(data[offset + 1])
-            return self == .little ? (b1 << 8) | b0 : (b0 << 8) | b1
-        }
-
-        func read32(_ data: Data, at offset: Int) -> UInt32 {
-            let b0 = UInt32(data[offset])
-            let b1 = UInt32(data[offset + 1])
-            let b2 = UInt32(data[offset + 2])
-            let b3 = UInt32(data[offset + 3])
-            return self == .little
-                ? (b3 << 24) | (b2 << 16) | (b1 << 8) | b0
-                : (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
-        }
-    }
 }

--- a/apps/mac-client/SuperPickyApp/SonyMakerNoteReader.swift
+++ b/apps/mac-client/SuperPickyApp/SonyMakerNoteReader.swift
@@ -1,0 +1,286 @@
+import Foundation
+
+/// Reads Sony AF tags directly from the file bytes.
+///
+/// Apple's ImageIO does not surface Sony MakerNote at all for ARW —
+/// `CGImageSourceCopyPropertiesAtIndex` returns no `{MakerNote}` key
+/// — so the brand-dispatched parser in `FocusPointDetector` never
+/// receives input via the standard path. This reader walks the TIFF
+/// IFD chain by hand:
+///
+/// ```
+///   TIFF header → IFD0 → ExifIFD (0x8769) → MakerNote (0x927C) → Sony5 IFD
+/// ```
+///
+/// Sony5 (modern bodies — A1 / A7Rx / A9) starts the MakerNote with a
+/// bare TIFF-style IFD using the same byte order as the parent and
+/// entry offsets relative to the TIFF base. Older bodies prefix the
+/// IFD with a 12-byte `"SONY DSC \0\0\0"` header; we detect this and
+/// skip past it before parsing.
+///
+/// Returns a dict shaped for `FocusPointDetector.parseSonyFocusPoint` —
+/// `FocusLocation` as `[Int]`, `FocusFrameSize` as `[Int]`, and the
+/// integer `FocusMode` code (Sony 1=MF, 2=AF-S, 3=AF-C, 4=AF-A, …).
+enum SonyMakerNoteReader {
+
+    /// Sony MakerNote tag IDs we care about for AF data.
+    private static let tagFocusMode: UInt16     = 0x201B  // int8u[1]
+    private static let tagFocusLocation: UInt16 = 0x2027  // int16u[4]: imgW imgH x y
+    private static let tagFocusFrameSize: UInt16 = 0x2037 // undef[6] → int16u[3]: w h validity
+
+    /// Memory-maps the file and returns a dict of Sony focus tags
+    /// (or nil if the container can't be parsed or no Sony MakerNote
+    /// is present).
+    static func readFocusData(from path: String) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path),
+                                   options: .alwaysMapped) else { return nil }
+        return readFocusData(fromContainer: data)
+    }
+
+    /// Pure-data entry point. Exposed `internal` for tests that craft
+    /// byte buffers without touching the filesystem.
+    static func readFocusData(fromContainer data: Data) -> [String: Any]? {
+        guard let tiffStart = locateTIFFStart(in: data) else { return nil }
+        guard data.count >= tiffStart + 8 else { return nil }
+
+        let byteOrder: ByteOrder
+        switch (data[tiffStart], data[tiffStart + 1]) {
+        case (0x49, 0x49): byteOrder = .little
+        case (0x4D, 0x4D): byteOrder = .big
+        default: return nil
+        }
+        guard byteOrder.read16(data, at: tiffStart + 2) == 42 else { return nil }
+
+        // IFD0 → ExifIFD (tag 0x8769) → MakerNote (tag 0x927C).
+        let ifd0Offset = Int(byteOrder.read32(data, at: tiffStart + 4))
+        guard let exifIFDPtr = findTagValueField(in: data,
+                                                  tiffStart: tiffStart,
+                                                  ifdRelativeOffset: ifd0Offset,
+                                                  tag: 0x8769,
+                                                  byteOrder: byteOrder) else {
+            return nil
+        }
+        guard let makerNoteEntry = findEntry(in: data,
+                                              tiffStart: tiffStart,
+                                              ifdRelativeOffset: Int(exifIFDPtr),
+                                              tag: 0x927C,
+                                              byteOrder: byteOrder) else {
+            return nil
+        }
+        // MakerNote contents live at the value-offset; the count is the
+        // byte length of the data block.
+        let mnRelativeOffset = Int(byteOrder.read32(data, at: makerNoteEntry + 8))
+        let mnByteCount      = Int(byteOrder.read32(data, at: makerNoteEntry + 4))
+        let mnAbsolute       = tiffStart + mnRelativeOffset
+        guard mnAbsolute >= 0,
+              mnByteCount >= 2,
+              mnAbsolute + mnByteCount <= data.count else {
+            return nil
+        }
+
+        // Sony5 starts the IFD directly. Older bodies prefix it with
+        // "SONY DSC \0\0\0" (12 bytes) — skip past that when present.
+        let sonyHeader: [UInt8] = [0x53, 0x4F, 0x4E, 0x59, 0x20,    // "SONY "
+                                    0x44, 0x53, 0x43, 0x20]          // "DSC "
+        var ifdStart = mnAbsolute
+        if mnByteCount >= 12,
+           Array(data[mnAbsolute..<(mnAbsolute + sonyHeader.count)]) == sonyHeader {
+            ifdStart = mnAbsolute + 12
+        }
+        guard ifdStart + 2 <= data.count else { return nil }
+
+        // Iterate Sony IFD entries looking for the AF tags. Bail when
+        // the entry count is implausibly large — defensive against
+        // misidentified containers.
+        let entryCount = Int(byteOrder.read16(data, at: ifdStart))
+        guard entryCount > 0, entryCount < 1000 else { return nil }
+        let entriesStart = ifdStart + 2
+        guard entriesStart + entryCount * 12 <= data.count else { return nil }
+
+        var out: [String: Any] = [:]
+        for index in 0..<entryCount {
+            let entry = entriesStart + index * 12
+            let tag = byteOrder.read16(data, at: entry)
+            switch tag {
+            case tagFocusMode:
+                if let value = readByte(in: data, entry: entry, tiffStart: tiffStart, byteOrder: byteOrder) {
+                    out["FocusMode"] = Int(value)
+                }
+            case tagFocusLocation:
+                if let values = readUInt16Array(in: data, entry: entry,
+                                                 tiffStart: tiffStart, byteOrder: byteOrder,
+                                                 expectedType: 3) {
+                    out["FocusLocation"] = values.map { Int($0) }
+                }
+            case tagFocusFrameSize:
+                // Stored as `undef` (type 7), but the byte payload is
+                // logically three little-endian shorts. We accept either
+                // declared type defensively.
+                if let values = readUInt16Array(in: data, entry: entry,
+                                                 tiffStart: tiffStart, byteOrder: byteOrder,
+                                                 expectedType: nil, expectedByteCount: 6) {
+                    out["FocusFrameSize"] = values.map { Int($0) }
+                }
+            default:
+                continue
+            }
+        }
+        return out.isEmpty ? nil : out
+    }
+
+    // MARK: - Container detection
+
+    /// Same logic as `EXIFOffsetReader.locateTIFFStart` — bare TIFF/ARW
+    /// at offset 0, JPEG inside an APP1 segment after `"Exif\0\0"`.
+    private static func locateTIFFStart(in data: Data) -> Int? {
+        guard data.count >= 4 else { return nil }
+        if (data[0] == 0x49 && data[1] == 0x49) || (data[0] == 0x4D && data[1] == 0x4D) {
+            return 0
+        }
+        guard data[0] == 0xFF, data[1] == 0xD8 else { return nil }
+        var cursor = 2
+        while cursor + 4 <= data.count {
+            guard data[cursor] == 0xFF else { return nil }
+            let marker = data[cursor + 1]
+            if marker == 0xDA || marker == 0xD9 { return nil }
+            let segmentLength = Int(data[cursor + 2]) << 8 | Int(data[cursor + 3])
+            guard segmentLength >= 2 else { return nil }
+            if marker == 0xE1 {
+                let headerStart = cursor + 4
+                if headerStart + 6 <= data.count,
+                   data[headerStart]     == 0x45,   // 'E'
+                   data[headerStart + 1] == 0x78,   // 'x'
+                   data[headerStart + 2] == 0x69,   // 'i'
+                   data[headerStart + 3] == 0x66,   // 'f'
+                   data[headerStart + 4] == 0x00,
+                   data[headerStart + 5] == 0x00 {
+                    return headerStart + 6
+                }
+            }
+            cursor += 2 + segmentLength
+        }
+        return nil
+    }
+
+    // MARK: - IFD walking
+
+    /// Returns the absolute byte offset of the IFD entry for `tag`, or
+    /// nil when not present. The 12-byte entry layout is
+    /// `(tag:2)(type:2)(count:4)(value-or-offset:4)`.
+    private static func findEntry(in data: Data,
+                                  tiffStart: Int,
+                                  ifdRelativeOffset: Int,
+                                  tag: UInt16,
+                                  byteOrder: ByteOrder) -> Int? {
+        let ifdAbsolute = tiffStart + ifdRelativeOffset
+        guard ifdAbsolute >= 0, ifdAbsolute + 2 <= data.count else { return nil }
+        let entryCount = Int(byteOrder.read16(data, at: ifdAbsolute))
+        guard entryCount >= 0, entryCount < 4096 else { return nil }
+        let entriesStart = ifdAbsolute + 2
+        guard entriesStart + entryCount * 12 <= data.count else { return nil }
+        for index in 0..<entryCount {
+            let entry = entriesStart + index * 12
+            if byteOrder.read16(data, at: entry) == tag {
+                return entry
+            }
+        }
+        return nil
+    }
+
+    /// Convenience: read the `(value-or-offset)` field of an IFD entry.
+    private static func findTagValueField(in data: Data,
+                                          tiffStart: Int,
+                                          ifdRelativeOffset: Int,
+                                          tag: UInt16,
+                                          byteOrder: ByteOrder) -> UInt32? {
+        guard let entry = findEntry(in: data,
+                                     tiffStart: tiffStart,
+                                     ifdRelativeOffset: ifdRelativeOffset,
+                                     tag: tag,
+                                     byteOrder: byteOrder) else { return nil }
+        return byteOrder.read32(data, at: entry + 8)
+    }
+
+    // MARK: - Typed value extraction
+
+    /// Read a single BYTE-typed (type=1) tag value.
+    private static func readByte(in data: Data, entry: Int,
+                                 tiffStart: Int, byteOrder: ByteOrder) -> UInt8? {
+        let type = byteOrder.read16(data, at: entry + 2)
+        let count = Int(byteOrder.read32(data, at: entry + 4))
+        guard type == 1 || type == 7, count >= 1 else { return nil }
+        // Inline (count ≤ 4) — first byte of value field.
+        return data[entry + 8]
+    }
+
+    /// Read SHORT-typed (type=3) array values. When `expectedType` is
+    /// nil, accept any type and use `expectedByteCount` to delineate
+    /// the byte payload, then reinterpret as little/big-endian shorts.
+    /// This handles the `undef[6] → int16u[3]` case for FocusFrameSize.
+    private static func readUInt16Array(in data: Data, entry: Int,
+                                        tiffStart: Int, byteOrder: ByteOrder,
+                                        expectedType: UInt16?,
+                                        expectedByteCount: Int? = nil) -> [UInt16]? {
+        let type = byteOrder.read16(data, at: entry + 2)
+        let count = Int(byteOrder.read32(data, at: entry + 4))
+        if let expectedType, type != expectedType { return nil }
+        let byteCount: Int
+        if let expectedByteCount {
+            // Accept either type (3 → count = byteCount/2 shorts; 7 →
+            // count = byteCount raw bytes). Bail if neither matches.
+            if count == expectedByteCount, type != 3 { byteCount = expectedByteCount }
+            else if type == 3, count * 2 == expectedByteCount { byteCount = expectedByteCount }
+            else { return nil }
+        } else if type == 3 {
+            byteCount = count * 2
+        } else {
+            return nil
+        }
+
+        let bytes: ArraySlice<UInt8>
+        if byteCount <= 4 {
+            // Inline — pulled from the value-or-offset field.
+            let inlineStart = entry + 8
+            bytes = ArraySlice(data[inlineStart..<(inlineStart + byteCount)])
+        } else {
+            let payloadOffset = tiffStart + Int(byteOrder.read32(data, at: entry + 8))
+            guard payloadOffset >= 0, payloadOffset + byteCount <= data.count else { return nil }
+            bytes = ArraySlice(data[payloadOffset..<(payloadOffset + byteCount)])
+        }
+
+        var result: [UInt16] = []
+        result.reserveCapacity(byteCount / 2)
+        let base = bytes.startIndex
+        for shortIndex in 0..<(byteCount / 2) {
+            let lo = bytes[base + shortIndex * 2]
+            let hi = bytes[base + shortIndex * 2 + 1]
+            let value: UInt16 = byteOrder == .little
+                ? (UInt16(hi) << 8) | UInt16(lo)
+                : (UInt16(lo) << 8) | UInt16(hi)
+            result.append(value)
+        }
+        return result
+    }
+
+    // MARK: - Byte order
+
+    enum ByteOrder {
+        case little, big
+
+        func read16(_ data: Data, at offset: Int) -> UInt16 {
+            let b0 = UInt16(data[offset])
+            let b1 = UInt16(data[offset + 1])
+            return self == .little ? (b1 << 8) | b0 : (b0 << 8) | b1
+        }
+
+        func read32(_ data: Data, at offset: Int) -> UInt32 {
+            let b0 = UInt32(data[offset])
+            let b1 = UInt32(data[offset + 1])
+            let b2 = UInt32(data[offset + 2])
+            let b3 = UInt32(data[offset + 3])
+            return self == .little
+                ? (b3 << 24) | (b2 << 16) | (b1 << 8) | b0
+                : (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+        }
+    }
+}

--- a/apps/mac-client/SuperPickyApp/TIFFIFDReader.swift
+++ b/apps/mac-client/SuperPickyApp/TIFFIFDReader.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Shared low-level helpers for walking TIFF/Exif IFDs straight from
+/// file bytes. Used by `EXIFOffsetReader` (timezone offset) and
+/// `SonyMakerNoteReader` (Sony AF tags) — both exist because Apple's
+/// ImageIO drops the tags they need.
+///
+/// Internal-only; no public clients outside this module.
+enum TIFFIFDReader {
+
+    enum ByteOrder {
+        case little, big
+
+        func read16(_ data: Data, at offset: Int) -> UInt16 {
+            let b0 = UInt16(data[offset])
+            let b1 = UInt16(data[offset + 1])
+            return self == .little ? (b1 << 8) | b0 : (b0 << 8) | b1
+        }
+
+        func read32(_ data: Data, at offset: Int) -> UInt32 {
+            let b0 = UInt32(data[offset])
+            let b1 = UInt32(data[offset + 1])
+            let b2 = UInt32(data[offset + 2])
+            let b3 = UInt32(data[offset + 3])
+            return self == .little
+                ? (b3 << 24) | (b2 << 16) | (b1 << 8) | b0
+                : (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+        }
+    }
+
+    /// Offset of the TIFF header within `data`. Bare TIFF/ARW starts at 0;
+    /// JPEG files place the TIFF inside an `APP1` segment after `"Exif\0\0"`.
+    static func locateTIFFStart(in data: Data) -> Int? {
+        guard data.count >= 4 else { return nil }
+        if (data[0] == 0x49 && data[1] == 0x49) || (data[0] == 0x4D && data[1] == 0x4D) {
+            return 0
+        }
+        guard data[0] == 0xFF, data[1] == 0xD8 else { return nil }
+        var cursor = 2
+        while cursor + 4 <= data.count {
+            guard data[cursor] == 0xFF else { return nil }
+            let marker = data[cursor + 1]
+            if marker == 0xDA || marker == 0xD9 { return nil }
+            let segmentLength = Int(data[cursor + 2]) << 8 | Int(data[cursor + 3])
+            guard segmentLength >= 2 else { return nil }
+            if marker == 0xE1 {
+                let headerStart = cursor + 4
+                if headerStart + 6 <= data.count,
+                   data[headerStart]     == 0x45,   // 'E'
+                   data[headerStart + 1] == 0x78,   // 'x'
+                   data[headerStart + 2] == 0x69,   // 'i'
+                   data[headerStart + 3] == 0x66,   // 'f'
+                   data[headerStart + 4] == 0x00,
+                   data[headerStart + 5] == 0x00 {
+                    return headerStart + 6
+                }
+            }
+            cursor += 2 + segmentLength
+        }
+        return nil
+    }
+
+    /// Returns the absolute byte offset of the IFD entry for `tag`, or
+    /// nil when not present. The 12-byte entry layout is
+    /// `(tag:2)(type:2)(count:4)(value-or-offset:4)`.
+    static func findEntry(in data: Data,
+                          tiffStart: Int,
+                          ifdRelativeOffset: Int,
+                          tag: UInt16,
+                          byteOrder: ByteOrder) -> Int? {
+        let ifdAbsolute = tiffStart + ifdRelativeOffset
+        guard ifdAbsolute >= 0, ifdAbsolute + 2 <= data.count else { return nil }
+        let entryCount = Int(byteOrder.read16(data, at: ifdAbsolute))
+        guard entryCount >= 0, entryCount < 4096 else { return nil }
+        let entriesStart = ifdAbsolute + 2
+        guard entriesStart + entryCount * 12 <= data.count else { return nil }
+        for index in 0..<entryCount {
+            let entry = entriesStart + index * 12
+            if byteOrder.read16(data, at: entry) == tag {
+                return entry
+            }
+        }
+        return nil
+    }
+
+    /// Read the `(value-or-offset)` 4-byte field of an IFD entry. Used
+    /// when we only need a scalar (e.g. an inner-IFD pointer like 0x8769).
+    static func findTagValueField(in data: Data,
+                                  tiffStart: Int,
+                                  ifdRelativeOffset: Int,
+                                  tag: UInt16,
+                                  byteOrder: ByteOrder) -> UInt32? {
+        guard let entry = findEntry(in: data,
+                                     tiffStart: tiffStart,
+                                     ifdRelativeOffset: ifdRelativeOffset,
+                                     tag: tag,
+                                     byteOrder: byteOrder) else { return nil }
+        return byteOrder.read32(data, at: entry + 8)
+    }
+}

--- a/apps/mac-client/SuperPickyTests/Core/EyeCropSharpnessTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/EyeCropSharpnessTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import CoreGraphics
+import Foundation
 @testable import SuperPicky
 
 struct HeadSharpnessTests {
@@ -61,6 +62,136 @@ struct HeadSharpnessTests {
             beakX: 0.6, beakY: 0.7, beakVis: 0.9
         )
         #expect(result == nil)
+    }
+
+    @Test func segMaskZeroEverywhereForcesScoreToZero() {
+        // Bird crop has a high-contrast white square inside a black field —
+        // a head circle covering it should report a high gradient. With an
+        // all-zeros seg mask the head circle ∩ seg mask is empty, so the
+        // Sobel sum has no contributing pixels and the function falls
+        // through to the `count == 0` branch returning 0.
+        let image = makeTestCGImage()  // 100×100, white square at (20,20)-(80,80)
+        let allZero = [UInt8](repeating: 0, count: image.width * image.height)
+        let zeroed = HeadSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0,
+            beakX: 0.6, beakY: 0.7, beakVis: 0.9,
+            segMask: allZero
+        )
+        #expect(zeroed == 0)
+    }
+
+    @Test func segMaskAllOnesMatchesNoMask() {
+        // An all-ones mask must not change the score relative to no mask:
+        // every in-circle pixel still passes through.
+        let image = makeTestCGImage()
+        let noMask = HeadSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0,
+            beakX: 0.6, beakY: 0.7, beakVis: 0.9
+        )
+        let allOne = [UInt8](repeating: 1, count: image.width * image.height)
+        let withMask = HeadSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0,
+            beakX: 0.6, beakY: 0.7, beakVis: 0.9,
+            segMask: allOne
+        )
+        #expect(noMask == withMask)
+    }
+
+    @Test func segMaskExcludesBackgroundEdges() {
+        // 200×200 image. The "bird body" is a uniform mid-gray patch on
+        // the left; the "background" on the right has a high-contrast
+        // black/white stripe that produces strong gradients.
+        // The eye-centered head circle reaches into both regions.
+        // With seg mask = bird-body-only, the high-gradient stripes are
+        // excluded and the score must drop.
+        let w = 200, h = 200
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(data: nil, width: w, height: h,
+                            bitsPerComponent: 8, bytesPerRow: 0, space: cs,
+                            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue)!
+        // Solid mid-gray everywhere (low gradient inside the bird body).
+        ctx.setFillColor(CGColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: w, height: h))
+        // High-contrast vertical stripes on the right half (background).
+        for stripe in 0..<10 {
+            let x = w/2 + stripe * 10
+            let color = stripe.isMultiple(of: 2) ? 0.0 : 1.0
+            ctx.setFillColor(CGColor(red: color, green: color, blue: color, alpha: 1))
+            ctx.fill(CGRect(x: x, y: 0, width: 10, height: h))
+        }
+        let image = ctx.makeImage()!
+
+        // Mask = left-half only (bird body lives there).
+        var mask = [UInt8](repeating: 0, count: w * h)
+        for y in 0..<h { for x in 0..<(w/2) { mask[y * w + x] = 1 } }
+
+        // Eye and beak both inside the left half; radius spans into the
+        // striped right half so the unmasked score is dominated by it.
+        let withoutMask = HeadSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.30, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0,
+            beakX: 0.85, beakY: 0.5, beakVis: 0.9   // far beak → big radius
+        )!
+        let withMask = HeadSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.30, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0,
+            beakX: 0.85, beakY: 0.5, beakVis: 0.9,
+            segMask: mask
+        )!
+        #expect(withMask < withoutMask)
+    }
+
+    @Test func birdCropAlignedSegMaskRejectsMalformedInput() {
+        let image = makeTestCGImage(width: 1280, height: 853)
+        let bbox = CGRect(x: 0.4, y: 0.4, width: 0.2, height: 0.2)
+        // Empty mask → nil
+        #expect(PipelineCoordinator.birdCropAlignedSegMask(
+            yoloMask: Data(), inferImage: image, bbox: bbox, birdCropSize: 100) == nil)
+        // Non-square mask byte count → nil
+        let nonSquare = Data(repeating: 1, count: 160 * 161)
+        #expect(PipelineCoordinator.birdCropAlignedSegMask(
+            yoloMask: nonSquare, inferImage: image, bbox: bbox, birdCropSize: 100) == nil)
+    }
+
+    @Test func birdCropAlignedSegMaskAllZerosProducesAllZeros() {
+        // Inference image roughly matching the Sony A1 inference frame
+        // (1280×853, 3:2 letterbox). Bbox sized so the smart-square crop
+        // lands within bounds without the letterbox-fill branch.
+        let image = makeTestCGImage(width: 1280, height: 853)
+        let bbox = CGRect(x: 0.45, y: 0.40, width: 0.10, height: 0.20)
+        let zeros = Data(repeating: 0, count: 160 * 160)
+        let out = PipelineCoordinator.birdCropAlignedSegMask(
+            yoloMask: zeros, inferImage: image, bbox: bbox, birdCropSize: 196)
+        #expect(out != nil)
+        #expect(out!.allSatisfy { $0 == 0 })
+    }
+
+    @Test func birdCropAlignedSegMaskAllOnesFillsCanvasInterior() {
+        // With an all-ones YOLO mask, every bird-crop pixel that maps back
+        // into the inference image (i.e. inside the clamped crop region)
+        // must be 1. The letterbox-fill margin around the clamped region
+        // — pixels outside the inference image — stays 0.
+        let image = makeTestCGImage(width: 1280, height: 853)
+        // Bbox near the top-left so smart-square clamping triggers the
+        // letterbox branch.
+        let bbox = CGRect(x: 0.02, y: 0.02, width: 0.18, height: 0.18)
+        let ones = Data(repeating: 1, count: 160 * 160)
+        let out = PipelineCoordinator.birdCropAlignedSegMask(
+            yoloMask: ones, inferImage: image, bbox: bbox, birdCropSize: 264)
+        #expect(out != nil)
+        // At least *some* pixels must be 1 (the in-canvas region) and at
+        // least some must be 0 (the letterbox margin). If the helper is
+        // entirely 0 or entirely 1, the geometry math is wrong.
+        #expect(out!.contains(where: { $0 == 1 }))
+        #expect(out!.contains(where: { $0 == 0 }))
     }
 
     @Test func isoSharpnessFactor() {

--- a/apps/mac-client/SuperPickyTests/Core/EyeCropSharpnessTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/EyeCropSharpnessTests.swift
@@ -149,6 +149,65 @@ struct HeadSharpnessTests {
         #expect(withMask < withoutMask)
     }
 
+    @Test func noBeakBboxFallbackUsesBboxNotCropSize() {
+        // 200×200 image with a single high-contrast vertical edge at x=120.
+        // Beak hidden → fallback radius branch fires.
+        // birdBboxSize.maxSide = 100  → radius = max(10, min(100*0.15=15, 99)) = 15
+        // No bbox             → radius = max(10, min(200*0.15=30, 99)) = 30
+        // The two radii produce DIFFERENT scores because the no-bbox circle
+        // covers more of the edge than the bbox circle.
+        let w = 200, h = 200
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let ctx = CGContext(data: nil, width: w, height: h,
+                            bitsPerComponent: 8, bytesPerRow: 0, space: cs,
+                            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue)!
+        ctx.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: w, height: h))
+        ctx.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        ctx.fill(CGRect(x: 120, y: 0, width: 1, height: h))
+        let image = ctx.makeImage()!
+
+        let withoutBox = HeadSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0,
+            beakX: nil, beakY: nil, beakVis: 0.0  // beak hidden → fallback
+        )!
+        let withBox = HeadSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0,
+            beakX: nil, beakY: nil, beakVis: 0.0,
+            birdBboxSize: (width: 100, height: 100)
+        )!
+        // Different radii → different scores. The exact direction depends
+        // on whether the edge sits inside the smaller bbox circle; what
+        // matters for parity is that the bbox value actually changes the
+        // computation rather than being silently ignored.
+        #expect(withoutBox != withBox)
+    }
+
+    @Test func beakVisibleIgnoresBboxFallback() {
+        // When the beak is visible the eye-beak × 1.2 path takes over and
+        // birdBboxSize is irrelevant — passing a wildly different bbox
+        // size must produce identical scores to omitting it.
+        let image = makeTestCGImage()
+        let withoutBox = HeadSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0,
+            beakX: 0.6, beakY: 0.7, beakVis: 0.9
+        )
+        let withTinyBox = HeadSharpness.score(
+            birdCrop: image,
+            leftEyeX: 0.5, leftEyeY: 0.5, leftEyeVis: 0.9,
+            rightEyeX: nil, rightEyeY: nil, rightEyeVis: 0.0,
+            beakX: 0.6, beakY: 0.7, beakVis: 0.9,
+            birdBboxSize: (width: 10, height: 10)
+        )
+        #expect(withoutBox == withTinyBox)
+    }
+
     @Test func birdCropAlignedSegMaskRejectsMalformedInput() {
         let image = makeTestCGImage(width: 1280, height: 853)
         let bbox = CGRect(x: 0.4, y: 0.4, width: 0.2, height: 0.2)

--- a/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
@@ -269,6 +269,114 @@ import SuperPickyInference
         #expect(abs(portrait.y - (1 - landscape.x)) < 0.001)
     }
 
+    // MARK: - Olympus AF parsing
+
+    @Test func olympusParsesAFPointSelectedNormalized() {
+        let mn: [String: Any] = ["AFPointSelected": "0.5 0.5"]
+        let r = FocusPointDetector.parseOlympusFocusPoint(
+            makerNote: mn, imageWidth: 4000, imageHeight: 3000, orientation: 1)!
+        #expect(r.x == 0.5 && r.y == 0.5)
+        #expect(r.isFocused == true)
+    }
+
+    @Test func olympusParsesPercentForm() {
+        // Some bodies surface "(50%,50%)"
+        let mn: [String: Any] = ["AFPointSelected": "(50%,50%)"]
+        let r = FocusPointDetector.parseOlympusFocusPoint(
+            makerNote: mn, imageWidth: 4000, imageHeight: 3000, orientation: 1)!
+        #expect(r.x == 0.5 && r.y == 0.5)
+    }
+
+    @Test func olympusFallsBackToAFFocusAreaWhenSelectedAbsent() {
+        // No AFPointSelected → use AFFocusArea + AFFrameSize
+        let mn: [String: Any] = [
+            "AFFocusArea": "100 100 200 200",  // x y w h
+            "AFFrameSize": "4000 3000"
+        ]
+        let r = FocusPointDetector.parseOlympusFocusPoint(
+            makerNote: mn, imageWidth: 0, imageHeight: 0, orientation: 1)!
+        // Center = (100+100, 100+100) = (200, 200) → (0.05, 0.0667)
+        #expect(abs(r.x - 0.05) < 0.001)
+        #expect(abs(r.y - Float(200) / Float(3000)) < 0.001)
+    }
+
+    @Test func olympusRejectsZeroZeroSelected() {
+        // "0 0" is Olympus's empty marker — fall through to AFFocusArea path
+        let mn: [String: Any] = ["AFPointSelected": "0 0"]
+        #expect(FocusPointDetector.parseOlympusFocusPoint(
+            makerNote: mn, imageWidth: 4000, imageHeight: 3000, orientation: 1) == nil)
+    }
+
+    @Test func olympusRejectsManualFocus() {
+        let mn: [String: Any] = [
+            "FocusMode": "Manual",
+            "AFPointSelected": "0.5 0.5"
+        ]
+        #expect(FocusPointDetector.parseOlympusFocusPoint(
+            makerNote: mn, imageWidth: 4000, imageHeight: 3000, orientation: 1) == nil)
+    }
+
+    // MARK: - Fujifilm AF parsing
+
+    @Test func fujifilmParsesFocusPixelAgainstExifImageDimensions() {
+        // Fujifilm FocusPixel is in embedded-JPEG-preview pixels.
+        // Frame 4416×2944, focus at (2208, 1472) → center → (0.5, 0.5).
+        let mn: [String: Any] = ["FocusPixel": "2208 1472"]
+        let r = FocusPointDetector.parseFujifilmFocusPoint(
+            makerNote: mn, imageWidth: 4416, imageHeight: 2944, orientation: 1)!
+        #expect(abs(r.x - 0.5) < 0.001)
+        #expect(abs(r.y - 0.5) < 0.001)
+        #expect(r.isFocused == true)
+    }
+
+    @Test func fujifilmReturnsNilWithoutImageDimensions() {
+        let mn: [String: Any] = ["FocusPixel": "2208 1472"]
+        #expect(FocusPointDetector.parseFujifilmFocusPoint(
+            makerNote: mn, imageWidth: 0, imageHeight: 0, orientation: 1) == nil)
+    }
+
+    @Test func fujifilmRejectsManualFocus() {
+        let mn: [String: Any] = [
+            "FocusMode": "MF",
+            "FocusPixel": "2208 1472"
+        ]
+        #expect(FocusPointDetector.parseFujifilmFocusPoint(
+            makerNote: mn, imageWidth: 4416, imageHeight: 2944, orientation: 1) == nil)
+    }
+
+    // MARK: - Panasonic AF parsing
+
+    @Test func panasonicParsesAFPointPositionNormalized() {
+        let mn: [String: Any] = ["AFPointPosition": "0.4 0.6"]
+        let r = FocusPointDetector.parsePanasonicFocusPoint(makerNote: mn, orientation: 1)!
+        #expect(abs(r.x - 0.4) < 0.001)
+        #expect(abs(r.y - 0.6) < 0.001)
+        #expect(r.isFocused == true)
+    }
+
+    @Test func panasonicRejectsSentinelValue() {
+        // Panasonic writes 4.194e+006 when no AF point was used
+        let mn: [String: Any] = ["AFPointPosition": "4.194e+006 4.194e+006"]
+        #expect(FocusPointDetector.parsePanasonicFocusPoint(makerNote: mn, orientation: 1) == nil)
+    }
+
+    @Test func panasonicRejectsManualFocus() {
+        let mn: [String: Any] = [
+            "FocusMode": "Manual",
+            "AFPointPosition": "0.5 0.5"
+        ]
+        #expect(FocusPointDetector.parsePanasonicFocusPoint(makerNote: mn, orientation: 1) == nil)
+    }
+
+    @Test func panasonicAppliesOrientationCorrection() {
+        let mn: [String: Any] = ["AFPointPosition": "0.25 0.5"]
+        let landscape = FocusPointDetector.parsePanasonicFocusPoint(makerNote: mn, orientation: 1)!
+        let portrait  = FocusPointDetector.parsePanasonicFocusPoint(makerNote: mn, orientation: 6)!
+        // Orientation 6 (CW): (x, y) → (y, 1-x)
+        #expect(abs(portrait.x - landscape.y) < 0.001)
+        #expect(abs(portrait.y - (1 - landscape.x)) < 0.001)
+    }
+
     // MARK: - Canon AF parsing
 
     @Test func canonEosCenteredAfPointWithYInversion() {

--- a/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
@@ -269,6 +269,99 @@ import SuperPickyInference
         #expect(abs(portrait.y - (1 - landscape.x)) < 0.001)
     }
 
+    // MARK: - Canon AF parsing
+
+    @Test func canonEosCenteredAfPointWithYInversion() {
+        // EOS body: image 6000×4000, AF point at offset (300, -200)
+        // → expected raw = (3000+300, 2000-(-200)*-1) = (3300, 2200)
+        // Wait: yDirection = -1 for EOS, so rawY = h/2 + yList[idx] * (-1)
+        //                                       = 2000 + (-200) * (-1) = 2200.
+        // Normalized: (3300/6000, 2200/4000) = (0.55, 0.55).
+        let mn: [String: Any] = [
+            "AFImageWidth": 6000,
+            "AFImageHeight": 4000,
+            "AFAreaXPositions": "300",
+            "AFAreaYPositions": "-200",
+            "AFPointsInFocus": "1"
+        ]
+        let r = FocusPointDetector.parseCanonFocusPoint(makerNote: mn, model: "Canon EOS R5", orientation: 1)!
+        #expect(abs(r.x - 0.55) < 0.001)
+        #expect(abs(r.y - 0.55) < 0.001)
+        #expect(r.isFocused == true)
+    }
+
+    @Test func canonCompactDoesNotInvertY() {
+        // Compact (PowerShot): yDirection = +1 → rawY = 2000 + (-200) = 1800.
+        let mn: [String: Any] = [
+            "AFImageWidth": 6000,
+            "AFImageHeight": 4000,
+            "AFAreaXPositions": "300",
+            "AFAreaYPositions": "-200",
+            "AFPointsInFocus": "1"
+        ]
+        let r = FocusPointDetector.parseCanonFocusPoint(makerNote: mn, model: "Canon PowerShot G7 X", orientation: 1)!
+        #expect(abs(r.y - 0.45) < 0.001)
+    }
+
+    @Test func canonPicksFirstFocusedAfPointFromBitmask() {
+        // 4 AF points; bitmask "0 0 1 0" → index 2 is in focus.
+        let mn: [String: Any] = [
+            "AFImageWidth": 6000,
+            "AFImageHeight": 4000,
+            "AFAreaXPositions": "0 0 600 0",
+            "AFAreaYPositions": "0 0 400 0",
+            "AFPointsInFocus": "0 0 1 0"
+        ]
+        let r = FocusPointDetector.parseCanonFocusPoint(makerNote: mn, model: "Canon EOS R6", orientation: 1)!
+        // Index 2: rawX = 3000+600 = 3600, rawY = 2000-400 = 1600 (EOS)
+        #expect(abs(r.x - 0.6) < 0.001)
+        #expect(abs(r.y - 0.4) < 0.001)
+        #expect(r.isFocused == true)
+    }
+
+    @Test func canonHandlesCommaSeparatedFocusIndices() {
+        // Some bodies surface "0,1" instead of bitmask
+        let mn: [String: Any] = [
+            "AFImageWidth": 6000,
+            "AFImageHeight": 4000,
+            "AFAreaXPositions": "100 200 300",
+            "AFAreaYPositions": "0 0 0",
+            "AFPointsInFocus": "1,2"
+        ]
+        let r = FocusPointDetector.parseCanonFocusPoint(makerNote: mn, model: "Canon EOS R", orientation: 1)!
+        // First locked index = 1 → rawX = 3000+200 = 3200
+        #expect(abs(r.x - Float(3200) / Float(6000)) < 0.001)
+    }
+
+    @Test func canonNoLockedPointFallsBackToFirstAfPointButReportsUnfocused() {
+        // No AFPointsInFocus → use index 0 but isFocused=false
+        let mn: [String: Any] = [
+            "AFImageWidth": 6000,
+            "AFImageHeight": 4000,
+            "AFAreaXPositions": "300",
+            "AFAreaYPositions": "-200",
+        ]
+        let r = FocusPointDetector.parseCanonFocusPoint(makerNote: mn, model: "Canon EOS R", orientation: 1)!
+        #expect(r.isFocused == false)
+        #expect(abs(r.x - 0.55) < 0.001)
+    }
+
+    @Test func canonRejectsManualFocus() {
+        let mn: [String: Any] = [
+            "FocusMode": "Manual",
+            "AFImageWidth": 6000,
+            "AFImageHeight": 4000,
+            "AFAreaXPositions": "300",
+            "AFAreaYPositions": "-200"
+        ]
+        #expect(FocusPointDetector.parseCanonFocusPoint(makerNote: mn, model: "Canon EOS R", orientation: 1) == nil)
+    }
+
+    @Test func canonReturnsNilWhenAfPositionsMissing() {
+        let mn: [String: Any] = ["AFImageWidth": 6000, "AFImageHeight": 4000]
+        #expect(FocusPointDetector.parseCanonFocusPoint(makerNote: mn, model: "Canon EOS R", orientation: 1) == nil)
+    }
+
     // MARK: - headRadiusFraction helper
 
     @Test func headRadiusFractionUsesEyeBeakDistanceWhenBeakVisible() {

--- a/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
@@ -274,7 +274,7 @@ import SuperPickyInference
     @Test func olympusParsesAFPointSelectedNormalized() {
         let mn: [String: Any] = ["AFPointSelected": "0.5 0.5"]
         let r = FocusPointDetector.parseOlympusFocusPoint(
-            makerNote: mn, imageWidth: 4000, imageHeight: 3000, orientation: 1)!
+            makerNote: mn, orientation: 1)!
         #expect(r.x == 0.5 && r.y == 0.5)
         #expect(r.isFocused == true)
     }
@@ -283,7 +283,7 @@ import SuperPickyInference
         // Some bodies surface "(50%,50%)"
         let mn: [String: Any] = ["AFPointSelected": "(50%,50%)"]
         let r = FocusPointDetector.parseOlympusFocusPoint(
-            makerNote: mn, imageWidth: 4000, imageHeight: 3000, orientation: 1)!
+            makerNote: mn, orientation: 1)!
         #expect(r.x == 0.5 && r.y == 0.5)
     }
 
@@ -294,7 +294,7 @@ import SuperPickyInference
             "AFFrameSize": "4000 3000"
         ]
         let r = FocusPointDetector.parseOlympusFocusPoint(
-            makerNote: mn, imageWidth: 0, imageHeight: 0, orientation: 1)!
+            makerNote: mn, orientation: 1)!
         // Center = (100+100, 100+100) = (200, 200) → (0.05, 0.0667)
         #expect(abs(r.x - 0.05) < 0.001)
         #expect(abs(r.y - Float(200) / Float(3000)) < 0.001)
@@ -304,7 +304,7 @@ import SuperPickyInference
         // "0 0" is Olympus's empty marker — fall through to AFFocusArea path
         let mn: [String: Any] = ["AFPointSelected": "0 0"]
         #expect(FocusPointDetector.parseOlympusFocusPoint(
-            makerNote: mn, imageWidth: 4000, imageHeight: 3000, orientation: 1) == nil)
+            makerNote: mn, orientation: 1) == nil)
     }
 
     @Test func olympusRejectsManualFocus() {
@@ -313,7 +313,7 @@ import SuperPickyInference
             "AFPointSelected": "0.5 0.5"
         ]
         #expect(FocusPointDetector.parseOlympusFocusPoint(
-            makerNote: mn, imageWidth: 4000, imageHeight: 3000, orientation: 1) == nil)
+            makerNote: mn, orientation: 1) == nil)
     }
 
     // MARK: - Fujifilm AF parsing

--- a/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import CoreGraphics
+import SuperPickyInference
 @testable import SuperPicky
 
 @Suite struct FocusPointDetectorTests {
@@ -189,6 +190,39 @@ import CoreGraphics
         )
         #expect(result.sharpness == 0.8)
         #expect(result.aesthetics == 0.9)
+    }
+
+    // MARK: - headRadiusFraction helper
+
+    @Test func headRadiusFractionUsesEyeBeakDistanceWhenBeakVisible() {
+        // eye-beak distance = √((0.6-0.5)² + 0²) = 0.10 → ×1.2 = 0.12.
+        // Different from the 0.15 no-beak fallback; confirms the helper
+        // actually uses the keypoint geometry instead of returning the
+        // constant.
+        let r = FocusPointDetector.headRadiusFraction(
+            beakVisibility: 0.9,
+            eye: (x: 0.5, y: 0.5),
+            beak: (x: 0.6, y: 0.5)
+        )
+        #expect(abs(r - 0.12) < 0.001)
+    }
+
+    @Test func headRadiusFractionFallsBackWhenBeakHidden() {
+        let r = FocusPointDetector.headRadiusFraction(
+            beakVisibility: 0.1,
+            eye: (x: 0.5, y: 0.5),
+            beak: (x: 0.6, y: 0.5)
+        )
+        #expect(r == 0.15)
+    }
+
+    @Test func headRadiusFractionTreatsBeakBelowThresholdAsHidden() {
+        let r = FocusPointDetector.headRadiusFraction(
+            beakVisibility: InferenceConstants.keypointVisibilityThreshold - 0.01,
+            eye: (x: 0.5, y: 0.5),
+            beak: (x: 0.5, y: 0.5)
+        )
+        #expect(r == 0.15)
     }
 
     // MARK: - No eye center: head check skipped, falls through to seg/bbox

--- a/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/FocusPointDetectorTests.swift
@@ -192,6 +192,83 @@ import SuperPickyInference
         #expect(result.aesthetics == 0.9)
     }
 
+    // MARK: - Sony FocusLocation parsing
+
+    @Test func sonyParsesFocusLocationFromStringForm() {
+        // Sony A1 MakerNote (exiftool string form): "5616 3744 2812 1885"
+        let makerNote: [String: Any] = [
+            "FocusLocation": "5616 3744 2812 1885",
+            "FocusFrameSize": "224 224 1"
+        ]
+        let r = FocusPointDetector.parseSonyFocusPoint(makerNote: makerNote, orientation: 1)!
+        #expect(abs(r.x - Float(2812) / Float(5616)) < 0.0001)
+        #expect(abs(r.y - Float(1885) / Float(3744)) < 0.0001)
+        #expect(r.isFocused == true)
+    }
+
+    @Test func sonyParsesFocusLocationFromArrayForm() {
+        // Same data but as [NSNumber] array (Apple ImageIO sometimes
+        // surfaces multi-int MakerNote tags this way).
+        let makerNote: [String: Any] = [
+            "FocusLocation": [NSNumber(value: 5616), NSNumber(value: 3744),
+                              NSNumber(value: 2812), NSNumber(value: 1885)],
+            "FocusFrameSize": [NSNumber(value: 224), NSNumber(value: 224), NSNumber(value: 1)]
+        ]
+        let r = FocusPointDetector.parseSonyFocusPoint(makerNote: makerNote, orientation: 1)!
+        #expect(abs(r.x - 0.5006) < 0.001)
+        #expect(r.isFocused == true)
+    }
+
+    @Test func sonyTreatsValidityZeroAsUnfocused() {
+        // FocusFrameSize[2] = 0 → AF didn't lock
+        let makerNote: [String: Any] = [
+            "FocusLocation": "5616 3744 2812 1885",
+            "FocusFrameSize": "224 224 0"
+        ]
+        let r = FocusPointDetector.parseSonyFocusPoint(makerNote: makerNote, orientation: 1)!
+        #expect(r.isFocused == false)
+    }
+
+    @Test func sonyDefaultsToFocusedWhenFrameSizeMissing() {
+        // No FocusFrameSize tag → conservatively assume focused (matches
+        // Python's `focus_result = 1` default).
+        let makerNote: [String: Any] = ["FocusLocation": "5616 3744 2812 1885"]
+        let r = FocusPointDetector.parseSonyFocusPoint(makerNote: makerNote, orientation: 1)!
+        #expect(r.isFocused == true)
+    }
+
+    @Test func sonyRejectsManualFocus() {
+        // FocusMode = "1" (Sony's MF code) → no AF data
+        let makerNote: [String: Any] = [
+            "FocusMode": "1",
+            "FocusLocation": "5616 3744 2812 1885"
+        ]
+        #expect(FocusPointDetector.parseSonyFocusPoint(makerNote: makerNote, orientation: 1) == nil)
+    }
+
+    @Test func sonyRejectsManualFocusByName() {
+        // Some Sony bodies surface "Manual" as a string label
+        let makerNote: [String: Any] = [
+            "FocusMode": "Manual",
+            "FocusLocation": "5616 3744 2812 1885"
+        ]
+        #expect(FocusPointDetector.parseSonyFocusPoint(makerNote: makerNote, orientation: 1) == nil)
+    }
+
+    @Test func sonyReturnsNilWhenFocusLocationMissing() {
+        let makerNote: [String: Any] = ["FocusFrameSize": "224 224 1"]
+        #expect(FocusPointDetector.parseSonyFocusPoint(makerNote: makerNote, orientation: 1) == nil)
+    }
+
+    @Test func sonyAppliesOrientationCorrection() {
+        // Portrait CW (orientation=6): (x, y) → (y, 1-x)
+        let makerNote: [String: Any] = ["FocusLocation": "5616 3744 1404 936"]
+        let landscape = FocusPointDetector.parseSonyFocusPoint(makerNote: makerNote, orientation: 1)!
+        let portrait  = FocusPointDetector.parseSonyFocusPoint(makerNote: makerNote, orientation: 6)!
+        #expect(abs(portrait.x - landscape.y) < 0.001)
+        #expect(abs(portrait.y - (1 - landscape.x)) < 0.001)
+    }
+
     // MARK: - headRadiusFraction helper
 
     @Test func headRadiusFractionUsesEyeBeakDistanceWhenBeakVisible() {

--- a/apps/mac-client/SuperPickyTests/Core/PhotoRatingPredictorTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/PhotoRatingPredictorTests.swift
@@ -28,6 +28,28 @@ import Foundation
         return p
     }
 
+    @Test func bestEyeVisibilityTakesMaxOfTwoEyes() {
+        let p = photo(leftEyeVis: 0.30, rightEyeVis: 0.85)
+        #expect(PhotoRatingPredictor.bestEyeVisibility(p) == 0.85)
+    }
+
+    @Test func bestEyeVisibilityTreatsNilAsZero() {
+        let p = photo(leftEyeVis: nil, rightEyeVis: 0.4)
+        #expect(PhotoRatingPredictor.bestEyeVisibility(p) == 0.4)
+    }
+
+    @Test func lowEyeVisibilityDegradesPredictedRating() {
+        // Both eyes barely visible (just above the 0.3 hidden floor so we
+        // skip the `allKeypointsHidden` short-circuit) — visibility weight
+        // = max(0.5, min(1.0, 0.31 * 2)) = 0.62 → 5★ * 0.62 ≈ 3.
+        let strong = photo(leftEyeVis: 0.9, rightEyeVis: 0.9)
+        let weak   = photo(leftEyeVis: 0.31, rightEyeVis: 0.31)
+        let strongStars = PhotoRatingPredictor.predict(photo: strong, config: config)!
+        let weakStars   = PhotoRatingPredictor.predict(photo: weak,   config: config)!
+        #expect(strongStars > weakStars)
+        #expect(weakStars >= 1)
+    }
+
     // MARK: - nil paths
 
     @Test func returnsNilWhenPhotoIsNil() {

--- a/apps/mac-client/SuperPickyTests/Core/SonyMakerNoteReaderTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/SonyMakerNoteReaderTests.swift
@@ -1,0 +1,211 @@
+import Testing
+import Foundation
+@testable import SuperPicky
+
+/// Unit tests for the raw-bytes Sony MakerNote IFD walker.
+/// Test fixtures are hand-built TIFF + IFD byte buffers so we don't
+/// need a real ARW on disk.
+@Suite struct SonyMakerNoteReaderTests {
+
+    // MARK: - Fixture builder
+
+    /// Builds a minimal valid little-endian TIFF container with one
+    /// IFD0 entry pointing at an ExifIFD that contains a MakerNote
+    /// pointer to a Sony5-style sub-IFD with the supplied entries.
+    /// All offsets are TIFF-base-relative.
+    private func makeFixture(sonyEntries: [SonyEntry], sonyHeaderPrefix: Bool = false) -> Data {
+        var data = Data()
+        // --- TIFF header (8 bytes) ---
+        data.append(contentsOf: [0x49, 0x49, 0x2A, 0x00])     // "II" little-endian + magic 42
+        data.append(contentsOf: u32le(8))                     // IFD0 offset = 8
+
+        // --- IFD0 at offset 8 ---
+        // 1 entry: ExifIFD pointer (tag 0x8769, type 4 LONG, count 1, value=offset of ExifIFD)
+        let ifd0Start = data.count
+        let ifd0EntryCount: UInt16 = 1
+        data.append(contentsOf: u16le(ifd0EntryCount))
+
+        // Compute layout: ExifIFD will follow IFD0 (which is 2 + 12 + 4 = 18 bytes).
+        // ExifIFD: 1 entry (MakerNote pointer 0x927C) + 2 bytes count + 4 bytes nextIFD = 18 bytes.
+        // Then comes the MakerNote data (Sony IFD).
+        let exifIFDOffset = ifd0Start + 2 + 12 + 4              // start of ExifIFD
+        let makerNoteOffset = exifIFDOffset + 2 + 12 + 4         // start of MakerNote bytes
+        // Sony MakerNote layout: optional 12-byte "SONY DSC \0\0\0" header,
+        // then IFD (2-byte count + N×12-byte entries + 4-byte next-IFD).
+        let sonyHeaderLen = sonyHeaderPrefix ? 12 : 0
+        let sonyIFDStart = makerNoteOffset + sonyHeaderLen
+        let sonyIFDEntriesStart = sonyIFDStart + 2
+        let sonyIFDEnd = sonyIFDEntriesStart + sonyEntries.count * 12 + 4
+
+        // IFD0 entry: ExifIFD pointer
+        data.append(contentsOf: u16le(0x8769))                // tag
+        data.append(contentsOf: u16le(4))                     // type = LONG
+        data.append(contentsOf: u32le(1))                     // count
+        data.append(contentsOf: u32le(UInt32(exifIFDOffset))) // value = offset
+        data.append(contentsOf: u32le(0))                     // next IFD = 0
+
+        // --- ExifIFD ---
+        data.append(contentsOf: u16le(1))                     // entry count
+        // MakerNote pointer (tag 0x927C, type 7 UNDEFINED, count = full MakerNote size)
+        let mnByteCount = sonyHeaderLen + 2 + sonyEntries.count * 12 + 4
+            + sonyEntries.compactMap(\.outOfLineBytes).map { $0.count }.reduce(0, +)
+        data.append(contentsOf: u16le(0x927C))                // tag
+        data.append(contentsOf: u16le(7))                     // type = UNDEFINED
+        data.append(contentsOf: u32le(UInt32(mnByteCount)))   // count = byte length
+        data.append(contentsOf: u32le(UInt32(makerNoteOffset)))// value = offset
+        data.append(contentsOf: u32le(0))                     // next IFD = 0
+
+        // --- MakerNote header (optional) ---
+        if sonyHeaderPrefix {
+            data.append(contentsOf: [0x53, 0x4F, 0x4E, 0x59, 0x20,    // "SONY "
+                                      0x44, 0x53, 0x43, 0x20,         // "DSC "
+                                      0x00, 0x00, 0x00])              // 3 nulls
+        }
+
+        // --- Sony IFD ---
+        data.append(contentsOf: u16le(UInt16(sonyEntries.count)))
+        // Out-of-line payloads go after all 12-byte entry slots + the
+        // 4-byte next-IFD field. Track positions as we write entries.
+        var payloadCursor = sonyIFDEnd
+        var payloads: [(offset: Int, bytes: [UInt8])] = []
+        for entry in sonyEntries {
+            data.append(contentsOf: u16le(entry.tag))
+            data.append(contentsOf: u16le(entry.type))
+            data.append(contentsOf: u32le(UInt32(entry.count)))
+            switch entry.valueOrOffset {
+            case .inline(let bytes):
+                var padded = bytes
+                while padded.count < 4 { padded.append(0) }
+                data.append(contentsOf: padded.prefix(4))
+            case .outOfLine(let bytes):
+                data.append(contentsOf: u32le(UInt32(payloadCursor)))
+                payloads.append((payloadCursor, bytes))
+                payloadCursor += bytes.count
+            }
+        }
+        data.append(contentsOf: u32le(0))    // next IFD = 0
+
+        // --- Out-of-line payloads ---
+        for (offset, bytes) in payloads {
+            // Pad with zeros if there are gaps (shouldn't happen here).
+            while data.count < offset { data.append(0) }
+            data.append(contentsOf: bytes)
+        }
+        return data
+    }
+
+    private struct SonyEntry {
+        let tag: UInt16
+        let type: UInt16
+        let count: Int
+        let valueOrOffset: Value
+        var outOfLineBytes: [UInt8]? {
+            if case .outOfLine(let b) = valueOrOffset { return b }
+            return nil
+        }
+        enum Value {
+            case inline([UInt8])
+            case outOfLine([UInt8])
+        }
+    }
+
+    private func u16le(_ value: UInt16) -> [UInt8] {
+        [UInt8(value & 0xFF), UInt8(value >> 8)]
+    }
+    private func u32le(_ value: UInt32) -> [UInt8] {
+        [UInt8(value & 0xFF),
+         UInt8((value >> 8) & 0xFF),
+         UInt8((value >> 16) & 0xFF),
+         UInt8((value >> 24) & 0xFF)]
+    }
+
+    // MARK: - Tests
+
+    @Test func parsesSonyA1FocusTags() {
+        // FocusLocation (0x2027) int16u[4] = {5616, 3744, 2860, 2106}
+        // FocusFrameSize (0x2037) undef[6] read as int16u[3] = {421, 421, 257}
+        // FocusMode (0x201B) int8u[1] = {3} (AF-C)
+        let focLocBytes: [UInt8] = u16le(5616) + u16le(3744) + u16le(2860) + u16le(2106)
+        let focFrameBytes: [UInt8] = u16le(421) + u16le(421) + u16le(257)
+        let entries = [
+            SonyEntry(tag: 0x201B, type: 1, count: 1,
+                      valueOrOffset: .inline([3])),
+            SonyEntry(tag: 0x2027, type: 3, count: 4,
+                      valueOrOffset: .outOfLine(focLocBytes)),
+            SonyEntry(tag: 0x2037, type: 7, count: 6,
+                      valueOrOffset: .outOfLine(focFrameBytes))
+        ]
+        let data = makeFixture(sonyEntries: entries)
+        let result = SonyMakerNoteReader.readFocusData(fromContainer: data)
+        #expect(result != nil)
+        #expect(result?["FocusLocation"] as? [Int] == [5616, 3744, 2860, 2106])
+        #expect(result?["FocusFrameSize"] as? [Int] == [421, 421, 257])
+        #expect(result?["FocusMode"] as? Int == 3)
+    }
+
+    @Test func handlesLegacySonyDscPrefix() {
+        // Older bodies prefix the MakerNote IFD with "SONY DSC \0\0\0".
+        let entries = [
+            SonyEntry(tag: 0x201B, type: 1, count: 1,
+                      valueOrOffset: .inline([2])),    // AF-S
+            SonyEntry(tag: 0x2027, type: 3, count: 4,
+                      valueOrOffset: .outOfLine(u16le(6000) + u16le(4000) + u16le(3000) + u16le(2000)))
+        ]
+        let data = makeFixture(sonyEntries: entries, sonyHeaderPrefix: true)
+        let result = SonyMakerNoteReader.readFocusData(fromContainer: data)
+        #expect(result?["FocusLocation"] as? [Int] == [6000, 4000, 3000, 2000])
+        #expect(result?["FocusMode"] as? Int == 2)
+    }
+
+    @Test func skipsUnknownSonyTags() {
+        // Foreign entries between the AF tags must be ignored, not
+        // crash the IFD walk.
+        let entries = [
+            SonyEntry(tag: 0x1000, type: 3, count: 1,
+                      valueOrOffset: .inline(u16le(99))),
+            SonyEntry(tag: 0x2027, type: 3, count: 4,
+                      valueOrOffset: .outOfLine(u16le(1) + u16le(2) + u16le(3) + u16le(4))),
+            SonyEntry(tag: 0xFFFF, type: 4, count: 1,
+                      valueOrOffset: .inline(u32le(0)))
+        ]
+        let data = makeFixture(sonyEntries: entries)
+        let result = SonyMakerNoteReader.readFocusData(fromContainer: data)!
+        #expect(result["FocusLocation"] as? [Int] == [1, 2, 3, 4])
+        #expect(result["FocusMode"] == nil)        // not in the input
+        #expect(result["FocusFrameSize"] == nil)
+    }
+
+    @Test func returnsNilOnMissingMakerNote() {
+        // No MakerNote tag at all → nil.
+        var data = Data()
+        data.append(contentsOf: [0x49, 0x49, 0x2A, 0x00])
+        data.append(contentsOf: u32le(8))    // IFD0 offset
+        // IFD0 with one entry that is NOT the ExifIFD pointer — IFD walk
+        // bails because tag 0x8769 isn't found.
+        data.append(contentsOf: u16le(1))
+        data.append(contentsOf: u16le(0x010F))   // Make tag
+        data.append(contentsOf: u16le(2))        // ASCII type
+        data.append(contentsOf: u32le(0))
+        data.append(contentsOf: u32le(0))
+        data.append(contentsOf: u32le(0))
+        #expect(SonyMakerNoteReader.readFocusData(fromContainer: data) == nil)
+    }
+
+    @Test func returnsNilOnNonTIFFContainer() {
+        // Random bytes that aren't TIFF or JPEG.
+        let data = Data([0xFF, 0x00, 0xAB, 0xCD])
+        #expect(SonyMakerNoteReader.readFocusData(fromContainer: data) == nil)
+    }
+
+    @Test func returnsNilOnTruncatedContainer() {
+        // Valid TIFF prefix but truncated before any IFD.
+        let data = Data([0x49, 0x49, 0x2A, 0x00] + u32le(8))
+        #expect(SonyMakerNoteReader.readFocusData(fromContainer: data) == nil)
+    }
+
+    @Test func emptyMakerNoteReturnsNil() {
+        // MakerNote IFD with zero entries → nothing to extract → nil.
+        let data = makeFixture(sonyEntries: [])
+        #expect(SonyMakerNoteReader.readFocusData(fromContainer: data) == nil)
+    }
+}


### PR DESCRIPTION
Closes a set of silent scope cuts from the Python superpicky → Swift port that had compounding effects on rating accuracy. Each fix is its own commit; the trailing one is the /simplify dedupe pass.

## Summary

- **Sharpness**: head circle now intersected with the YOLO segmentation mask, no-beak radius uses the YOLO bbox instead of the smart-cropped image.
- **Rating**: `bestEyeVisibility` is wired through `RatingEngine` end-to-end. Photos with one eye half-visible no longer get the unconditional 1.0× weight.
- **Focus point**: full brand dispatch landed (Sony / Canon / Olympus / Fujifilm / Panasonic). Sony A1 ARWs are decoded via a hand-rolled TIFF/IFD walker because Apple's `CGImageSource` drops the entire `{MakerNote}` dict for that container.
- **Cleanup**: `TIFFIFDReader` shared helper extracted; brand-parser MF rejection collapsed to one helper.

## Per-commit changes

| Commit | What |
|---|---|
| `fix(sharpness): intersect head circle with YOLO seg mask` | `EyeCropSharpness` now passes a bird-crop-aligned mask to `TenengradSharpness.maskedScore` so background pixels stop dragging on the gradient² average |
| `fix(rating): wire bestEyeVisibility through to RatingEngine` | `KeypointResult.bestEyeVisibility` (computed `max(L,R)`) reaches `RatingEngine.calculate` from both the pipeline and `PhotoRatingPredictor` |
| `fix(sharpness): restore YOLO bbox fallback for no-beak head radius` | Three-branch radius fallback matches superpicky: eye-beak × 1.2 / bbox × 0.15 / crop × 0.15 |
| `fix(focus): pass actual head radius to FocusPointDetector` | `.headFocus` tier no longer over-triggers: head radius now tracks eye-beak × 1.2 instead of the static 0.15 fallback |
| `feat(focus): parse Sony FocusLocation` | Parser for `FocusLocation` + `FocusFrameSize` + `FocusMode` MakerNote tags |
| `feat(focus): parse Canon AFAreaXPositions` | Image-center offsets, EOS Y-inversion, bitmask + comma-list focus indices |
| `feat(focus): parse Olympus / Fujifilm / Panasonic` | `AFPointSelected`/`AFFocusArea`, `FocusPixel`, `AFPointPosition` (+ Panasonic 4.194e sentinel) |
| `feat(focus): walk Sony MakerNote IFD` | Hand-rolled IFD walker on the file bytes — Apple's ImageIO drops `{MakerNote}` entirely for Sony ARW |
| `chore(simplify): dedupe TIFF/IFD walker + MF check` | Extract `TIFFIFDReader`; collapse 5× MF rejection into `isManualFocus`; drop dead Olympus placeholder |

## Verification

- **586/586 L1 tests pass**: existing 538 plus 48 new cases (seg-mask coverage, brand-parser fixtures, IFD byte-walker fixtures, `bestEyeVisibility` wiring).
- **Real Sony A1 ARW decoded correctly**: `FocusLocation: [5616, 3744, 2860, 2106]` → focus at `(0.509, 0.563)`, AF locked, AF-C mode. 0.6 ms cold / 0.04 ms warm per file.
- **Reprocessed the production folder** (`/Volumes/Untitled/DCIM/.report.db`): photos with visible eyes show consistent +3–5% sharpness (seg-mask trims background); both-eyes-hidden photos unchanged at 0% (predicted eye lands at body center, head circle entirely inside silhouette → no trim possible). Pattern matches the seg-mask fix's predicted behavior exactly.

## Test plan

- [x] `xcodebuild test -scheme SuperPicky -destination 'platform=macOS' -only-testing:SuperPickyTests` — 586/586 green
- [x] App builds cleanly via `xcodebuild build -scheme SuperPicky -destination 'platform=macOS'`
- [x] Real-world: reprocess one Sony A1 folder, confirm sharpness deltas align with the seg-mask prediction
- [ ] CI green (this PR)

## Out of scope (deferred)

- Auto-pick batch pass (`_calculate_picked_flags` from `photo_processor.py:2615`) — the user has ditched this feature
- Coordinate-mapping refinement inside `FocusPointDetector.computeWeights` (the eye-position scaling currently uses bbox-relative arithmetic where bird-crop-relative would be more accurate; ~5–20% drift on edge-clamped subjects) — defer until real focus-tier data shows whether the drift matters
- File-handle sharing between `EXIFOffsetReader` and `SonyMakerNoteReader` (both mmap the same file independently; ~20–50 ms saving on a 1000-photo cull, not worth the plumbing today)