### PR TITLE
feat(sharpness): measure on full-res embedded preview

### DIFF
--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -587,25 +587,41 @@ final class PipelineCoordinator: @unchecked Sendable {
         photo.flightConfidence = flight.confidence
 
         // Head-region sharpness (circular mask around eye, matches superpicky).
+        //
+        // Sharpness needs a higher-resolution input than ML inference does.
+        // At the 1280 max-side inference resolution a distant bird's head
+        // crop is 80–150 px and 1-pixel focus blur becomes unobservable;
+        // raw gradient² values for two visibly distinct shots tie within
+        // 0.1 % (verified on DSC09838 vs DSC09846). Decode the embedded
+        // full-res preview just for the sharpness pass and reuse the
+        // already-normalized YOLO bbox. Falls back to the inference image
+        // when the hi-res decode isn't available (older RAW with no
+        // embedded preview).
+        let sharpnessSource: CGImage = rawConverter.decodeForSharpness(fileURL: fileURL) ?? image
+        let sharpnessBirdCrop = sharpnessSource.smartSquareBirdCrop(bbox: bird.bbox) ?? birdCrop
+
         // Build a bird-crop-aligned segmentation mask so the head circle is
         // intersected with the YOLO seg mask, matching the
         // `cv2.bitwise_and(circle_mask, seg_mask)` step in
         // `superpicky/core/keypoint_detector.py:_calculate_head_sharpness`.
+        // The mask alignment uses the same source image the bird crop was
+        // taken from — at hi-res the YOLO letterbox math still resolves
+        // correctly because the aspect ratio matches the inference image.
         let birdCropSegMask = Self.birdCropAlignedSegMask(
             yoloMask: bird.mask,
-            inferImage: image,
+            inferImage: sharpnessSource,
             bbox: bird.bbox,
-            birdCropSize: birdCrop.width
+            birdCropSize: sharpnessBirdCrop.width
         )
-        // YOLO bbox in inference-image pixel space — feeds HeadSharpness's
+        // YOLO bbox in sharpness-source pixel space — feeds HeadSharpness's
         // no-beak radius fallback (matches superpicky's `box[2]/box[3]`
         // branch in keypoint_detector.py:248-252).
         let bboxPx = (
-            width:  Int((bird.bbox.width  * CGFloat(image.width )).rounded()),
-            height: Int((bird.bbox.height * CGFloat(image.height)).rounded())
+            width:  Int((bird.bbox.width  * CGFloat(sharpnessSource.width )).rounded()),
+            height: Int((bird.bbox.height * CGFloat(sharpnessSource.height)).rounded())
         )
         let headSharpness = HeadSharpness.score(
-            birdCrop: birdCrop,
+            birdCrop: sharpnessBirdCrop,
             leftEyeX: keypoints.leftEye.x, leftEyeY: keypoints.leftEye.y,
             leftEyeVis: keypoints.leftEye.visibility,
             rightEyeX: keypoints.rightEye.x, rightEyeY: keypoints.rightEye.y,
@@ -614,7 +630,7 @@ final class PipelineCoordinator: @unchecked Sendable {
             beakVis: keypoints.beak.visibility,
             segMask: birdCropSegMask,
             birdBboxSize: bboxPx
-        ) ?? TenengradSharpness.score(image: birdCrop) // fallback to full-crop
+        ) ?? TenengradSharpness.score(image: sharpnessBirdCrop) // fallback to full-crop
 
         // `imageProps` (loaded at the top) also feeds the ISO sharpness
         // factor and the focus-point weighting below — one CGImageSource

--- a/apps/mac-client/SuperPickyApp/RAWConverter.swift
+++ b/apps/mac-client/SuperPickyApp/RAWConverter.swift
@@ -7,6 +7,16 @@ struct RAWConverter: Sendable {
     /// Max pixel dimension for detect/aesthetics/keypoints/flight inference.
     private static let maxInferenceSize = 1280
 
+    /// Max pixel dimension for sharpness measurement. The 1280 inference
+    /// crop is undersampled for sharpness — at that resolution a distant
+    /// bird's head circle is 80–150 px and 1-pixel focus blur is
+    /// unobservable. Decoding to ~5800 picks up the embedded full-res
+    /// JPEG preview that modern bodies (Sony A1/A7Rx/A9, Canon R5/R6,
+    /// Nikon Z9) write into ARW/CR3/NEF — fast enough to run per photo
+    /// and recovers the ~65% raw-gradient gap we see between visually
+    /// distinct shots that tied at 1280.
+    static let maxSharpnessSize = 5800
+
     /// Decoded thumbnail plus the EXIF/TIFF property dictionary read from
     /// the same CGImageSource. `processOnePhoto` needs both for every
     /// photo, and opening the source twice (one thumbnail, one properties)
@@ -61,6 +71,23 @@ struct RAWConverter: Sendable {
             throw RAWConversionError.conversionFailed
         }
         return Decoded(image: image, properties: props)
+    }
+
+    /// Decode a higher-resolution image for the sharpness pass. Uses the
+    /// embedded full-res JPEG preview (no slow CIRAW path) and caps at
+    /// `maxPixelSize` so memory stays bounded. Returns nil on failure;
+    /// caller is expected to fall back to the inference image.
+    func decodeForSharpness(fileURL: URL,
+                            maxPixelSize: Int = RAWConverter.maxSharpnessSize) -> CGImage? {
+        guard let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil) else {
+            return nil
+        }
+        let options: [CFString: Any] = [
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceCreateThumbnailFromImageIfAbsent: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ]
+        return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
     }
 
     /// Slow fallback: full RAW decode.


### PR DESCRIPTION
## Summary

ML inference (YOLO/keypoints/aesthetics/flight) needs the 1280 max-side thumbnail Apple's CGImageSource fast-paths. Sharpness measurement does not — at 1280 a distant bird's head crop is 80–150 px and 1-pixel focus blur becomes unobservable, so two visibly distinct shots can produce identical raw² gradient sums.

## What changed

- `RAWConverter.decodeForSharpness(fileURL:)` — new entry point that requests the embedded full-resolution JPEG preview (max 5800 px, covers Sony A1 5616×3744 and Canon R5 6000×4000 without forcing CIRAW).
- `PipelineCoordinator.processOnePhoto` decodes hi-res only for the sharpness path. YOLO bbox + keypoints stay normalized so they apply at any resolution. Falls back to the 1280 inference image when the preview decode fails.

## Quality verification — DSC09838 vs DSC09846 (the case that triggered this)

Same Anna's Hummingbird burst, same EXIF, both eyes hidden — user reports 9846 is visibly sharper.

| | DSC09838 (soft) | DSC09846 (sharper) | gap |
|---|---:|---:|---:|
| pre-fix | 421.7 | 421.4 | 0.3 |
| 1280 (post seg-mask fix) | 421.7 | 421.4 | 0.3 |
| **full-res (this PR)** | **401.3** | **406.9** | **5.6** ✅ |

The tie that started this thread is broken; ranking now matches perception. Verified by raw²: at full-res the head circles are 3601 vs 5928 (65 % apart); at 1280 they're 9472 vs 9463 (0.1 % apart).

## Performance — release build, 877 SD-card ARWs

| | Elapsed | Rate |
|---|---:|---:|
| 1280 baseline | 112 s | 7.83 photos/s |
| **Full-res** | **114 s** | **7.69 photos/s** |

**−1.8 % throughput**, within timer noise. The hi-res decode is essentially free in steady state because the file's pages are already mapped from the inference decode (second mmap = RAM-speed) and embedded JPEG decode bypasses CIRAW.

## Test plan

- [x] `xcodebuild test -scheme SuperPicky -destination 'platform=macOS' -only-testing:SuperPickyTests` — 586/586 green
- [x] App builds cleanly in Release configuration
- [x] Real-world: re-processed `/Volumes/Untitled/DCIM/100MSDCF` (877 ARWs) end-to-end with the release binary, confirmed 9838/9846 ranking flip
- [ ] CI green (this PR)

## Out of scope

- Smaller-resolution variants (e.g. 2880 max) — measurable benchmark gain was zero, not worth the tuning surface
- File-handle sharing between EXIFOffsetReader / SonyMakerNoteReader / decodeForSharpness — three mmaps of the same file per photo, all RAM-speed after the first; consolidating saves ~1ms/photo at most