### PR TITLE
fix(sharpness): walk Sony ARW IFD chain to extract full-res JPEG

### DIFF
--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -272,6 +272,8 @@
 		D5780C7327D0F6E8E642EA4E /* EXIFOffsetReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DC1B03F94601690B7CEE70 /* EXIFOffsetReader.swift */; };
 		C3901B0082034877AE3BC55C /* SonyMakerNoteReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */; };
 		4ED691282A8C468A9D7BD925 /* TIFFIFDReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53C33BA781A440C9AE778D6 /* TIFFIFDReader.swift */; };
+		6F23FF145A47470BA787AF59 /* ARWPreviewExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F5E90BEF90404C87B11FC7 /* ARWPreviewExtractor.swift */; };
+		D38A19D7CAC54302B15A874A /* ARWPreviewExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9657238527145B999C1DB00 /* ARWPreviewExtractorTests.swift */; };
 		C411A16A447248E699F22041 /* SonyMakerNoteReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */; };
 		D6070A885F8DE451AE897CEE /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1508E6CA44451D6B09FAD8BF /* ImageLoader.swift */; };
 		D716E8F51325F58C77043E42 /* species_list_CN-91.json in Resources */ = {isa = PBXBuildFile; fileRef = 0840F652B0CB17459DB81648 /* species_list_CN-91.json */; };
@@ -470,6 +472,8 @@
 		55DC1B03F94601690B7CEE70 /* EXIFOffsetReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXIFOffsetReader.swift; sourceTree = "<group>"; };
 		DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonyMakerNoteReader.swift; sourceTree = "<group>"; };
 		B53C33BA781A440C9AE778D6 /* TIFFIFDReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TIFFIFDReader.swift; sourceTree = "<group>"; };
+		B6F5E90BEF90404C87B11FC7 /* ARWPreviewExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARWPreviewExtractor.swift; sourceTree = "<group>"; };
+		C9657238527145B999C1DB00 /* ARWPreviewExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARWPreviewExtractorTests.swift; sourceTree = "<group>"; };
 		91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonyMakerNoteReaderTests.swift; sourceTree = "<group>"; };
 		55FD8383417E1258A87ACD4A /* species_list_FI.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = species_list_FI.json; sourceTree = "<group>"; };
 		56C47414BCC2DF0A9F491F21 /* RegionBounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionBounds.swift; sourceTree = "<group>"; };
@@ -741,6 +745,7 @@
 				B2D4034E9FA4FAEA2BFB8D8D /* ExifFormattersTests.swift */,
 				1B0DFDEC10521C90189BDE9F /* EXIFOffsetReaderTests.swift */,
 				91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */,
+				C9657238527145B999C1DB00 /* ARWPreviewExtractorTests.swift */,
 				CB9A3A9BD8A728146C3DDD2F /* EXIFReaderTests.swift */,
 				7B7DFAB7427E7D50B6C2F83D /* ExportServiceTests.swift */,
 				42EA84402A20D3F540816789 /* ExposureDetectorTests.swift */,
@@ -801,6 +806,7 @@
 				55DC1B03F94601690B7CEE70 /* EXIFOffsetReader.swift */,
 				DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */,
 				B53C33BA781A440C9AE778D6 /* TIFFIFDReader.swift */,
+				B6F5E90BEF90404C87B11FC7 /* ARWPreviewExtractor.swift */,
 				8D61960564355CE428DB7AAB /* ExifPanelView.swift */,
 				75A29A263D346C79918EC367 /* EXIFReader.swift */,
 				C9D7B139DADC49E884F6DC14 /* ExportService.swift */,
@@ -1518,6 +1524,7 @@
 				A677967B8F5115A2BA4E50F7 /* DirectoryScannerTests.swift in Sources */,
 				C4C1B719F8B6A6E22DBB1B38 /* EXIFOffsetReaderTests.swift in Sources */,
 				C411A16A447248E699F22041 /* SonyMakerNoteReaderTests.swift in Sources */,
+				D38A19D7CAC54302B15A874A /* ARWPreviewExtractorTests.swift in Sources */,
 				1F6EE45CD79999D1EF5491F3 /* EXIFReaderTests.swift in Sources */,
 				C8B71FD5634761985FC15545 /* ExifFormattersTests.swift in Sources */,
 				0248B7B5C0E566EFFBB63CCB /* ExifPanelTests.swift in Sources */,
@@ -1584,6 +1591,7 @@
 				D5780C7327D0F6E8E642EA4E /* EXIFOffsetReader.swift in Sources */,
 				C3901B0082034877AE3BC55C /* SonyMakerNoteReader.swift in Sources */,
 				4ED691282A8C468A9D7BD925 /* TIFFIFDReader.swift in Sources */,
+				6F23FF145A47470BA787AF59 /* ARWPreviewExtractor.swift in Sources */,
 				E8A2927BC88504E05E879CEC /* EXIFReader.swift in Sources */,
 				AD9998180DB9935038EF3D5A /* ExifFormatters.swift in Sources */,
 				8D6EA52385D28EA1B9D1B25F /* ExifPanelView.swift in Sources */,

--- a/apps/mac-client/SuperPickyApp/ARWPreviewExtractor.swift
+++ b/apps/mac-client/SuperPickyApp/ARWPreviewExtractor.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Extracts the full-resolution JPEG preview embedded in Sony ARW files.
+///
+/// Sony ARW stores three images: a small thumbnail (~160 px), a medium
+/// preview (1616×1080, what ImageIO's `kCGImageSourceCreateThumbnailFrom
+/// ImageIfAbsent` returns), and a full-resolution JPEG matching the
+/// sensor's active area (5616×3744 on Sony A1, 8640×5760 on A1 II /
+/// A7R V). The full-res JPEG lives in **IFD2** under standard EXIF tags
+/// `JpgFromRawStart` (0x0201) and `JpgFromRawLength` (0x0202). IFD2 is
+/// reached by following the next-IFD pointer at the end of IFD0 twice.
+///
+/// ImageIO doesn't expose this as a separate sub-image
+/// (`CGImageSourceGetCount` returns 1 for ARW), and the only way to
+/// force full-res via ImageIO is `kCGImageSourceCreateThumbnailFrom
+/// ImageAlways`, which routes through CIRAW. Measured cost on a Sony A1
+/// ARW: 611 ms via `Always` vs 18 ms decoding our extracted JPEG slice.
+///
+/// The extractor's output is a `Data` slice positioned over the
+/// memory-mapped file — no copy. Pass it to
+/// `CGImageSourceCreateWithData` to decode at native resolution.
+enum ARWPreviewExtractor {
+    private static let tagJpgFromRawStart: UInt16 = 0x0201
+    private static let tagJpgFromRawLength: UInt16 = 0x0202
+
+    /// Memory-maps the file and returns the embedded full-res JPEG slice.
+    /// Returns nil for non-ARW containers, files that lack IFD2, or
+    /// older Sony bodies that don't write a `JpgFromRaw` block.
+    static func extractFullResJPEG(from path: String) -> Data? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path),
+                                   options: .alwaysMapped) else { return nil }
+        return extractFullResJPEG(fromContainer: data)
+    }
+
+    /// Pure-data entry point. Exposed `internal` for tests using crafted
+    /// byte buffers.
+    static func extractFullResJPEG(fromContainer data: Data) -> Data? {
+        guard let tiffStart = TIFFIFDReader.locateTIFFStart(in: data) else { return nil }
+        guard data.count >= tiffStart + 8 else { return nil }
+
+        let byteOrder: TIFFIFDReader.ByteOrder
+        switch (data[tiffStart], data[tiffStart + 1]) {
+        case (0x49, 0x49): byteOrder = .little
+        case (0x4D, 0x4D): byteOrder = .big
+        default: return nil
+        }
+        guard byteOrder.read16(data, at: tiffStart + 2) == 42 else { return nil }
+
+        // Walk IFD0 → next → IFD1 → next → IFD2 by chasing the
+        // next-IFD pointer that sits right after each IFD's entry array.
+        var ifdOffset = Int(byteOrder.read32(data, at: tiffStart + 4))
+        for _ in 0..<2 {
+            guard ifdOffset > 0 else { return nil }
+            let ifdAbsolute = tiffStart + ifdOffset
+            guard ifdAbsolute + 2 <= data.count else { return nil }
+            let entryCount = Int(byteOrder.read16(data, at: ifdAbsolute))
+            guard entryCount >= 0, entryCount < 4096 else { return nil }
+            let nextIFDPos = ifdAbsolute + 2 + entryCount * 12
+            guard nextIFDPos + 4 <= data.count else { return nil }
+            ifdOffset = Int(byteOrder.read32(data, at: nextIFDPos))
+        }
+        guard ifdOffset > 0 else { return nil }
+
+        // IFD2: read JpgFromRawStart (0x0201) + JpgFromRawLength (0x0202).
+        // Both are TIFF type LONG (4) count 1, so the 4-byte value-or-
+        // offset field holds the scalar directly.
+        guard let startEntry = TIFFIFDReader.findEntry(in: data,
+                                                        tiffStart: tiffStart,
+                                                        ifdRelativeOffset: ifdOffset,
+                                                        tag: tagJpgFromRawStart,
+                                                        byteOrder: byteOrder),
+              let lengthEntry = TIFFIFDReader.findEntry(in: data,
+                                                         tiffStart: tiffStart,
+                                                         ifdRelativeOffset: ifdOffset,
+                                                         tag: tagJpgFromRawLength,
+                                                         byteOrder: byteOrder) else {
+            return nil
+        }
+        let jpgStart = Int(byteOrder.read32(data, at: startEntry + 8))
+        let jpgLength = Int(byteOrder.read32(data, at: lengthEntry + 8))
+        guard jpgStart > 0, jpgLength > 0,
+              jpgStart + jpgLength <= data.count else {
+            return nil
+        }
+
+        // Sanity check: the bytes must start with a JPEG SOI marker.
+        // Catches files where IFD2 exists but the tags point at non-JPEG
+        // data (some older or third-party RAW).
+        guard data[jpgStart] == 0xFF, data[jpgStart + 1] == 0xD8 else {
+            return nil
+        }
+
+        return data.subdata(in: jpgStart..<(jpgStart + jpgLength))
+    }
+}

--- a/apps/mac-client/SuperPickyApp/RAWConverter.swift
+++ b/apps/mac-client/SuperPickyApp/RAWConverter.swift
@@ -73,18 +73,44 @@ struct RAWConverter: Sendable {
         return Decoded(image: image, properties: props)
     }
 
-    /// Decode a higher-resolution image for the sharpness pass. Uses the
-    /// embedded full-res JPEG preview (no slow CIRAW path) and caps at
-    /// `maxPixelSize` so memory stays bounded. Returns nil on failure;
-    /// caller is expected to fall back to the inference image.
+    /// Decode a higher-resolution image for the sharpness pass.
+    ///
+    /// Sony ARW: extract the embedded full-res JPEG (5616×3744 on A1,
+    /// 8640×5760 on A1 II / A7R V) directly from IFD2 and decode it.
+    /// Bypasses ImageIO's CIRAW path which costs ~611 ms per A1 ARW —
+    /// the embedded-JPEG path costs ~70 ms.
+    ///
+    /// Other RAW formats (CR3, NEF, RAF, …) and JPEG/HEIC fall back to
+    /// `kCGImageSourceCreateThumbnailFromImageAlways`. That's still slow
+    /// for non-Sony RAW (also CIRAW for those) but correct;
+    /// `kCGImageSourceCreateThumbnailFromImageIfAbsent` would silently
+    /// return the small embedded preview and we'd be back to the
+    /// 1280-equivalent resolution problem.
+    ///
+    /// Returns nil only when both the ARW fast path and the ImageIO
+    /// fallback fail. Caller falls back to the inference image.
     func decodeForSharpness(fileURL: URL,
                             maxPixelSize: Int = RAWConverter.maxSharpnessSize) -> CGImage? {
+        let ext = fileURL.pathExtension.lowercased()
+        if ext == "arw",
+           let jpegData = ARWPreviewExtractor.extractFullResJPEG(from: fileURL.path),
+           let source = CGImageSourceCreateWithData(jpegData as CFData, nil) {
+            let options: [CFString: Any] = [
+                kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+            ]
+            if let img = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) {
+                return img
+            }
+        }
+
         guard let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil) else {
             return nil
         }
         let options: [CFString: Any] = [
             kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
-            kCGImageSourceCreateThumbnailFromImageIfAbsent: true,
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceCreateThumbnailWithTransform: true,
         ]
         return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)

--- a/apps/mac-client/SuperPickyTests/Core/ARWPreviewExtractorTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/ARWPreviewExtractorTests.swift
@@ -1,0 +1,214 @@
+import Testing
+import Foundation
+@testable import SuperPicky
+
+/// Hand-built TIFF byte fixtures for the ARW IFD walker. The structure
+/// is: TIFF header → IFD0 (empty, points at IFD1) → IFD1 (empty, points
+/// at IFD2) → IFD2 (carries JpgFromRawStart 0x0201 + JpgFromRawLength
+/// 0x0202) → JPEG bytes appended at a known offset.
+@Suite struct ARWPreviewExtractorTests {
+
+    // MARK: - Helpers
+
+    private func u16le(_ v: UInt16) -> [UInt8] {
+        [UInt8(v & 0xFF), UInt8(v >> 8)]
+    }
+    private func u32le(_ v: UInt32) -> [UInt8] {
+        [UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF),
+         UInt8((v >> 16) & 0xFF), UInt8((v >> 24) & 0xFF)]
+    }
+
+    /// Build a fixture: empty IFD0 → empty IFD1 → IFD2 with optional
+    /// JpgFromRaw entries → JPEG bytes appended after IFD2's
+    /// next-pointer. Returns (data, jpegOffset, jpegLength).
+    private func makeFixture(jpegBytes: [UInt8],
+                             includeStart: Bool = true,
+                             includeLength: Bool = true) -> (Data, UInt32, UInt32) {
+        var data = Data()
+        // TIFF header
+        data.append(contentsOf: [0x49, 0x49, 0x2A, 0x00])     // II + magic 42
+        data.append(contentsOf: u32le(8))                     // IFD0 offset = 8
+
+        // IFD0: 0 entries, next-IFD-offset = 14 (= 8 + 2 + 0 + 4)
+        let ifd0Start = data.count
+        data.append(contentsOf: u16le(0))
+        let ifd1Offset = ifd0Start + 2 + 4
+        data.append(contentsOf: u32le(UInt32(ifd1Offset)))
+
+        // IFD1: 0 entries, next-IFD-offset = ifd2Offset
+        data.append(contentsOf: u16le(0))
+        let ifd2Offset = ifd1Offset + 2 + 4
+        data.append(contentsOf: u32le(UInt32(ifd2Offset)))
+
+        // IFD2: 0–2 entries (depending on flags) + 4-byte next-IFD = 0
+        var ifd2Entries: [(UInt16, UInt32)] = []
+        // We'll back-fill the value for JpgFromRawStart once we know the
+        // append offset; for now write a placeholder.
+        let entryCount = (includeStart ? 1 : 0) + (includeLength ? 1 : 0)
+        data.append(contentsOf: u16le(UInt16(entryCount)))
+        let entriesStart = data.count
+
+        // Reserve entry slots
+        for _ in 0..<entryCount {
+            data.append(contentsOf: [UInt8](repeating: 0, count: 12))
+        }
+        data.append(contentsOf: u32le(0))   // next IFD = 0 (end)
+
+        // JPEG bytes appended at the end
+        let jpegOffset = UInt32(data.count)
+        let jpegLength = UInt32(jpegBytes.count)
+        data.append(contentsOf: jpegBytes)
+
+        // Now back-fill IFD2 entries with the correct offset/length.
+        var entryIdx = 0
+        if includeStart {
+            ifd2Entries.append((0x0201, jpegOffset))   // JpgFromRawStart
+            let entry = entriesStart + entryIdx * 12
+            data.replaceSubrange(entry..<(entry+12), with:
+                u16le(0x0201) + u16le(4) + u32le(1) + u32le(jpegOffset))
+            entryIdx += 1
+        }
+        if includeLength {
+            ifd2Entries.append((0x0202, jpegLength))   // JpgFromRawLength
+            let entry = entriesStart + entryIdx * 12
+            data.replaceSubrange(entry..<(entry+12), with:
+                u16le(0x0202) + u16le(4) + u32le(1) + u32le(jpegLength))
+        }
+        _ = ifd2Entries
+
+        return (data, jpegOffset, jpegLength)
+    }
+
+    private let validJPEG: [UInt8] = [
+        0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46,
+        0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+        0xFF, 0xD9
+    ]
+
+    // MARK: - Happy path
+
+    @Test func extractsJpegFromValidIFD2() {
+        let (data, off, len) = makeFixture(jpegBytes: validJPEG)
+        let extracted = ARWPreviewExtractor.extractFullResJPEG(fromContainer: data)
+        #expect(extracted != nil)
+        #expect(extracted?.count == Int(len))
+        #expect(Array(extracted!) == validJPEG)
+        _ = off
+    }
+
+    // MARK: - Negative paths
+
+    @Test func returnsNilWhenIFD2HasNoStartTag() {
+        let (data, _, _) = makeFixture(jpegBytes: validJPEG, includeStart: false)
+        #expect(ARWPreviewExtractor.extractFullResJPEG(fromContainer: data) == nil)
+    }
+
+    @Test func returnsNilWhenIFD2HasNoLengthTag() {
+        let (data, _, _) = makeFixture(jpegBytes: validJPEG, includeLength: false)
+        #expect(ARWPreviewExtractor.extractFullResJPEG(fromContainer: data) == nil)
+    }
+
+    @Test func returnsNilWhenChainTerminatesBeforeIFD2() {
+        // Build a fixture where IFD0's next-offset = 0 (no IFD1).
+        var data = Data()
+        data.append(contentsOf: [0x49, 0x49, 0x2A, 0x00])
+        data.append(contentsOf: u32le(8))
+        data.append(contentsOf: u16le(0))      // IFD0 entry count
+        data.append(contentsOf: u32le(0))      // next IFD = 0 (chain ends)
+        #expect(ARWPreviewExtractor.extractFullResJPEG(fromContainer: data) == nil)
+    }
+
+    @Test func returnsNilWhenChainTerminatesAtIFD1() {
+        // IFD0 → IFD1, but IFD1's next = 0
+        var data = Data()
+        data.append(contentsOf: [0x49, 0x49, 0x2A, 0x00])
+        data.append(contentsOf: u32le(8))
+        data.append(contentsOf: u16le(0))      // IFD0 count
+        data.append(contentsOf: u32le(14))     // → IFD1 at offset 14
+        data.append(contentsOf: u16le(0))      // IFD1 count
+        data.append(contentsOf: u32le(0))      // IFD1 next = 0 → no IFD2
+        #expect(ARWPreviewExtractor.extractFullResJPEG(fromContainer: data) == nil)
+    }
+
+    @Test func returnsNilWhenJpegBytesDoNotStartWithSOI() {
+        // Replace JPEG SOI with garbage — extractor must reject.
+        let bogus: [UInt8] = [0x00, 0x00, 0x00, 0x00, 0x00]
+        let (data, _, _) = makeFixture(jpegBytes: bogus)
+        #expect(ARWPreviewExtractor.extractFullResJPEG(fromContainer: data) == nil)
+    }
+
+    @Test func returnsNilWhenJpegOffsetOutOfRange() {
+        // Build fixture, then tamper with the start-offset value to point
+        // past the end of the buffer.
+        var (data, _, _) = makeFixture(jpegBytes: validJPEG)
+        // Find IFD2 (at offset 20) and its first entry (offset 22).
+        // Entry layout: tag(2) type(2) count(4) value(4)
+        // Replace value with a huge offset.
+        data.replaceSubrange(30..<34, with: u32le(0xFFFFFFFF))
+        #expect(ARWPreviewExtractor.extractFullResJPEG(fromContainer: data) == nil)
+    }
+
+    @Test func returnsNilOnNonTIFFContainer() {
+        let data = Data([0xFF, 0x00, 0xAB, 0xCD])
+        #expect(ARWPreviewExtractor.extractFullResJPEG(fromContainer: data) == nil)
+    }
+
+    @Test func returnsNilOnTruncatedTIFF() {
+        // Valid TIFF magic but truncated before any IFD.
+        let data = Data([0x49, 0x49, 0x2A, 0x00] + u32le(8))
+        #expect(ARWPreviewExtractor.extractFullResJPEG(fromContainer: data) == nil)
+    }
+
+    @Test func handlesBigEndianByteOrder() {
+        // Build the same fixture but with big-endian encoding.
+        var data = Data()
+        data.append(contentsOf: [0x4D, 0x4D, 0x00, 0x2A])     // "MM" + magic 42 (big-endian)
+        // IFD0 offset = 8 (big-endian)
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x08])
+
+        // IFD0: 0 entries, next = 14
+        data.append(contentsOf: [0x00, 0x00])
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x0E])
+
+        // IFD1: 0 entries, next = 20
+        data.append(contentsOf: [0x00, 0x00])
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x14])
+
+        // IFD2: 2 entries + next=0
+        data.append(contentsOf: [0x00, 0x02])
+        let entriesStart = data.count
+        // reserve 24 bytes for two entries + 4 for next
+        data.append(contentsOf: [UInt8](repeating: 0, count: 12))
+        data.append(contentsOf: [UInt8](repeating: 0, count: 12))
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+
+        let jpegOffset = UInt32(data.count)
+        data.append(contentsOf: validJPEG)
+        let jpegLength = UInt32(validJPEG.count)
+
+        // Back-fill JpgFromRawStart entry
+        data.replaceSubrange(entriesStart..<(entriesStart+12), with:
+            [0x02, 0x01, 0x00, 0x04] +     // tag 0x0201 + type 4 (LONG)
+            [0x00, 0x00, 0x00, 0x01] +     // count 1
+            [
+                UInt8((jpegOffset >> 24) & 0xFF),
+                UInt8((jpegOffset >> 16) & 0xFF),
+                UInt8((jpegOffset >> 8) & 0xFF),
+                UInt8(jpegOffset & 0xFF)
+            ])
+        // JpgFromRawLength entry
+        data.replaceSubrange((entriesStart+12)..<(entriesStart+24), with:
+            [0x02, 0x02, 0x00, 0x04] +
+            [0x00, 0x00, 0x00, 0x01] +
+            [
+                UInt8((jpegLength >> 24) & 0xFF),
+                UInt8((jpegLength >> 16) & 0xFF),
+                UInt8((jpegLength >> 8) & 0xFF),
+                UInt8(jpegLength & 0xFF)
+            ])
+
+        let extracted = ARWPreviewExtractor.extractFullResJPEG(fromContainer: data)
+        #expect(extracted != nil)
+        #expect(Array(extracted!) == validJPEG)
+    }
+}


### PR DESCRIPTION
## Why this is needed

PR #73 made \`decodeForSharpness\` use \`kCGImageSourceCreateThumbnailFromImageIfAbsent\` thinking that returned Sony's embedded full-res preview. It does not — for Sony ARW it returns the **1616×1080 medium preview**, only marginally larger than the 1280 inference image. The sharpness pass effectively still ran at the wrong resolution; the DSC09838 vs DSC09846 case (same hummingbird burst, both eyes hidden, one visibly sharper) tied within 0.3 points instead of separating across a rating threshold.

## The actual ARW layout

Sony ARW embeds three images:

| IFD | Tag | Size | What |
|---|---|---|---|
| IFD0 | 0x0288 | ~160 px | Small thumbnail |
| IFD0 | 0x0201 | **1616×1080** | Medium preview (what \`IfAbsent\` returns) |
| **IFD2** | **0x0201** | **5616×3744 / 8640×5760** | **Full-res JPEG (what we want)** |

The full-res JPEG isn't reachable through ImageIO's thumbnail API: \`CGImageSourceGetCount\` returns 1, and the only way to force full-res is \`kCGImageSourceCreateThumbnailFromImageAlways\`, which routes through CIRAW (~611 ms per A1 ARW).

## What this PR does

\`ARWPreviewExtractor.swift\` — hand-rolled TIFF IFD walker that follows IFD0 → next → IFD1 → next → IFD2 and reads the \`JpgFromRaw\` start (0x0201) and length (0x0202) tags. Returns the JPEG byte slice positioned over the memory-mapped file (no copy). Same pattern as \`SonyMakerNoteReader\`.

\`RAWConverter.decodeForSharpness\` tries this fast path for \`.arw\` files first and falls back to ImageIO \`Always\` for non-ARW RAW.

## Verification on real Sony A1 ARW

| | bytes | extract | decode | total |
|---|---:|---:|---:|---:|
| DSC09838.ARW | 3,691,567 → 5616×3744 | 35 ms | 73 ms | **108 ms** |
| DSC09984.ARW | 5,287,618 → 8640×5760 | 42 ms | 35 ms | **77 ms** |

Compared to the \`Always\` path's ~611 ms per A1 ARW: **~5–8× faster**.

## Release benchmark on 877 SD-card ARWs

| Mode | Elapsed | Rate | DSC09838 | DSC09846 | Gap |
|---|---:|---:|---:|---:|---:|
| 1280 baseline | 121 s | 7.25/s | 421.7 | 421.4 | 0.3 |
| ImageIO Always (PR #73 attempt) | 386 s | 2.27/s | 362.6 | 404.7 | 42.1 |
| **ARW extractor (this PR)** | **147 s** | **5.97/s** | **341.0** | **388.3** | **47.3** ✅ |

Faster *and* better gap than the Always path. The 47-point gap puts DSC09838 (341, < 380 default threshold) on the throwaway side and DSC09846 (388, > 380) on the keeper side — the user-perceived classification finally lines up.

## Test plan

- [x] \`xcodebuild test -scheme SuperPicky -destination 'platform=macOS' -only-testing:SuperPickyTests\` — 596/596 green (9 new test cases)
- [x] App builds cleanly in Release configuration
- [x] Real-world: re-processed \`/Volumes/Untitled/DCIM/100MSDCF\` (877 ARWs), confirmed gap and perf
- [ ] CI green (this PR)

## Out of scope

- Threshold recalibration — full-res scoring drops absolute values 30–200 points across the board (gradient density scales down at higher resolution). Ranking is still correct; the user can adjust \`sharpnessThreshold\` in Settings if their existing threshold was tuned to 1280 inference resolution.
- CR3 / NEF / RAF / ORF support — would need analogous IFD walkers per format (Canon CR3 is HEIF, Nikon NEF is TIFF-like but with different tag layout). For now non-Sony RAW falls back to the \`Always\` slow path (correct, just slower).

## Tests

9 cases against hand-built TIFF byte fixtures:
- Happy path on little + big endian byte ordering
- Missing JpgFromRawStart / JpgFromRawLength → nil
- IFD chain truncates at IFD0 → nil
- IFD chain truncates at IFD1 → nil
- Garbage where JPEG should be (no SOI marker) → nil
- Out-of-range JPEG offset → nil
- Non-TIFF container → nil
- Truncated TIFF → nil