### PR TITLE
feat(ui): bypass CIRAW for ARW full-res via embedded JPEG

### DIFF
--- a/apps/mac-client/SuperPickyApp/ImageLoader.swift
+++ b/apps/mac-client/SuperPickyApp/ImageLoader.swift
@@ -85,6 +85,14 @@ enum ImageLoader {
     /// enqueues a serialised JPEG write. Set `eager` only for paths that
     /// will hand the bitmap to AppKit/SwiftUI for display — eager decoding
     /// allocates a full-resolution backing buffer (~96 MB for ARW).
+    ///
+    /// Sony ARW fast path: full-res requests pull the embedded JPEG
+    /// directly from IFD2 (5616×3744 on A1, 8640×5760 on A1 II / A7R V).
+    /// Skips ImageIO's CIRAW pipeline (~250 ms → ~70 ms per photo on
+    /// internal SSD) and writes the extracted bytes to the disk cache
+    /// verbatim — no decode-encode round-trip. Falls back to the
+    /// CGImageSource path on extraction failure (older Sony bodies that
+    /// don't write the IFD2 entry).
     private static func decodeCore(path: String, maxPixelSize: Int?, tag: String, eager: Bool) -> CGImage? {
         let basename = (path as NSString).lastPathComponent
         let started = DispatchTime.now()
@@ -94,6 +102,26 @@ enum ImageLoader {
             log.info("[\(tag, privacy: .public)] HIT \(basename, privacy: .public) \(ms, privacy: .public)ms")
             return cached
         }
+
+        // ARW fast path: full-res requests bypass CIRAW entirely.
+        let isARW = (path as NSString).pathExtension.lowercased() == "arw"
+        if maxPixelSize == nil, isARW,
+           let jpegData = ARWPreviewExtractor.extractFullResJPEG(from: path),
+           let arwSource = CGImageSourceCreateWithData(jpegData as CFData, nil),
+           let result = decodeFromSource(arwSource, eager: eager) {
+            let s = PreviewCache.settings
+            if s.generate, !Task.isCancelled {
+                // The extracted bytes are already a JPEG — write them to
+                // disk verbatim instead of re-encoding from a decoded
+                // bitmap. Saves ~50 ms per first-visit photo and avoids
+                // pinning a 96 MB CGImage in the writer queue.
+                schedulePreviewCacheWriteBytes(data: jpegData, rawPath: path, capBytes: s.capBytes)
+            }
+            let ms = elapsedMs(since: started)
+            log.info("[\(tag, privacy: .public)] ARW-MISS \(basename, privacy: .public) \(ms, privacy: .public)ms eager=\(eager, privacy: .public) write=\(s.generate, privacy: .public)")
+            return result
+        }
+
         let url = URL(fileURLWithPath: path)
         guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
             log.error("[\(tag, privacy: .public)] OPEN-FAIL \(basename, privacy: .public)")
@@ -105,23 +133,7 @@ enum ImageLoader {
             log.info("[\(tag, privacy: .public)] PREVIEW \(maxPixelSize)px \(basename, privacy: .public) \(ms, privacy: .public)ms")
             return result
         }
-        // ShouldCache pins the decoded bitmap inside the source. We only
-        // want that for paths that will return the bitmap to a caller —
-        // for the sweep we throw it away after the JPEG encode.
-        let createOpts: [CFString: Any] = eager
-            ? [kCGImageSourceShouldCache: true,
-               kCGImageSourceShouldCacheImmediately: true,
-               kCGImageSourceCreateThumbnailWithTransform: true]
-            : [kCGImageSourceShouldCache: false,
-               kCGImageSourceCreateThumbnailWithTransform: true]
-        let cgImage = CGImageSourceCreateImageAtIndex(source, 0, createOpts as CFDictionary)
-
-        let result: CGImage?
-        if let cgImage, eager {
-            result = forceDecode(cgImage)
-        } else {
-            result = cgImage
-        }
+        let result = decodeFromSource(source, eager: eager)
 
         let s = PreviewCache.settings
         if let imageForEncode = result, s.generate, !Task.isCancelled {
@@ -146,6 +158,25 @@ enum ImageLoader {
         let ms = elapsedMs(since: started)
         log.info("[\(tag, privacy: .public)] MISS \(basename, privacy: .public) \(ms, privacy: .public)ms eager=\(eager, privacy: .public) write=\(s.generate, privacy: .public)")
         return result
+    }
+
+    /// Decode the primary image from a `CGImageSource` with the
+    /// eager/lazy bookkeeping shared between the ARW fast path and the
+    /// regular CGImageSource path.
+    private static func decodeFromSource(_ source: CGImageSource, eager: Bool) -> CGImage? {
+        // ShouldCache pins the decoded bitmap inside the source. We only
+        // want that for paths that will return the bitmap to a caller —
+        // for the sweep we throw it away after the JPEG encode.
+        let createOpts: [CFString: Any] = eager
+            ? [kCGImageSourceShouldCache: true,
+               kCGImageSourceShouldCacheImmediately: true,
+               kCGImageSourceCreateThumbnailWithTransform: true]
+            : [kCGImageSourceShouldCache: false,
+               kCGImageSourceCreateThumbnailWithTransform: true]
+        guard let cgImage = CGImageSourceCreateImageAtIndex(source, 0, createOpts as CFDictionary) else {
+            return nil
+        }
+        return eager ? forceDecode(cgImage) : cgImage
     }
 
     /// Render the image into a same-sized bitmap context and return the


### PR DESCRIPTION
## Why

\`ImageLoader.decodeCore\` (\`maxPixelSize: nil\` path) was the slowest single hot-path in the UI: \`CGImageSourceCreateImageAtIndex\` on a Sony ARW URL routes through CIRAW. Per-photo cost on internal SSD: **~611 ms**. Zoom-mode arrow scrubbing and back-arrow nav were waiting on this every time the disk cache missed.

PR #74 already established that the embedded full-res JPEG inside the ARW (5616×3744 on A1, 8640×5760 on A1 II / A7R V) is reachable in ~70 ms via a hand-rolled TIFF IFD walker. This PR wires that same fast path into the UI loader.

## What changes

- \`ImageLoader.decodeCore\` tries \`ARWPreviewExtractor.extractFullResJPEG\` first for full-res requests on \`.arw\`. On success, decodes the JPEG slice via \`CGImageSourceCreateWithData\` (~30 ms) and \`forceDecode\`s for eager paths (same memory pinning rules as before).
- Disk cache write path **copies the extracted JPEG bytes verbatim** via the existing \`schedulePreviewCacheWriteBytes\` infrastructure. No more decode-encode round-trip — saves another ~50 ms per first-visit photo.
- Factored the eager/lazy decode bookkeeping into a shared \`decodeFromSource\` helper so both branches stay consistent.
- Preview path (\`maxPixelSize: 2000\`) is unchanged. It was already optimal for ARW — returns the 1616 px embedded medium thumb directly via \`kCGImageSourceCreateThumbnailFromImageIfAbsent\`.
- Non-ARW RAW (CR3, NEF, …) and older Sony bodies that don't write the IFD2 JpgFromRaw entry: fall back to the existing CGImageSource path. Same behavior as before.

## Benchmark — 50 ARW files, Sony A1, internal SSD

| Path | Total | Per photo |
|---|---:|---:|
| CIRAW (current) | 30,554 ms | 611 ms |
| **ARW extractor** | **2,829 ms** | **57 ms** |
| Speedup | | **10.8×** |

## Test plan

- [x] \`xcodebuild test -scheme SuperPicky -destination 'platform=macOS' -only-testing:SuperPickyTests\` — 596/596 green
- [x] App builds in Release configuration
- [x] Real-world bench on 50 ARWs — 10.8× speedup measured
- [ ] CI green (this PR)

## Behavior change

The embedded JPEG reflects in-camera processing (white balance, picture profile, Creative Look, in-camera sharpening + NR). CIRAW does its own demosaic with default Apple settings. The decoded display image will look slightly different — usually a bit closer to "what the camera saw." For the culling use case this is arguably more accurate.

Existing disk-cache files (from prior CIRAW decodes) remain valid — they're JPEG, just decoded from different source pixels. They'll be naturally replaced with embedded-JPEG copies on next visit.

## Out of scope

- Cache effectiveness telemetry — discussed offline. Plan to evaluate hit rate over a few real culling sessions before deciding whether to drop the cache infrastructure entirely.
- Non-ARW formats (CR3, NEF, RAF) — would need format-specific embedded-preview extractors. Not scoped here.