### PR TITLE
feat(ui): sharpness-bbox debug overlay

### DIFF
--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 		C3901B0082034877AE3BC55C /* SonyMakerNoteReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */; };
 		4ED691282A8C468A9D7BD925 /* TIFFIFDReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53C33BA781A440C9AE778D6 /* TIFFIFDReader.swift */; };
 		6F23FF145A47470BA787AF59 /* ARWPreviewExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F5E90BEF90404C87B11FC7 /* ARWPreviewExtractor.swift */; };
+		CC8FAC23CCA940C089496D9A /* SharpnessOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027FDBF4E1334683B8F48E4D /* SharpnessOverlay.swift */; };
 		D38A19D7CAC54302B15A874A /* ARWPreviewExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9657238527145B999C1DB00 /* ARWPreviewExtractorTests.swift */; };
 		C411A16A447248E699F22041 /* SonyMakerNoteReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */; };
 		D6070A885F8DE451AE897CEE /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1508E6CA44451D6B09FAD8BF /* ImageLoader.swift */; };
@@ -473,6 +474,7 @@
 		DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonyMakerNoteReader.swift; sourceTree = "<group>"; };
 		B53C33BA781A440C9AE778D6 /* TIFFIFDReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TIFFIFDReader.swift; sourceTree = "<group>"; };
 		B6F5E90BEF90404C87B11FC7 /* ARWPreviewExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARWPreviewExtractor.swift; sourceTree = "<group>"; };
+		027FDBF4E1334683B8F48E4D /* SharpnessOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharpnessOverlay.swift; sourceTree = "<group>"; };
 		C9657238527145B999C1DB00 /* ARWPreviewExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARWPreviewExtractorTests.swift; sourceTree = "<group>"; };
 		91ADC144F7724CCEB918F650 /* SonyMakerNoteReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonyMakerNoteReaderTests.swift; sourceTree = "<group>"; };
 		55FD8383417E1258A87ACD4A /* species_list_FI.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = species_list_FI.json; sourceTree = "<group>"; };
@@ -807,6 +809,7 @@
 				DCEACE5C871E4202BF29F2E5 /* SonyMakerNoteReader.swift */,
 				B53C33BA781A440C9AE778D6 /* TIFFIFDReader.swift */,
 				B6F5E90BEF90404C87B11FC7 /* ARWPreviewExtractor.swift */,
+				027FDBF4E1334683B8F48E4D /* SharpnessOverlay.swift */,
 				8D61960564355CE428DB7AAB /* ExifPanelView.swift */,
 				75A29A263D346C79918EC367 /* EXIFReader.swift */,
 				C9D7B139DADC49E884F6DC14 /* ExportService.swift */,
@@ -1592,6 +1595,7 @@
 				C3901B0082034877AE3BC55C /* SonyMakerNoteReader.swift in Sources */,
 				4ED691282A8C468A9D7BD925 /* TIFFIFDReader.swift in Sources */,
 				6F23FF145A47470BA787AF59 /* ARWPreviewExtractor.swift in Sources */,
+				CC8FAC23CCA940C089496D9A /* SharpnessOverlay.swift in Sources */,
 				E8A2927BC88504E05E879CEC /* EXIFReader.swift in Sources */,
 				AD9998180DB9935038EF3D5A /* ExifFormatters.swift in Sources */,
 				8D6EA52385D28EA1B9D1B25F /* ExifPanelView.swift in Sources */,

--- a/apps/mac-client/SuperPickyApp/ContentView.swift
+++ b/apps/mac-client/SuperPickyApp/ContentView.swift
@@ -43,6 +43,7 @@ struct ContentView: View {
     @State private var pendingDeleteID: UUID?
     @State private var showKeyboardHelp = false
     @State private var showThresholdCalibrator = false
+    @State private var showSharpnessOverlay = false
 
     private var filteredPhotos: [Photo] {
         var result = photos
@@ -80,7 +81,8 @@ struct ContentView: View {
                             brightnessAdjustment: brightnessAdj,
                             mouseInView: $mouseInPreview, viewSize: $previewSize,
                             appState: appState,
-                            onCorrectSpecies: onCorrectSpecies)
+                            onCorrectSpecies: onCorrectSpecies,
+                            showSharpnessOverlay: showSharpnessOverlay)
                     .onChange(of: selectedPhotoID) { _, newID in
                         guard let newID,
                               let idx = filteredPhotos.firstIndex(where: { $0.id == newID }) else {
@@ -270,6 +272,17 @@ struct ContentView: View {
                 }
                 .accessibilityIdentifier("ExportMenu")
                 .help(config.localized("Export photos (⌘E for picks)"))
+            }
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    showSharpnessOverlay.toggle()
+                } label: {
+                    Image(systemName: showSharpnessOverlay
+                          ? "rectangle.dashed.badge.record"
+                          : "rectangle.dashed")
+                }
+                .accessibilityIdentifier("SharpnessOverlayToggle")
+                .help(config.localized("Show sharpness measurement region (bbox + head circle)"))
             }
             ToolbarItem(placement: .automatic) {
                 Button {

--- a/apps/mac-client/SuperPickyApp/EyeCropSharpness.swift
+++ b/apps/mac-client/SuperPickyApp/EyeCropSharpness.swift
@@ -11,6 +11,60 @@ struct HeadSharpness {
     static let noBeakRadiusRatio: Float = 0.15
     static let lowVisPenalty: Float = 0.8
 
+    /// The eye `score(...)` measures over, and which `SharpnessOverlay`
+    /// must draw to honestly visualize the metric.
+    struct EyePick {
+        let x: Float
+        let y: Float
+        /// True when neither eye crossed `visibilityThreshold` and we
+        /// fell back to the higher-visibility one. The metric applies
+        /// `lowVisPenalty` in this case.
+        let bothHidden: Bool
+    }
+
+    /// Pick the eye `score(...)` would measure over. Shared with
+    /// `SharpnessOverlay` so the debug overlay can't disagree with the
+    /// metric.
+    static func pickEye(
+        leftEyeX: Float?, leftEyeY: Float?, leftEyeVis: Float?,
+        rightEyeX: Float?, rightEyeY: Float?, rightEyeVis: Float?,
+        beakX: Float?, beakY: Float?
+    ) -> EyePick? {
+        let leftVis = leftEyeVis ?? 0
+        let rightVis = rightEyeVis ?? 0
+        let bothHidden = leftVis < visibilityThreshold && rightVis < visibilityThreshold
+        if bothHidden {
+            if leftVis >= rightVis, let x = leftEyeX, let y = leftEyeY {
+                return EyePick(x: x, y: y, bothHidden: true)
+            }
+            if let x = rightEyeX, let y = rightEyeY {
+                return EyePick(x: x, y: y, bothHidden: true)
+            }
+            return nil
+        }
+        let leftOK = leftVis >= visibilityThreshold
+        let rightOK = rightVis >= visibilityThreshold
+        // Both eyes visible + beak: pick whichever is further from the beak
+        // (matches superpicky's far-eye preference for occlusion robustness).
+        if leftOK && rightOK,
+           let lx = leftEyeX, let ly = leftEyeY,
+           let rx = rightEyeX, let ry = rightEyeY,
+           let bx = beakX, let by = beakY {
+            let leftDist = hypot(lx - bx, ly - by)
+            let rightDist = hypot(rx - bx, ry - by)
+            return leftDist >= rightDist
+                ? EyePick(x: lx, y: ly, bothHidden: false)
+                : EyePick(x: rx, y: ry, bothHidden: false)
+        }
+        if leftOK, let x = leftEyeX, let y = leftEyeY {
+            return EyePick(x: x, y: y, bothHidden: false)
+        }
+        if let x = rightEyeX, let y = rightEyeY {
+            return EyePick(x: x, y: y, bothHidden: false)
+        }
+        return nil
+    }
+
     /// Compute head-region sharpness of the bird crop using a circular mask centered on the best eye.
     /// Returns nil if crop is too small to measure.
     ///
@@ -38,42 +92,14 @@ struct HeadSharpness {
         let h = birdCrop.height
         guard w > 10 && h > 10 else { return nil }
 
-        let leftVis = leftEyeVis ?? 0
-        let rightVis = rightEyeVis ?? 0
+        guard let pick = pickEye(
+            leftEyeX: leftEyeX, leftEyeY: leftEyeY, leftEyeVis: leftEyeVis,
+            rightEyeX: rightEyeX, rightEyeY: rightEyeY, rightEyeVis: rightEyeVis,
+            beakX: beakX, beakY: beakY
+        ) else { return nil }
+
         let beakVisible = (beakVis ?? 0) >= visibilityThreshold
-
-        // Both eyes below visibility threshold: fallback with penalty
-        let bothHidden = leftVis < visibilityThreshold && rightVis < visibilityThreshold
-        let eye: (Float, Float)
-        if bothHidden {
-            // Use whichever eye has higher visibility as fallback
-            if leftVis >= rightVis, let x = leftEyeX, let y = leftEyeY {
-                eye = (x, y)
-            } else if let x = rightEyeX, let y = rightEyeY {
-                eye = (x, y)
-            } else {
-                return nil
-            }
-        } else {
-            // Pick eye further from beak (matches superpicky logic)
-            let leftOK = leftVis >= visibilityThreshold
-            let rightOK = rightVis >= visibilityThreshold
-            if leftOK && rightOK, let lx = leftEyeX, let ly = leftEyeY,
-               let rx = rightEyeX, let ry = rightEyeY,
-               let bx = beakX, let by = beakY {
-                let leftDist = hypot(lx - bx, ly - by)
-                let rightDist = hypot(rx - bx, ry - by)
-                eye = leftDist >= rightDist ? (lx, ly) : (rx, ry)
-            } else if leftOK, let x = leftEyeX, let y = leftEyeY {
-                eye = (x, y)
-            } else if let x = rightEyeX, let y = rightEyeY {
-                eye = (x, y)
-            } else {
-                return nil
-            }
-        }
-
-        let eyePx = (Int(eye.0 * Float(w)), Int(eye.1 * Float(h)))
+        let eyePx = (Int(pick.x * Float(w)), Int(pick.y * Float(h)))
 
         // Compute radius. Three-branch fallback matches superpicky's
         // _calculate_head_sharpness:
@@ -105,6 +131,6 @@ struct HeadSharpness {
             extraMask: segMask
         )
 
-        return bothHidden ? score * lowVisPenalty : score
+        return pick.bothHidden ? score * lowVisPenalty : score
     }
 }

--- a/apps/mac-client/SuperPickyApp/PreviewView.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewView.swift
@@ -9,12 +9,18 @@ struct PreviewView: View {
     @Binding var viewSize: CGSize
     var appState: AppState? = nil
     var onCorrectSpecies: ((UUID, String) -> Void)?
+    /// Toolbar toggle: when true, overlays the YOLO bbox + head circle
+    /// the sharpness pipeline measures over.
+    var showSharpnessOverlay: Bool = false
     @Environment(CullingConfig.self) private var config
 
     var body: some View {
         VStack(spacing: 0) {
             if let photo {
-                AsyncPreviewImage(filePath: photo.filePath, zoomState: zoomState, brightnessAdjustment: brightnessAdjustment)
+                AsyncPreviewImage(filePath: photo.filePath,
+                                  zoomState: zoomState,
+                                  brightnessAdjustment: brightnessAdjustment,
+                                  sharpnessOverlayPhoto: showSharpnessOverlay ? photo : nil)
                     .accessibilityIdentifier("PhotoPreview")
                     .onContinuousHover { phase in
                         if case .active(let loc) = phase { mouseInView = loc }
@@ -46,6 +52,8 @@ struct AsyncPreviewImage: View {
     let filePath: String
     @Bindable var zoomState: ZoomState
     var brightnessAdjustment: Double = 0
+    /// Photo metadata for the sharpness overlay. Nil = overlay off.
+    var sharpnessOverlayPhoto: Photo? = nil
     @State private var image: NSImage?
     @State private var isFullRes = false
 
@@ -74,7 +82,10 @@ struct AsyncPreviewImage: View {
         ZStack {
             Color(nsColor: .controlBackgroundColor)
             if let image {
-                ZoomableImageView(image: image, zoomState: zoomState, brightnessAdjustment: brightnessAdjustment)
+                ZoomableImageView(image: image,
+                                   zoomState: zoomState,
+                                   brightnessAdjustment: brightnessAdjustment,
+                                   sharpnessOverlayPhoto: sharpnessOverlayPhoto)
             } else {
                 ProgressView()
             }

--- a/apps/mac-client/SuperPickyApp/SharpnessOverlay.swift
+++ b/apps/mac-client/SuperPickyApp/SharpnessOverlay.swift
@@ -1,0 +1,164 @@
+import AVFoundation
+import SwiftUI
+
+/// Debug overlay that draws the geometry the sharpness pipeline measures
+/// over the displayed photo.
+///
+/// - **Red bbox** — YOLO bird bounding box. Sharpness is computed only
+///   inside this region.
+/// - **Yellow circle** — head circle (eye-centered, radius =
+///   eye-beak distance × 1.2 when beak visible, else 15 % of the
+///   smart-square crop's max side). The actual region Tenengrad
+///   averages over.
+/// - **Blue dot** — predicted eye location used as the circle centre.
+///   When eye visibility < 0.5 ("bothHidden") this is a fallback
+///   prediction and the circle's anatomical accuracy is suspect —
+///   exactly the case this overlay diagnoses.
+///
+/// Coordinates: bbox is normalized to the original image. Eye/beak
+/// keypoints are normalized to the smartSquareBirdCrop output canvas,
+/// which may include black letterbox bars on near-edge subjects. We
+/// reproduce that pixel-exact crop math in `cropToImageNorm` so the
+/// rendered circle/dot land on the same pixels the metric measures.
+struct SharpnessOverlay: View {
+    let photo: Photo
+    /// Natural pixel size of the displayed image (NSImage.size). Needed
+    /// to resolve aspect-fit margins inside the overlay's geo, and to
+    /// reproduce the smart-square-crop letterbox math.
+    let imageSize: CGSize
+
+    private static let radiusMultiplier: CGFloat = 1.2
+    private static let noBeakRadiusRatio: CGFloat = 0.15
+    private static let cropPaddingFactor: CGFloat = 1.15
+
+    var body: some View {
+        GeometryReader { geo in
+            if let bbox = bbox, imageSize.width > 0, imageSize.height > 0 {
+                let imgRect = AVMakeRect(
+                    aspectRatio: imageSize,
+                    insideRect: CGRect(origin: .zero, size: geo.size)
+                )
+                let bboxRect = CGRect(
+                    x: imgRect.minX + bbox.minX * imgRect.width,
+                    y: imgRect.minY + bbox.minY * imgRect.height,
+                    width:  bbox.width  * imgRect.width,
+                    height: bbox.height * imgRect.height
+                )
+                Rectangle()
+                    .stroke(.red, lineWidth: 1.5)
+                    .frame(width: bboxRect.width, height: bboxRect.height)
+                    .position(x: bboxRect.midX, y: bboxRect.midY)
+
+                if let eye = selectedEyeInCropCoords,
+                   let eyeImageNorm = cropToImageNorm(eye, bbox: bbox) {
+                    let eyeOnScreen = CGPoint(
+                        x: imgRect.minX + eyeImageNorm.x * imgRect.width,
+                        y: imgRect.minY + eyeImageNorm.y * imgRect.height
+                    )
+                    // Head radius is in IMAGE PIXELS (smart-square crop is
+                    // in image-pixel space). Convert to screen via the
+                    // imgRect-to-image scale.
+                    let scale = imgRect.width / imageSize.width
+                    let radiusPx = headRadiusInImagePx(eyeCrop: eye, bbox: bbox)
+                    let radiusOnScreen = radiusPx * scale
+                    Circle()
+                        .stroke(.yellow, lineWidth: 1.5)
+                        .frame(width: radiusOnScreen * 2,
+                                height: radiusOnScreen * 2)
+                        .position(eyeOnScreen)
+                    Circle()
+                        .fill(.blue)
+                        .frame(width: 6, height: 6)
+                        .position(eyeOnScreen)
+                }
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    /// Reproduce `CGImage.smartSquareBirdCrop`'s pixel-exact geometry —
+    /// including bbox-to-image clamping and the letterbox padding that
+    /// makes the cropped region square — and return the keypoint's
+    /// position in image-normalized [0, 1] coords.
+    ///
+    /// The keypoint model received an image at 1280-max-side, but bbox is
+    /// normalized so doing the math at the displayed image's pixel size
+    /// gives the same crop *normalized* coordinate.
+    ///
+    /// TODO: this is the third copy of `smartSquareBirdCrop`'s integer
+    /// geometry (others in `CGImageExtensions.swift` and
+    /// `PipelineCoordinator.birdCropAlignedSegMask`). Lift to a shared
+    /// `SmartSquareCropGeometry` struct in CGImageExtensions in a
+    /// follow-up PR.
+    private func cropToImageNorm(_ cropPoint: (x: Float, y: Float),
+                                  bbox: CGRect) -> CGPoint? {
+        let imgW = imageSize.width, imgH = imageSize.height
+        let px1 = floor(bbox.origin.x * imgW)
+        let py1 = floor(bbox.origin.y * imgH)
+        let px2 = ceil((bbox.origin.x + bbox.size.width)  * imgW)
+        let py2 = ceil((bbox.origin.y + bbox.size.height) * imgH)
+        let bboxW = px2 - px1, bboxH = py2 - py1
+        guard bboxW > 0, bboxH > 0 else { return nil }
+        let maxSide = max(bboxW, bboxH)
+        let target = floor(maxSide * Self.cropPaddingFactor)
+        let cx = (px1 + px2) / 2, cy = (py1 + py2) / 2
+        let half = floor(target / 2)
+        let cropX1 = max(0, cx - half), cropY1 = max(0, cy - half)
+        let cropX2 = min(imgW, cx + half), cropY2 = min(imgH, cy + half)
+        let cropW = cropX2 - cropX1, cropH = cropY2 - cropY1
+        guard cropW > 0, cropH > 0 else { return nil }
+        let sqSize = max(cropW, cropH)
+        // Letterbox offset of the image content inside the square canvas.
+        let offX = floor((sqSize - cropW) / 2)
+        let offY = floor((sqSize - cropH) / 2)
+
+        let cpx = CGFloat(cropPoint.x) * sqSize
+        let cpy = CGFloat(cropPoint.y) * sqSize
+        let imgPx = cropX1 + (cpx - offX)
+        let imgPy = cropY1 + (cpy - offY)
+        return CGPoint(x: imgPx / imgW, y: imgPy / imgH)
+    }
+
+    /// Head circle radius in image pixels (mirrors `HeadSharpness`'s
+    /// 3-branch fallback at the smart-square-crop's pixel resolution).
+    private func headRadiusInImagePx(eyeCrop: (x: Float, y: Float),
+                                      bbox: CGRect) -> CGFloat {
+        let imgW = imageSize.width, imgH = imageSize.height
+        let bboxW = bbox.width * imgW, bboxH = bbox.height * imgH
+        let target = max(bboxW, bboxH) * Self.cropPaddingFactor
+        let beakVisible = (photo.beakVis ?? 0) >= HeadSharpness.visibilityThreshold
+        if beakVisible, let bx = photo.beakX, let by = photo.beakY {
+            let dx = CGFloat(eyeCrop.x - bx), dy = CGFloat(eyeCrop.y - by)
+            // Eye-beak distance in crop-canvas pixels = norm * target.
+            return hypot(dx, dy) * target * Self.radiusMultiplier
+        }
+        return target * Self.noBeakRadiusRatio
+    }
+
+    /// Bird bbox in image-normalized [0, 1] coords. The DB stores the
+    /// JSON `[x1, y1, x2, y2]` — see `PipelineCoordinator.encodeJSON` of
+    /// `bird.bbox`'s minX/minY/maxX/maxY.
+    private var bbox: CGRect? {
+        guard let json = photo.birdBboxJSON,
+              let data = json.data(using: .utf8),
+              let arr = (try? JSONSerialization.jsonObject(with: data)) as? [Double],
+              arr.count == 4 else {
+            return nil
+        }
+        let x = arr[0], y = arr[1], w = arr[2] - arr[0], h = arr[3] - arr[1]
+        guard w > 0, h > 0 else { return nil }
+        return CGRect(x: x, y: y, width: w, height: h)
+    }
+
+    /// Picked eye in bird-crop normalized coords. Delegates to
+    /// `HeadSharpness.pickEye` so the overlay can't disagree with the
+    /// metric's selection rule.
+    private var selectedEyeInCropCoords: (x: Float, y: Float)? {
+        guard let pick = HeadSharpness.pickEye(
+            leftEyeX: photo.leftEyeX, leftEyeY: photo.leftEyeY, leftEyeVis: photo.leftEyeVis,
+            rightEyeX: photo.rightEyeX, rightEyeY: photo.rightEyeY, rightEyeVis: photo.rightEyeVis,
+            beakX: photo.beakX, beakY: photo.beakY
+        ) else { return nil }
+        return (pick.x, pick.y)
+    }
+}

--- a/apps/mac-client/SuperPickyApp/ZoomableImageView.swift
+++ b/apps/mac-client/SuperPickyApp/ZoomableImageView.swift
@@ -67,6 +67,9 @@ struct ZoomableImageView: View {
     let image: NSImage
     @Bindable var zoomState: ZoomState
     var brightnessAdjustment: Double = 0
+    /// Optional photo metadata for the sharpness-region overlay. Drawn
+    /// only when the toolbar toggle is on.
+    var sharpnessOverlayPhoto: Photo?
 
     @State private var dragStart: CGSize = .zero
 
@@ -75,6 +78,16 @@ struct ZoomableImageView: View {
             Image(nsImage: image)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
+                .overlay {
+                    // Overlay sits in the same aspect-fit box as the
+                    // image, so geo.size inside it matches the displayed
+                    // image's content rect. Subsequent .scaleEffect /
+                    // .offset apply equally to image and overlay so they
+                    // track together when the user zooms / pans.
+                    if let photo = sharpnessOverlayPhoto {
+                        SharpnessOverlay(photo: photo, imageSize: image.size)
+                    }
+                }
                 .brightness(brightnessAdjustment)
                 .scaleEffect(zoomState.scale)
                 .offset(zoomState.offset)


### PR DESCRIPTION
## Summary

- New toolbar toggle (between Export and ThresholdCalibrator) that overlays the YOLO bbox + head circle + predicted-eye dot on the preview, showing the exact geometry `HeadSharpness` measures over. Use it to diagnose cases where the score doesn't match visual sharpness (wrong eye picked, head circle on the wrong feature, fallback prediction at the canvas center, etc.).
- Eye-pick logic extracted to `HeadSharpness.pickEye(...)` so the overlay and the metric share the same selection rule — the debug tool can't silently lie about what's measured.
- Coordinate math reproduces `smartSquareBirdCrop`'s pixel-exact letterbox geometry so the circle/dot land on the same pixels `HeadSharpness` averages over.

## Notes

- /simplify cleanup applied: `AVFoundation.AVMakeRect` for aspect-fit math (drops a hand-rolled helper), comment trims.
- Deferred (separate PR): the smart-square-crop integer geometry now has 3 in-tree copies (`CGImageExtensions.smartSquareBirdCrop`, `PipelineCoordinator.birdCropAlignedSegMask`, `SharpnessOverlay.cropToImageNorm`). TODO marker added in the new file pointing at a follow-up extraction into a shared `SmartSquareCropGeometry` struct. Skipping here to keep the PR scoped — the overlay's correctness only requires the math be byte-identical, which it is.

## Test plan

- [x] `xcodebuild build -scheme SuperPicky -destination 'platform=macOS'` — green
- [x] `xcodebuild test -only-testing:SuperPickyTests` — 596/596 pass (pickEye refactor preserves HeadSharpness.score behavior)
- [x] swiftlint clean on touched files
- [ ] Toggle the overlay in the running app on a folder with processed photos and confirm bbox/circle/eye-dot register on the displayed image at all zoom levels