### PR TITLE
Add Reveal in Finder right-click context menu

### DIFF
--- a/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+++ b/apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
@@ -287,6 +287,8 @@
 		E0160F8B17617703E31466F2 /* species_list_CN-12.json in Resources */ = {isa = PBXBuildFile; fileRef = A9EBF634334BADAF97C8EBD3 /* species_list_CN-12.json */; };
 		E0B05DE538CC0A9CECAB49DD /* species_list_RO.json in Resources */ = {isa = PBXBuildFile; fileRef = 630E0E89318F8DD9B239C3CF /* species_list_RO.json */; };
 		E0EE37CCF733B5B791B59CC5 /* SourceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1BBBB42C2CD216C1D02DAF /* SourceListView.swift */; };
+		74D486A7467148B4AB966177 /* FinderReveal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332E27F28CB24062B2D1F396 /* FinderReveal.swift */; };
+		2380DF8702044FDB8C3A2C7B /* FinderRevealTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF09D112F74C4947928E0032 /* FinderRevealTests.swift */; };
 		E1FCA59C8FC8E5512E0AA81B /* species_list_CN-34.json in Resources */ = {isa = PBXBuildFile; fileRef = EBDE1BB7D41B36A0E8FCD82B /* species_list_CN-34.json */; };
 		E2EF039AD03AF4B1634A1B8E /* species_list_US-KS.json in Resources */ = {isa = PBXBuildFile; fileRef = E2E8038D8ACEA4821EB52B46 /* species_list_US-KS.json */; };
 		E35151E7C480D8AA62F668A2 /* species_list_ZA.json in Resources */ = {isa = PBXBuildFile; fileRef = F032247F3FF943B296C8ECF3 /* species_list_ZA.json */; };
@@ -505,6 +507,8 @@
 		69576E5469D18F7A15647585 /* EyeCropSharpness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EyeCropSharpness.swift; sourceTree = "<group>"; };
 		6BAE259F49B382A29C715A18 /* species_list_CN-13.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "species_list_CN-13.json"; sourceTree = "<group>"; };
 		6C1BBBB42C2CD216C1D02DAF /* SourceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceListView.swift; sourceTree = "<group>"; };
+		332E27F28CB24062B2D1F396 /* FinderReveal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderReveal.swift; sourceTree = "<group>"; };
+		CF09D112F74C4947928E0032 /* FinderRevealTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderRevealTests.swift; sourceTree = "<group>"; };
 		6C752379CFE1D005A0F3C8D1 /* species_list_GB.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = species_list_GB.json; sourceTree = "<group>"; };
 		6D03B7B3D939AB0A665F70A8 /* SpeciesHierarchyIncrementalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeciesHierarchyIncrementalTests.swift; sourceTree = "<group>"; };
 		6DC3715223CF6A27524FF960 /* AestheticsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AestheticsModelTests.swift; sourceTree = "<group>"; };
@@ -737,6 +741,7 @@
 			children = (
 				B692D00B454892AE77C8C7E2 /* AssignedSpeciesTests.swift */,
 				D1FE12CD3456789012345678 /* NavigationStateMonitorTests.swift */,
+				CF09D112F74C4947928E0032 /* FinderRevealTests.swift */,
 				B3FE12CD3456789012345678 /* PreviewCacheTests.swift */,
 				B7FE12CD3456789012345678 /* ImageCacheBudgetTests.swift */,
 				B8FE12CD3456789012345678 /* PreviewLoadPolicyTests.swift */,
@@ -844,6 +849,7 @@
 				9E0746DF7299012FFAB245AC /* ReverseGeocoder.swift */,
 				7D33DE9FFC32E245ECAD4536 /* ScrollWheelRedirector.swift */,
 				2035E1F0D51979F7D9BD4857 /* SettingsView.swift */,
+				332E27F28CB24062B2D1F396 /* FinderReveal.swift */,
 				6C1BBBB42C2CD216C1D02DAF /* SourceListView.swift */,
 				C4D16716BD00EB694FAEF0DB /* SpeciesAssignmentEditor.swift */,
 				6DDC8E8C649AF2E099E54AB6 /* SpeciesHierarchyBuilder.swift */,
@@ -1517,6 +1523,7 @@
 				DDE8E519157564DD655F575A /* AestheticsModelTests.swift in Sources */,
 				7CF4E498D7CA0C66F2559AFE /* AssignedSpeciesTests.swift in Sources */,
 				C1FE12CD3456789012345678 /* NavigationStateMonitorTests.swift in Sources */,
+				2380DF8702044FDB8C3A2C7B /* FinderRevealTests.swift in Sources */,
 				A3FE12CD3456789012345678 /* PreviewCacheTests.swift in Sources */,
 				A7FE12CD3456789012345678 /* ImageCacheBudgetTests.swift in Sources */,
 				A8FE12CD3456789012345678 /* PreviewLoadPolicyTests.swift in Sources */,
@@ -1632,6 +1639,7 @@
 				D3AB1B683EDBD7F05D14C18C /* ReverseGeocoder.swift in Sources */,
 				1E365AD68087DE165D07CA7E /* ScrollWheelRedirector.swift in Sources */,
 				72593C01A639B74395F129D0 /* SettingsView.swift in Sources */,
+				74D486A7467148B4AB966177 /* FinderReveal.swift in Sources */,
 				E0EE37CCF733B5B791B59CC5 /* SourceListView.swift in Sources */,
 				3BB13D2BC4F7884AA4BB4DBA /* SpeciesAssignmentEditor.swift in Sources */,
 				06B5974B68BDC4BE7D30DD44 /* SpeciesHierarchyBuilder.swift in Sources */,

--- a/apps/mac-client/SuperPickyApp/FinderReveal.swift
+++ b/apps/mac-client/SuperPickyApp/FinderReveal.swift
@@ -1,0 +1,21 @@
+import AppKit
+import Foundation
+
+protocol FinderRevealer {
+    func reveal(_ urls: [URL])
+}
+
+struct SystemFinderRevealer: FinderRevealer {
+    func reveal(_ urls: [URL]) {
+        NSWorkspace.shared.activateFileViewerSelecting(urls)
+    }
+}
+
+@MainActor
+enum FinderReveal {
+    static var revealer: FinderRevealer = SystemFinderRevealer()
+
+    static func reveal(_ photo: Photo) {
+        revealer.reveal([URL(fileURLWithPath: photo.filePath)])
+    }
+}

--- a/apps/mac-client/SuperPickyApp/PreviewView.swift
+++ b/apps/mac-client/SuperPickyApp/PreviewView.swift
@@ -29,6 +29,14 @@ struct PreviewView: View {
                         Color.clear.onAppear { viewSize = geo.size }
                             .onChange(of: geo.size) { _, s in viewSize = s }
                     })
+                    .contextMenu {
+                        Button {
+                            FinderReveal.reveal(photo)
+                        } label: {
+                            Label(config.localized("Reveal in Finder"), systemImage: "folder")
+                        }
+                        .accessibilityIdentifier("RevealInFinder")
+                    }
                 InfoBarView(photo: photo, appState: appState, onCorrectSpecies: { name in
                     onCorrectSpecies?(photo.id, name)
                 })

--- a/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
+++ b/apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
@@ -93,6 +93,7 @@ struct ThumbnailCell: View {
     let isActive: Bool
     let isSelected: Bool
     let isDimmed: Bool
+    @Environment(CullingConfig.self) private var config
 
     static let accessibilityIDPrefix = "Thumbnail_"
 
@@ -167,6 +168,14 @@ struct ThumbnailCell: View {
         .animation(.easeInOut(duration: 0.15), value: isDimmed)
         .accessibilityIdentifier(Self.accessibilityID(for: photo))
         .accessibilityValue(a11ySelectionValue)
+        .contextMenu {
+            Button {
+                FinderReveal.reveal(photo)
+            } label: {
+                Label(config.localized("Reveal in Finder"), systemImage: "folder")
+            }
+            .accessibilityIdentifier("RevealInFinder")
+        }
     }
 }
 

--- a/apps/mac-client/SuperPickyTests/Core/FinderRevealTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/FinderRevealTests.swift
@@ -1,0 +1,31 @@
+import Testing
+import Foundation
+@testable import SuperPicky
+
+@MainActor
+struct FinderRevealTests {
+    final class RecordingRevealer: FinderRevealer {
+        var recorded: [URL] = []
+        func reveal(_ urls: [URL]) {
+            recorded.append(contentsOf: urls)
+        }
+    }
+
+    @Test
+    func revealsPhotoFilePathAsURL() {
+        let original = FinderReveal.revealer
+        defer { FinderReveal.revealer = original }
+
+        let fake = RecordingRevealer()
+        FinderReveal.revealer = fake
+
+        let photo = Photo(
+            filename: "test.arw",
+            filePath: "/tmp/superpicky/test.arw",
+            folderPath: "/tmp/superpicky"
+        )
+        FinderReveal.reveal(photo)
+
+        #expect(fake.recorded == [URL(fileURLWithPath: "/tmp/superpicky/test.arw")])
+    }
+}

--- a/apps/mac-client/SuperPickyUITests/A11y.swift
+++ b/apps/mac-client/SuperPickyUITests/A11y.swift
@@ -12,6 +12,7 @@ enum A11y {
     static let speciesEditPanelSearchField = "SpeciesEditPanel_SearchField"
     static let speciesEditPanelEmptyAssigned = "SpeciesEditPanel_EmptyAssigned"
     static let selectionCounter = "SelectionCounter"
+    static let revealInFinderMenuItem = "RevealInFinder"
 
     /// Accessibility values used by ThumbnailCell — match
     /// `ThumbnailCell.a11ySelectionValue`.

--- a/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -454,4 +454,43 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         dismissConfirmDialogIfPresent()
         XCTAssertTrue(preview.exists, "Preview should remain after Cmd+E")
     }
+
+    // MARK: - 50-59: Context menu
+
+    func test50_ThumbnailRightClick_RevealInFinderMenuItemExists() {
+        let app = Self.app!
+        let preview = app.images[A11y.photoPreview]
+        XCTAssertTrue(preview.waitForExistence(timeout: 10),
+                      "Photo preview must be visible before right-clicking thumbnails")
+
+        // Pick the first thumbnail in the strip — must arrow into view
+        // first so LazyHStack instantiates it (per A11y rule on lazy strips).
+        let firstThumbnail = app.images.matching(NSPredicate(format: "identifier BEGINSWITH 'Thumbnail_'")).firstMatch
+        XCTAssertTrue(firstThumbnail.waitForExistence(timeout: 5),
+                      "At least one thumbnail must exist")
+
+        firstThumbnail.rightClick()
+
+        let menuItem = app.menuItems[A11y.revealInFinderMenuItem]
+        XCTAssertTrue(menuItem.waitForExistence(timeout: 3),
+                      "Reveal in Finder menu item should appear on right-click")
+
+        // Dismiss without invoking — clicking would launch Finder during CI.
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    func test51_PreviewRightClick_RevealInFinderMenuItemExists() {
+        let app = Self.app!
+        let preview = app.images[A11y.photoPreview]
+        XCTAssertTrue(preview.waitForExistence(timeout: 10),
+                      "Photo preview must be visible")
+
+        preview.rightClick()
+
+        let menuItem = app.menuItems[A11y.revealInFinderMenuItem]
+        XCTAssertTrue(menuItem.waitForExistence(timeout: 3),
+                      "Reveal in Finder menu item should appear on right-click")
+
+        app.typeKey(.escape, modifierFlags: [])
+    }
 }

--- a/docs/superpowers/plans/2026-05-04-reveal-in-finder-context-menu.md
+++ b/docs/superpowers/plans/2026-05-04-reveal-in-finder-context-menu.md
@@ -1,0 +1,441 @@
+# Reveal in Finder context menu — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a right-click context menu with a single "Reveal in Finder" item to thumbnail strip cells and the main preview, so the user can jump from the app to the photo's parent folder in Finder with the file selected.
+
+**Architecture:** Extract a tiny `FinderReveal` helper (protocol + enum) so both call sites share one line and the L1 test can swap the AppKit call for a fake. Attach `.contextMenu` to `ThumbnailCell` and to `AsyncPreviewImage` inside `PreviewView`. Add an `A11y.revealInFinderMenuItem` identifier so XCUITests can address the menu item.
+
+**Tech Stack:** Swift / SwiftUI, AppKit (`NSWorkspace.activateFileViewerSelecting`), Swift Testing for L1, XCUITest for L3.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-reveal-in-finder-context-menu-design.md`
+
+**Working directory for all commands:** `apps/mac-client/` (so `xcodebuild` finds the `.xcodeproj`).
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `apps/mac-client/SuperPickyApp/FinderReveal.swift` | new | `FinderRevealer` protocol + `SystemFinderRevealer` + `FinderReveal` static API |
+| `apps/mac-client/SuperPickyTests/FinderRevealTests.swift` | new | L1 Swift Testing — verifies `FinderReveal.reveal(_:)` calls injected revealer with the photo's URL |
+| `apps/mac-client/SuperPickyApp/ThumbnailStripView.swift` | modify | Add `@Environment(CullingConfig.self)` + `.contextMenu` on `ThumbnailCell` |
+| `apps/mac-client/SuperPickyApp/PreviewView.swift` | modify | Add `.contextMenu` on `AsyncPreviewImage` inside `if let photo` arm |
+| `apps/mac-client/SuperPickyUITests/A11y.swift` | modify | Add `revealInFinderMenuItem` identifier |
+| `apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift` | modify | Two new test methods: thumbnail right-click + preview right-click |
+| `apps/mac-client/SuperPicky.xcodeproj/project.pbxproj` | modify | Register `FinderReveal.swift` (app target) and `FinderRevealTests.swift` (test target) — 4 entries each |
+
+No new `.strings` keys: `"Reveal in Finder"` is already used at `MainView.swift:207`, so en + zh-Hans entries already exist. (Verify in Task 1.)
+
+---
+
+## Task 1: Verify localization key exists
+
+**Files:** read-only check — no edits.
+
+- [ ] **Step 1: Confirm `Reveal in Finder` is in both `.strings` files**
+
+Run: `grep -n "Reveal in Finder" apps/mac-client/SuperPickyApp/*.lproj/*.strings`
+
+Expected: at least one match in `en.lproj/Localizable.strings` and one in `zh-Hans.lproj/Localizable.strings`. If missing in either, add the entry there before continuing — copy the surrounding format of neighboring keys.
+
+- [ ] **Step 2: No commit (read-only).**
+
+---
+
+## Task 2: `FinderReveal` helper (TDD)
+
+**Files:**
+- Create: `apps/mac-client/SuperPickyApp/FinderReveal.swift`
+- Create: `apps/mac-client/SuperPickyTests/FinderRevealTests.swift`
+- Modify: `apps/mac-client/SuperPicky.xcodeproj/project.pbxproj` (register both files)
+
+- [ ] **Step 1: Write the failing L1 test**
+
+Create `apps/mac-client/SuperPickyTests/FinderRevealTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import SuperPicky
+
+@MainActor
+struct FinderRevealTests {
+    final class RecordingRevealer: FinderRevealer {
+        var recorded: [URL] = []
+        func reveal(_ urls: [URL]) {
+            recorded.append(contentsOf: urls)
+        }
+    }
+
+    @Test
+    func revealsPhotoFilePathAsURL() {
+        let original = FinderReveal.revealer
+        defer { FinderReveal.revealer = original }
+
+        let fake = RecordingRevealer()
+        FinderReveal.revealer = fake
+
+        let photo = Photo(
+            filename: "test.arw",
+            filePath: "/tmp/superpicky/test.arw",
+            folderPath: "/tmp/superpicky"
+        )
+        FinderReveal.reveal(photo)
+
+        #expect(fake.recorded == [URL(fileURLWithPath: "/tmp/superpicky/test.arw")])
+    }
+}
+```
+
+`Photo`'s designated init is `Photo(id: UUID = UUID(), filename: String, filePath: String, folderPath: String, dateCreated: Date = Date())` (see `SuperPickyApp/Photo.swift:63`); existing tests use the three-arg form (e.g. `SuperPickyTests/Core/PhotoSelectionTests.swift:9`).
+
+- [ ] **Step 2: Run test to verify it fails to compile**
+
+Run from `apps/mac-client/`:
+
+```bash
+xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+    -only-testing:SuperPickyTests/FinderRevealTests 2>&1 | tail -40
+```
+
+Expected: build error mentioning `FinderReveal` / `FinderRevealer` not found, OR test target doesn't include `FinderRevealTests.swift` (we register in Step 4).
+
+- [ ] **Step 3: Create the implementation**
+
+Create `apps/mac-client/SuperPickyApp/FinderReveal.swift`:
+
+```swift
+import AppKit
+import Foundation
+
+/// Protocol seam so unit tests can swap the AppKit call for a fake
+/// without launching Finder during the test run.
+protocol FinderRevealer {
+    func reveal(_ urls: [URL])
+}
+
+struct SystemFinderRevealer: FinderRevealer {
+    func reveal(_ urls: [URL]) {
+        NSWorkspace.shared.activateFileViewerSelecting(urls)
+    }
+}
+
+/// Reveals a photo in Finder with the file selected. Both right-click
+/// surfaces (thumbnail strip, main preview) call into this single API.
+@MainActor
+enum FinderReveal {
+    static var revealer: FinderRevealer = SystemFinderRevealer()
+
+    static func reveal(_ photo: Photo) {
+        revealer.reveal([URL(fileURLWithPath: photo.filePath)])
+    }
+}
+```
+
+- [ ] **Step 4: Register both new files in `project.pbxproj`**
+
+Open `apps/mac-client/SuperPicky.xcodeproj/project.pbxproj`. For each new `.swift` file, add four entries. Use `uuidgen | tr -d '-' | head -c 24` to mint UUIDs, or hand-pick 24-hex-char IDs that don't already appear in the file.
+
+For `FinderReveal.swift` (app target — pattern mirrors `SourceListView.swift` per its 4 entries at lines 289 / 507 / 847 / 1635):
+
+1. **PBXBuildFile section** (with the other `... in Sources */` entries near line 289):
+   ```
+   <NEW_BUILD_UUID> /* FinderReveal.swift in Sources */ = {isa = PBXBuildFile; fileRef = <NEW_FILE_REF_UUID> /* FinderReveal.swift */; };
+   ```
+2. **PBXFileReference section** (with the other `*.swift` file refs near line 507):
+   ```
+   <NEW_FILE_REF_UUID> /* FinderReveal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderReveal.swift; sourceTree = "<group>"; };
+   ```
+3. **PBXGroup `SuperPickyApp` children** (the alphabetic-ish list of `.swift` siblings near line 847):
+   ```
+   <NEW_FILE_REF_UUID> /* FinderReveal.swift */,
+   ```
+4. **PBXSourcesBuildPhase for the app target** (the long `in Sources` list near line 1635):
+   ```
+   <NEW_BUILD_UUID> /* FinderReveal.swift in Sources */,
+   ```
+
+Repeat the four-entry pattern for `FinderRevealTests.swift` against the **test target**, mirroring `PreviewCacheTests.swift` (lines 162 / 629 / 740 / 1520 — confirm by `grep -n PreviewCacheTests project.pbxproj`).
+
+- [ ] **Step 5: Build to confirm pbxproj edits are well-formed**
+
+```bash
+touch SuperPickyApp/FinderReveal.swift SuperPickyTests/FinderRevealTests.swift
+xcodebuild build -scheme SuperPicky -destination 'platform=macOS' 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`. If the parse fails (e.g. duplicate UUID, missing brace), the error mentions `project.pbxproj` — fix and retry.
+
+- [ ] **Step 6: Run the L1 test to confirm it passes**
+
+```bash
+xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+    -only-testing:SuperPickyTests/FinderRevealTests 2>&1 | tail -20
+```
+
+Expected: `Test Suite 'FinderRevealTests' passed`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac
+git add apps/mac-client/SuperPickyApp/FinderReveal.swift \
+        apps/mac-client/SuperPickyTests/FinderRevealTests.swift \
+        apps/mac-client/SuperPicky.xcodeproj/project.pbxproj
+git commit -m "feat(reveal): FinderReveal helper + L1 test"
+```
+
+---
+
+## Task 3: A11y identifier for the menu item
+
+**Files:**
+- Modify: `apps/mac-client/SuperPickyUITests/A11y.swift`
+
+- [ ] **Step 1: Add the identifier**
+
+In `A11y.swift`, after the existing `static let selectionCounter = "SelectionCounter"` line (around line 14), add:
+
+```swift
+    static let revealInFinderMenuItem = "RevealInFinder"
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+```bash
+xcodebuild build -scheme SuperPicky -destination 'platform=macOS' 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac
+git add apps/mac-client/SuperPickyUITests/A11y.swift
+git commit -m "feat(reveal): A11y id for Reveal in Finder menu item"
+```
+
+---
+
+## Task 4: Right-click on thumbnails
+
+**Files:**
+- Modify: `apps/mac-client/SuperPickyApp/ThumbnailStripView.swift`
+
+- [ ] **Step 1: Inject `CullingConfig` into `ThumbnailCell`**
+
+In `ThumbnailStripView.swift`, inside `struct ThumbnailCell: View` (currently starts around line 91), add this property right after `let isDimmed: Bool`:
+
+```swift
+    @Environment(CullingConfig.self) private var config
+```
+
+- [ ] **Step 2: Add the context menu**
+
+Still in `ThumbnailCell.body`, after the existing `.accessibilityValue(a11ySelectionValue)` line (currently the last modifier, around line 169), append:
+
+```swift
+        .contextMenu {
+            Button {
+                FinderReveal.reveal(photo)
+            } label: {
+                Label(config.localized("Reveal in Finder"), systemImage: "folder")
+            }
+            .accessibilityIdentifier(A11y.revealInFinderMenuItem)
+        }
+```
+
+Note: `A11y` lives in the UI test target, so the identifier string `"RevealInFinder"` cannot be referenced by name from the app target. Use the literal string in the app code:
+
+```swift
+            .accessibilityIdentifier("RevealInFinder")
+```
+
+(Identifier is mirrored — not imported — exactly like every other entry in `A11y.swift` per the comment at the top of that file.)
+
+- [ ] **Step 3: Touch + build**
+
+```bash
+touch SuperPickyApp/ThumbnailStripView.swift
+xcodebuild build -scheme SuperPicky -destination 'platform=macOS' 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac
+git add apps/mac-client/SuperPickyApp/ThumbnailStripView.swift
+git commit -m "feat(reveal): right-click Reveal in Finder on thumbnail strip"
+```
+
+---
+
+## Task 5: Right-click on the main preview
+
+**Files:**
+- Modify: `apps/mac-client/SuperPickyApp/PreviewView.swift`
+
+- [ ] **Step 1: Add the context menu to `AsyncPreviewImage`**
+
+In `PreviewView.swift`, inside `var body` of `struct PreviewView`, find the `if let photo {` arm (around line 19). The `AsyncPreviewImage(...)` chain currently ends with `.background(GeometryReader { ... })`. Append `.contextMenu` after that `.background`:
+
+```swift
+                AsyncPreviewImage(filePath: photo.filePath,
+                                  zoomState: zoomState,
+                                  brightnessAdjustment: brightnessAdjustment,
+                                  sharpnessOverlayPhoto: showSharpnessOverlay ? photo : nil)
+                    .accessibilityIdentifier("PhotoPreview")
+                    .onContinuousHover { phase in
+                        if case .active(let loc) = phase { mouseInView = loc }
+                    }
+                    .background(GeometryReader { geo in
+                        Color.clear.onAppear { viewSize = geo.size }
+                            .onChange(of: geo.size) { _, s in viewSize = s }
+                    })
+                    .contextMenu {
+                        Button {
+                            FinderReveal.reveal(photo)
+                        } label: {
+                            Label(config.localized("Reveal in Finder"), systemImage: "folder")
+                        }
+                        .accessibilityIdentifier("RevealInFinder")
+                    }
+```
+
+`config` is already in scope via `@Environment(CullingConfig.self) private var config` at the top of `PreviewView` — no new bindings needed.
+
+- [ ] **Step 2: Touch + build**
+
+```bash
+touch SuperPickyApp/PreviewView.swift
+xcodebuild build -scheme SuperPicky -destination 'platform=macOS' 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac
+git add apps/mac-client/SuperPickyApp/PreviewView.swift
+git commit -m "feat(reveal): right-click Reveal in Finder on main preview"
+```
+
+---
+
+## Task 6: L3 XCUITests
+
+**Files:**
+- Modify: `apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift`
+
+The test class uses sequential `testNN_` numbering grouped by category (see header comment in the file). Categories used: 01-09 UI, 10-19 keyboard, 20-29 filter/counter, 30-39 export, 40-49 species. Use **50-59 for the new "context menu" group**.
+
+- [ ] **Step 1: Add both tests at the end of the class (before the final `}`)**
+
+```swift
+    // MARK: - 50-59: Context menu
+
+    func test50_ThumbnailRightClick_RevealInFinderMenuItemExists() {
+        let app = Self.app!
+        let preview = app.images[A11y.photoPreview]
+        XCTAssertTrue(preview.waitForExistence(timeout: 10),
+                      "Photo preview must be visible before right-clicking thumbnails")
+
+        // Pick the first thumbnail in the strip — must arrow into view
+        // first so LazyHStack instantiates it (per A11y rule on lazy strips).
+        let firstThumbnail = app.images.matching(NSPredicate(format: "identifier BEGINSWITH 'Thumbnail_'")).firstMatch
+        XCTAssertTrue(firstThumbnail.waitForExistence(timeout: 5),
+                      "At least one thumbnail must exist")
+
+        firstThumbnail.rightClick()
+
+        let menuItem = app.menuItems[A11y.revealInFinderMenuItem]
+        XCTAssertTrue(menuItem.waitForExistence(timeout: 3),
+                      "Reveal in Finder menu item should appear on right-click")
+
+        // Dismiss without invoking — clicking would launch Finder during CI.
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    func test51_PreviewRightClick_RevealInFinderMenuItemExists() {
+        let app = Self.app!
+        let preview = app.images[A11y.photoPreview]
+        XCTAssertTrue(preview.waitForExistence(timeout: 10),
+                      "Photo preview must be visible")
+
+        preview.rightClick()
+
+        let menuItem = app.menuItems[A11y.revealInFinderMenuItem]
+        XCTAssertTrue(menuItem.waitForExistence(timeout: 3),
+                      "Reveal in Finder menu item should appear on right-click")
+
+        app.typeKey(.escape, modifierFlags: [])
+    }
+```
+
+- [ ] **Step 2: Do NOT run XCUITests locally**
+
+Per the project's testing policy (CLAUDE.md "Do not run XCUITest suites locally") these run on CI only. Skip the local run; CI will execute on push.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac
+git add apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
+git commit -m "test(reveal): L3 XCUITests for thumbnail + preview right-click"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Clean build + L1 test pass**
+
+From `apps/mac-client/`:
+
+```bash
+xcodebuild build -scheme SuperPicky -destination 'platform=macOS' 2>&1 | tail -5
+xcodebuild test -scheme SuperPicky -destination 'platform=macOS' \
+    -only-testing:SuperPickyTests 2>&1 | tail -20
+```
+
+Expected: build succeeds; the entire `SuperPickyTests` suite (including the new `FinderRevealTests`) passes.
+
+- [ ] **Step 2: Run pre-commit script**
+
+From repo root:
+
+```bash
+cd /Users/dazhen/projects/SuperPickyMac
+./scripts/pre-commit.sh 2>&1 | tail -20
+```
+
+Expected: green (build + swiftlint + L1 unit). If swiftlint flags anything in the new code, fix and amend the most recent task's commit (do NOT amend earlier commits — make a new fix commit).
+
+- [ ] **Step 3: Manual smoke (optional, non-blocking)**
+
+Open the app, right-click a thumbnail, confirm the menu appears with "Reveal in Finder" (en) / "在 Finder 中显示" (zh-Hans depending on the .strings entry — confirm what's there in Task 1). Click it → Finder opens with the photo highlighted. Repeat on the main preview.
+
+This is a sanity check only — the L1 + L3 tests cover the regression surface.
+
+- [ ] **Step 4: Push (no merge)**
+
+```bash
+git push
+```
+
+Then watch CI per the "Watch CI until green" memory rule.
+
+---
+
+## Out of scope (do NOT implement)
+
+- Multi-select reveal (right-click acts on the photo under the cursor only).
+- Keyboard shortcut binding (⌘⇧R) — future work.
+- "Open With…" submenu, "Show Package Contents", etc.
+- Right-click on any surface other than `ThumbnailCell` and `AsyncPreviewImage`.

--- a/docs/superpowers/specs/2026-05-04-reveal-in-finder-context-menu-design.md
+++ b/docs/superpowers/specs/2026-05-04-reveal-in-finder-context-menu-design.md
@@ -1,0 +1,129 @@
+# Reveal in Finder — right-click context menu
+
+**Status:** approved
+**Date:** 2026-05-04
+
+## Goal
+
+Let the user right-click a photo in SuperPicky and jump straight to its location in Finder, with the file highlighted. Mirrors the standard macOS "Reveal in Finder" behavior found in Lightroom, Photos, and Finder itself.
+
+## Surfaces
+
+Two right-click surfaces, both showing the same single-item menu:
+
+1. **Thumbnail strip cells** (`ThumbnailStripView.swift` → `ThumbnailCell`).
+2. **Main preview image** (`PreviewView.swift` → the `AsyncPreviewImage` inside `if let photo`).
+
+The menu acts on the photo under the cursor, not on the active selection. This matches Lightroom/Finder: right-click on a non-active thumbnail reveals *that* photo, not the currently-displayed one.
+
+## Behavior
+
+- Single menu item, label `Reveal in Finder` (localized key already exists in the codebase per `MainView.swift:207`).
+- Selecting it calls `NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: photo.filePath)])`.
+  - This opens the parent folder *and* highlights the file. The existing call in `MainView.swift:208` uses `selectFile(nil, inFileViewerRootedAtPath:)`, which only opens the folder — not what we want here.
+- No keyboard shortcut. (Future addition could bind ⌘⇧R, out of scope for this spec.)
+
+## Implementation
+
+### Shared helper
+
+New file `apps/mac-client/SuperPickyApp/FinderReveal.swift`. Rule-of-two: two call sites (thumbnail + preview) is the trigger to extract.
+
+The AppKit call sits behind a tiny protocol seam so the L1 test can swap in a fake without launching Finder during the test run:
+
+```swift
+protocol FinderRevealer {
+    func reveal(_ urls: [URL])
+}
+
+struct SystemFinderRevealer: FinderRevealer {
+    func reveal(_ urls: [URL]) {
+        NSWorkspace.shared.activateFileViewerSelecting(urls)
+    }
+}
+
+@MainActor
+enum FinderReveal {
+    static var revealer: FinderRevealer = SystemFinderRevealer()
+    static func reveal(_ photo: Photo) {
+        revealer.reveal([URL(fileURLWithPath: photo.filePath)])
+    }
+}
+```
+
+Both call sites use `FinderReveal.reveal(photo)`.
+
+### ThumbnailCell
+
+Attach `.contextMenu` to the `ThumbnailCell` body (after the existing `.accessibilityValue(...)` modifier). The cell already captures `photo: Photo`, so the closure has what it needs.
+
+```swift
+.contextMenu {
+    Button(config.localized("Reveal in Finder"), systemImage: "folder") {
+        FinderReveal.reveal(photo)
+    }
+}
+```
+
+`ThumbnailCell` does not currently have access to `CullingConfig`. Inject via `@Environment(CullingConfig.self) private var config` like sibling views do.
+
+### PreviewView
+
+Attach `.contextMenu` to the `AsyncPreviewImage` block inside the `if let photo` arm of `PreviewView.body`. The view already has `config` in scope.
+
+```swift
+AsyncPreviewImage(...)
+    .accessibilityIdentifier("PhotoPreview")
+    .onContinuousHover { ... }
+    .background(...)
+    .contextMenu {
+        Button(config.localized("Reveal in Finder"), systemImage: "folder") {
+            FinderReveal.reveal(photo)
+        }
+    }
+```
+
+## Localization
+
+`Reveal in Finder` key is already used at `MainView.swift:207`, so en + zh-Hans strings exist. No new `.strings` entries required. Verify on the planning step by grepping the `.lproj` files.
+
+## Accessibility
+
+- The context menu items inherit standard SwiftUI a11y. To make the L3 test addressable, mirror the menu-item identifier in `A11y.swift` — e.g. `static let revealInFinderMenuItem = "RevealInFinder"`, attached via `.accessibilityIdentifier(A11y.revealInFinderMenuItem)` on the menu `Button`.
+
+## Tests
+
+### L1 (Swift Testing)
+
+In `SuperPickyTests`, add a small test that swaps `FinderReveal.revealer` for a recording fake, calls `FinderReveal.reveal(photo)`, and asserts the recorded URL equals `URL(fileURLWithPath: photo.filePath)`. Restores the original revealer in teardown.
+
+### L3 (XCUITest)
+
+Add to existing `CullingWorkflowUITests` class (per "Group XCUITests" memory rule). Two cases:
+
+1. `test_thumbnail_rightClick_showsRevealInFinder()` — right-click a known thumbnail (use `arrowStripUntil` to materialize it lazily first per LazyHStack rule), assert the menu item with id `RevealInFinder` exists, dismiss with Escape. Do not click it (would launch Finder during CI).
+2. `test_preview_rightClick_showsRevealInFinder()` — right-click `images["PhotoPreview"]`, assert menu item exists, dismiss.
+
+Both tests must `XCTAssertTrue` on every `waitForExistence` call (per "waitForExistence silent timeout" memory).
+
+Right-click in XCUITest: `element.rightClick()` (works on macOS).
+
+### Out of scope for tests
+
+- No test that actually triggers Finder. Asserting menu *visibility* is sufficient; the helper's URL correctness is covered by L1.
+
+## Out of scope
+
+- Multi-select reveal (right-click ignores selection — acts on the photo under the cursor).
+- "Open With…" submenu, "Show Package Contents", or other Finder-style menu items.
+- Keyboard shortcut binding.
+- Right-click on grid views other than the thumbnail strip and preview (no other photo-rendering surfaces exist today; if added later, they should reuse `FinderReveal.reveal`).
+
+## File touch list (preview)
+
+- `apps/mac-client/SuperPickyApp/FinderReveal.swift` — new file (also register in `SuperPicky.xcodeproj/project.pbxproj` per CLAUDE.md).
+- `apps/mac-client/SuperPickyApp/ThumbnailStripView.swift` — add `@Environment(CullingConfig.self)` + `.contextMenu`.
+- `apps/mac-client/SuperPickyApp/PreviewView.swift` — add `.contextMenu`.
+- `apps/mac-client/SuperPickyUITests/A11y.swift` — add `revealInFinderMenuItem` identifier.
+- `apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift` — add two XCUITest cases.
+- `apps/mac-client/SuperPickyTests/FinderRevealTests.swift` — new L1 test file (also register in pbxproj).


### PR DESCRIPTION
## Summary

- Right-click on a thumbnail in the strip OR on the main preview shows a **Reveal in Finder** menu item that opens Finder with the photo highlighted.
- Acts on the photo under the cursor (Lightroom/Finder convention), not the active selection.
- Single-item menu — no other items.

## Implementation

- New helper `FinderReveal` (`apps/mac-client/SuperPickyApp/FinderReveal.swift`) wraps `NSWorkspace.shared.activateFileViewerSelecting(_:)` behind a tiny protocol seam (`FinderRevealer`) so the L1 unit test can swap it without launching Finder during tests.
- `.contextMenu` attached to `ThumbnailCell` (`ThumbnailStripView.swift`) and `AsyncPreviewImage` inside `PreviewView`.
- Reuses the existing `Reveal in Finder` localization key (en/zh-Hans already present at `Localizable.strings:88`).

## Tests

- **L1** (`FinderRevealTests.swift`): asserts `FinderReveal.reveal(_:)` calls the injected revealer with `URL(fileURLWithPath: photo.filePath)`.
- **L3 XCUITests** (`CullingWorkflowUITests.test50/51`): right-click thumbnail / preview, assert the menu item appears, dismiss with Escape (does not click — would launch Finder during CI).

## Test plan

- [x] L1 suite: `xcodebuild test -only-testing:SuperPickyTests` — 599 / 599 pass locally
- [x] Clean build: `xcodebuild build` — succeeds
- [ ] CI: full CI run (L1 + L3) green
- [ ] Manual smoke: right-click a thumbnail → menu shows → click → Finder opens with photo highlighted; same for preview

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-04-reveal-in-finder-context-menu-design.md`
- Plan: `docs/superpowers/plans/2026-05-04-reveal-in-finder-context-menu.md`