### PR TITLE
fix(culling): re-clicking sidebar folder resets selection to display-first

### DIFF
--- a/apps/mac-client/SuperPickyApp/AppState.swift
+++ b/apps/mac-client/SuperPickyApp/AppState.swift
@@ -182,8 +182,12 @@ final class AppState {
     /// Load photos from the database for the selected folder.
     /// Preserves current filter and selection when possible.
     /// Pass `skipHierarchy: true` during incremental processing to avoid O(n²) rebuilds.
-    func loadPhotos(for folder: URL, skipHierarchy: Bool = false) {
+    /// Pass `deferSelection: true` from a user-initiated sidebar click so the
+    /// view layer can pick the displayed-first photo even when re-clicking the
+    /// already-loaded folder (where `isFolderSwitch` would otherwise be `false`).
+    func loadPhotos(for folder: URL, skipHierarchy: Bool = false, deferSelection: Bool = false) {
         let isFolderSwitch = (currentFolder != folder)
+        let shouldDeferSelection = isFolderSwitch || deferSelection
         currentFolder = folder
         cachedDB = nil
         undoStack = []
@@ -198,9 +202,10 @@ final class AppState {
             }
 
             // Re-apply current filter instead of resetting to all.
-            // Folder switch defers selection to the view layer so the
-            // first photo picked respects the user's current sort order.
-            applyFilter(autoSelectFirst: !isFolderSwitch)
+            // Folder switch (or any user-driven sidebar click) defers
+            // selection to the view layer so the first photo picked
+            // respects the user's current sort order.
+            applyFilter(autoSelectFirst: !shouldDeferSelection)
 
             if isFolderSwitch {
                 let paths = allPhotos.map(\.filePath)
@@ -219,7 +224,7 @@ final class AppState {
             allPhotos = []
             allPhotoIndex = [:]
             speciesEntries = []
-            applyFilter(autoSelectFirst: !isFolderSwitch)
+            applyFilter(autoSelectFirst: !shouldDeferSelection)
         }
     }
 

--- a/apps/mac-client/SuperPickyApp/AppState.swift
+++ b/apps/mac-client/SuperPickyApp/AppState.swift
@@ -68,6 +68,10 @@ final class AppState {
     private let logger = Logger(subsystem: "com.halfhacked.superpicky", category: "AppState")
 
     var sidebarSelection: SidebarSelection?
+    /// Bumped whenever the displayed photo list changes due to a sidebar
+    /// filter or folder switch. ContentView observes this to reset the
+    /// active selection to the first photo in its current display sort.
+    var filterToken: Int = 0
     let selection = PhotoSelection()
 
     /// Back-compat accessor. Reads/writes `selection.activeID`. New code
@@ -193,8 +197,10 @@ final class AppState {
                 buildSpeciesHierarchy()
             }
 
-            // Re-apply current filter instead of resetting to all
-            applyFilter()
+            // Re-apply current filter instead of resetting to all.
+            // Folder switch defers selection to the view layer so the
+            // first photo picked respects the user's current sort order.
+            applyFilter(autoSelectFirst: !isFolderSwitch)
 
             if isFolderSwitch {
                 let paths = allPhotos.map(\.filePath)
@@ -211,10 +217,9 @@ final class AppState {
         } catch {
             logger.error("loadPhotos failed: \(error)")
             allPhotos = []
-            photos = []
             allPhotoIndex = [:]
-            filteredPhotoIndex = [:]
             speciesEntries = []
+            applyFilter(autoSelectFirst: !isFolderSwitch)
         }
     }
 
@@ -617,7 +622,13 @@ final class AppState {
     }
 
     /// Filter photos by sidebar selection.
-    func applyFilter() {
+    ///
+    /// When `autoSelectFirst` is `true` (the default), the legacy behavior
+    /// of selecting `photos.first` whenever no selection survives reconcile
+    /// stays. When `false`, selection is left as-is and `filterToken` is
+    /// bumped so the view layer can pick the displayed-first photo using
+    /// its own sort order.
+    func applyFilter(autoSelectFirst: Bool = true) {
         switch sidebarSelection {
         case .folder:
             photos = allPhotos
@@ -640,8 +651,12 @@ final class AppState {
         }
         rebuildFilteredPhotoIndex()
         selection.reconcile(with: photos)
-        if selection.activeID == nil, let first = photos.first {
-            selection.click(first.id, photos: photos)
+        if autoSelectFirst {
+            if selection.activeID == nil, let first = photos.first {
+                selection.click(first.id, photos: photos)
+            }
+        } else {
+            filterToken += 1
         }
     }
 }

--- a/apps/mac-client/SuperPickyApp/ContentView.swift
+++ b/apps/mac-client/SuperPickyApp/ContentView.swift
@@ -122,6 +122,7 @@ struct ContentView: View {
                                 .foregroundStyle(n <= minimumStars ? .primary : .secondary)
                                 .onTapGesture {
                                     minimumStars = minimumStars == n ? 0 : n
+                                    selectFirstFiltered()
                                 }
                         }
                     }
@@ -132,6 +133,7 @@ struct ContentView: View {
 
                     Button {
                         topBurstOnly.toggle()
+                        selectFirstFiltered()
                     } label: {
                         Image(systemName: topBurstOnly ? "crown.fill" : "crown")
                             .font(.system(size: 10))
@@ -143,6 +145,7 @@ struct ContentView: View {
 
                     Button {
                         pickedOnly.toggle()
+                        selectFirstFiltered()
                     } label: {
                         Image(systemName: pickedOnly ? "flag.fill" : "flag")
                             .font(.system(size: 10))
@@ -163,6 +166,7 @@ struct ContentView: View {
                                     sortOrder = order
                                     sortAscending = (order == .filename || order == .captureDate)
                                 }
+                                selectFirstFiltered()
                             } label: {
                                 HStack {
                                     Text(order.rawValue)
@@ -317,6 +321,18 @@ struct ContentView: View {
         .onChange(of: selectedPhotoID) { _, _ in
             brightnessAdj = 0
         }
+        .task(id: appState.filterToken) {
+            selectFirstFiltered()
+        }
+    }
+
+    /// Move the active selection to the first photo of the currently
+    /// displayed `filteredPhotos` (or clear it if none). Called whenever
+    /// the displayed list changes via filter or sort, so the visible
+    /// "first photo" matches the user's display order rather than the
+    /// raw `appState.photos` backing order.
+    private func selectFirstFiltered() {
+        selectedPhotoID = filteredPhotos.first?.id
     }
 
     private func handleKey(_ key: KeyboardMonitor.KeyEvent) -> Bool {
@@ -367,6 +383,7 @@ struct ContentView: View {
            let digit = char.wholeNumberValue,
            (0...5).contains(digit) {
             minimumStars = digit
+            selectFirstFiltered()
             return true
         }
 

--- a/apps/mac-client/SuperPickyApp/MainView.swift
+++ b/apps/mac-client/SuperPickyApp/MainView.swift
@@ -163,7 +163,7 @@ struct MainView: View {
             case .folder(let url):
                 appState.loadPhotos(for: url)
             case .rating, .flying, .picks, .species, .burstGroup, .singles:
-                appState.applyFilter()
+                appState.applyFilter(autoSelectFirst: false)
             case nil:
                 break
             }

--- a/apps/mac-client/SuperPickyApp/MainView.swift
+++ b/apps/mac-client/SuperPickyApp/MainView.swift
@@ -161,7 +161,7 @@ struct MainView: View {
         .onChange(of: appState.sidebarSelection) { _, newValue in
             switch newValue {
             case .folder(let url):
-                appState.loadPhotos(for: url)
+                appState.loadPhotos(for: url, deferSelection: true)
             case .rating, .flying, .picks, .species, .burstGroup, .singles:
                 appState.applyFilter(autoSelectFirst: false)
             case nil:

--- a/apps/mac-client/SuperPickyTests/Core/AppStateBatchMutationTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/AppStateBatchMutationTests.swift
@@ -315,6 +315,38 @@ import Foundation
         #expect(app.selection.activeID == p2.id)
     }
 
+    @Test func loadPhotosOnFolderSwitchDefersSelectionAndBumpsFilterToken() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        _ = try seedPhotos(3, into: folder)
+
+        let app = AppState()
+        let initialToken = app.filterToken
+        app.loadPhotos(for: folder)
+
+        #expect(app.selection.activeID == nil,
+                "Folder switch should defer selection to the view layer")
+        #expect(app.filterToken != initialToken,
+                "Folder switch should bump filterToken so the view can react")
+    }
+
+    @Test func applyFilterAutoSelectFirstFalseLeavesSelectionCleared() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        _ = try seedPhoto(filename: "eagle.CR3", species: match("eagle"), into: folder)
+        _ = try seedPhoto(filename: "hawk.CR3", species: match("hawk"), into: folder)
+
+        let app = AppState()
+        app.loadPhotos(for: folder)
+        app.selection.clear()
+        app.sidebarSelection = .species("hawk")
+        app.applyFilter(autoSelectFirst: false)
+
+        #expect(app.photos.count == 1)
+        #expect(app.selection.activeID == nil,
+                "autoSelectFirst:false should leave selection cleared for the view to fill in")
+    }
+
     // MARK: - Undo restores species
 
     @Test func undoRestoresAssignedSpeciesAfterBatchEdit() throws {

--- a/apps/mac-client/SuperPickyTests/Core/AppStateBatchMutationTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/AppStateBatchMutationTests.swift
@@ -330,6 +330,25 @@ import Foundation
                 "Folder switch should bump filterToken so the view can react")
     }
 
+    @Test func loadPhotosWithDeferSelectionBumpsTokenOnSameFolderReclick() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        _ = try seedPhotos(3, into: folder)
+
+        let app = AppState()
+        app.loadPhotos(for: folder)
+        let tokenAfterInitialLoad = app.filterToken
+
+        // Simulate a sidebar re-click on the already-loaded folder. The
+        // sidebar selection wraps a `.folder(URL)` so the URL is the same;
+        // without `deferSelection` this is a no-op for selection state and
+        // the view's auto-select-first never fires.
+        app.loadPhotos(for: folder, deferSelection: true)
+
+        #expect(app.filterToken != tokenAfterInitialLoad,
+                "Same-folder re-click with deferSelection must bump filterToken so the view re-selects display-first")
+    }
+
     @Test func applyFilterAutoSelectFirstFalseLeavesSelectionCleared() throws {
         let folder = try makeTempFolder()
         defer { try? FileManager.default.removeItem(at: folder) }

--- a/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/apps/mac-client/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -437,6 +437,140 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
                        "After reset, counter should match initial")
     }
 
+    // MARK: - 23-24: Selection lands on display-first when filter changes
+
+    /// Switching a sidebar filter (here: rating round-trip → folder) must
+    /// land the active selection on the displayed-first thumbnail, not on
+    /// whatever was first in the unsorted backing list. We assert
+    /// active == leftmost-visible thumbnail to stay agnostic of which
+    /// specific photo is first under the current sort.
+    func test23_SidebarFilterSelectsLeftmostThumbnail() {
+        let app = Self.app!
+        let preview = app.images[A11y.photoPreview]
+        XCTAssertTrue(preview.waitForExistence(timeout: 10))
+
+        // Push selection off the leftmost so the auto-select-first reset
+        // is observable.
+        preview.click()
+        for _ in 0..<3 { app.typeKey(.rightArrow, modifierFlags: []) }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        // Round-trip Excellent → folder. The folder click is a sidebar
+        // selection change, which is what the fix targets.
+        app.staticTexts["Excellent"].click()
+        Thread.sleep(forTimeInterval: 0.5)
+        let folderName = (Self.testDir! as NSString).lastPathComponent
+        app.staticTexts[folderName].click()
+        Thread.sleep(forTimeInterval: 0.7)
+
+        let activeID = activeThumbnailID(in: app)
+        let leftmostID = leftmostVisibleThumbnailID(in: app)
+        XCTAssertNotNil(activeID, "Some thumbnail should be marked active")
+        XCTAssertEqual(activeID, leftmostID,
+                       "Sidebar filter switch must select the displayed-first thumbnail")
+    }
+
+    /// Changing the sort order (Date asc ↔ desc here, via the SortMenu's
+    /// "Date" item) must also land selection on the leftmost thumbnail of
+    /// the freshly-sorted list. Sort-driven re-orderings flip which
+    /// filename is leftmost, so active == leftmost is the observable
+    /// invariant.
+    func test24_SortChangeSelectsLeftmostThumbnail() {
+        let app = Self.app!
+        let preview = app.images[A11y.photoPreview]
+        XCTAssertTrue(preview.waitForExistence(timeout: 10))
+
+        preview.click()
+        for _ in 0..<3 { app.typeKey(.rightArrow, modifierFlags: []) }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        // Open the sort menu and click "Date" — toggles ascending if
+        // already Date, else switches to Date. Either way the displayed
+        // list's leftmost shifts and selection must follow.
+        let sortMenu = app.descendants(matching: .any)
+            .matching(identifier: "SortMenu").firstMatch
+        XCTAssertTrue(sortMenu.waitForExistence(timeout: 5),
+                      "SortMenu should be present")
+        if sortMenu.isHittable {
+            sortMenu.click()
+        } else {
+            sortMenu.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
+        }
+        Thread.sleep(forTimeInterval: 0.6)
+
+        let dateItem = app.menuItems["Date"].firstMatch
+        if dateItem.exists {
+            dateItem.click()
+        } else {
+            app.descendants(matching: .any)["Date"].firstMatch.click()
+        }
+        Thread.sleep(forTimeInterval: 0.7)
+
+        let activeID = activeThumbnailID(in: app)
+        let leftmostID = leftmostVisibleThumbnailID(in: app)
+        XCTAssertNotNil(activeID, "Some thumbnail should be marked active")
+        XCTAssertEqual(activeID, leftmostID,
+                       "Sort change must select the displayed-first thumbnail")
+    }
+
+    /// Toggling an in-bar filter (PickedFilter on→off) must also land
+    /// selection on the leftmost thumbnail of the now-displayed list.
+    /// Mirrors test23 for the ContentView-level filters.
+    func test25_InBarPickedFilterTogglePicksLeftmostThumbnail() {
+        let app = Self.app!
+        let preview = app.images[A11y.photoPreview]
+        XCTAssertTrue(preview.waitForExistence(timeout: 10))
+
+        preview.click()
+        for _ in 0..<3 { app.typeKey(.rightArrow, modifierFlags: []) }
+        Thread.sleep(forTimeInterval: 0.4)
+
+        let pickedFilter = app.buttons["PickedFilter"]
+        XCTAssertTrue(pickedFilter.waitForExistence(timeout: 3))
+        pickedFilter.click()
+        Thread.sleep(forTimeInterval: 0.5)
+        pickedFilter.click()
+        Thread.sleep(forTimeInterval: 0.7)
+
+        let activeID = activeThumbnailID(in: app)
+        let leftmostID = leftmostVisibleThumbnailID(in: app)
+        XCTAssertNotNil(activeID, "Some thumbnail should be marked active")
+        XCTAssertEqual(activeID, leftmostID,
+                       "Toggling PickedFilter must select the displayed-first thumbnail")
+    }
+
+    // MARK: - Helpers
+
+    /// Identifier of the thumbnail whose `accessibilityValue == "active"`,
+    /// or nil if no thumbnail is currently active in the a11y tree.
+    private func activeThumbnailID(in app: XCUIApplication) -> String? {
+        let active = app.images.matching(NSPredicate(
+            format: "identifier BEGINSWITH 'Thumbnail_' AND value == 'active'"
+        )).firstMatch
+        return active.exists ? active.identifier : nil
+    }
+
+    /// Identifier of the leftmost thumbnail in the visible viewport. The
+    /// LazyHStack only puts in-viewport items in the a11y tree, so this
+    /// query reliably returns the displayed-first thumbnail.
+    private func leftmostVisibleThumbnailID(in app: XCUIApplication) -> String? {
+        let thumbs = app.images.matching(NSPredicate(
+            format: "identifier BEGINSWITH 'Thumbnail_'"
+        ))
+        var minX = CGFloat.greatestFiniteMagnitude
+        var result: String?
+        for i in 0..<thumbs.count {
+            let t = thumbs.element(boundBy: i)
+            guard t.exists, t.frame.size.width > 0 else { continue }
+            let x = t.frame.origin.x
+            if x.isFinite, x < minX {
+                minX = x
+                result = t.identifier
+            }
+        }
+        return result
+    }
+
     // MARK: - 30-39: Export
 
     func test30_CmdEExportPicks() {


### PR DESCRIPTION
## Why

Re-merging PR #78's filter/sort auto-select-first work, this time with the bug found by `test23_SidebarFilterSelectsLeftmostThumbnail` on the post-merge main run fixed.

PR #78 deferred selection to the view layer only when the clicked folder differed from the currently-loaded one. A sidebar **re-click** on the already-loaded folder (e.g. Excellent → folder) had \`isFolderSwitch == false\`, so the legacy "preserve activeID" path ran and \`filterToken\` was never bumped. The previously-selected rating-filtered photo stayed selected. The XCUITest log:

\`\`\`
test23_SidebarFilterSelectsLeftmostThumbnail FAILED
  active=Thumbnail_DSC09952.jpg
  leftmost=Thumbnail_DSC09180.jpg
\`\`\`

Main was reverted via `4601926` to keep CI green while this fix lands.

## What

- \`AppState.loadPhotos\` gains \`deferSelection: Bool = false\`. When true, the autoSelect-first path is skipped regardless of \`isFolderSwitch\`, and \`applyFilter\` bumps \`filterToken\` so the view's task fires.
- \`MainView\`'s \`.folder\` sidebar branch passes \`deferSelection: true\`. Reprocess and onAppear keep the default false.
- New L1 test \`loadPhotosWithDeferSelectionBumpsTokenOnSameFolderReclick\` pins the new behavior. The two PR commits are:
  1. \`Reapply\` of PR #78's content (will squash with the fix on merge).
  2. The fix itself.

## Test plan
- [x] L1: 600 / 60 suites passing locally
- [x] L3 build: \`xcodebuild build-for-testing\` green
- [ ] CI: \`test23\` (and \`test24\`/\`test25\`) green on this PR
- [ ] After merge: main CI green