### PR TITLE
perf(loadPhotos): skip full reload on no-op same-folder re-click

### DIFF
--- a/apps/mac-client/SuperPickyApp/AppState.swift
+++ b/apps/mac-client/SuperPickyApp/AppState.swift
@@ -187,6 +187,14 @@ final class AppState {
     /// already-loaded folder (where `isFolderSwitch` would otherwise be `false`).
     func loadPhotos(for folder: URL, skipHierarchy: Bool = false, deferSelection: Bool = false) {
         let isFolderSwitch = (currentFolder != folder)
+        // Sidebar re-click on the already-loaded folder: the in-memory
+        // photo set, indices, species hierarchy, undo stack, and DB cache
+        // are all still valid. Skip the full reload and just nudge the
+        // view layer to re-select display-first via filterToken.
+        if !isFolderSwitch && deferSelection {
+            applyFilter(autoSelectFirst: false)
+            return
+        }
         let shouldDeferSelection = isFolderSwitch || deferSelection
         currentFolder = folder
         cachedDB = nil

--- a/apps/mac-client/SuperPickyTests/Core/AppStateBatchMutationTests.swift
+++ b/apps/mac-client/SuperPickyTests/Core/AppStateBatchMutationTests.swift
@@ -349,6 +349,26 @@ import Foundation
                 "Same-folder re-click with deferSelection must bump filterToken so the view re-selects display-first")
     }
 
+    @Test func sameFolderReclickPreservesUndoStack() throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(3, into: folder)
+
+        let app = AppState()
+        app.loadPhotos(for: folder)
+        app.setRating(ids: [ids[0]], rating: 5)
+        #expect(app.undoStackSizeForTesting() == 1,
+                "Setup: rating mutation should push one undo entry")
+
+        // Re-click the same folder via the user-initiated path. The
+        // pre-existing full-reload behavior wiped the undo stack on
+        // every loadPhotos call; the no-op fast path keeps it intact.
+        app.loadPhotos(for: folder, deferSelection: true)
+
+        #expect(app.undoStackSizeForTesting() == 1,
+                "Same-folder re-click must not wipe the undo stack")
+    }
+
     @Test func applyFilterAutoSelectFirstFalseLeavesSelectionCleared() throws {
         let folder = try makeTempFolder()
         defer { try? FileManager.default.removeItem(at: folder) }


### PR DESCRIPTION
## Why

Follow-up to PR #79 (deferSelection plumbing). When the user clicks a sidebar folder that's already loaded, \`loadPhotos\` was doing a full reload pipeline:

1. \`database.fetchAllPhotos()\` — full SQLite scan
2. \`rebuildAllPhotoIndex()\` — O(N)
3. \`buildSpeciesHierarchy()\` — O(N)
4. \`undoStack = []\`, \`cachedDB = nil\` (then reopened)
5. \`applyFilter()\`

…to arrive at the same in-memory state. For a 9 k-photo folder this is hundreds of ms of pure waste, visible as lag on every sidebar click. The undo stack also got wiped, which surprises the user.

## What

Early-return in \`loadPhotos\` when \`!isFolderSwitch && deferSelection\` — only the path PR #79 routed sidebar re-clicks through. In that case:

- In-memory \`allPhotos\`, \`allPhotoIndex\`, \`filteredPhotoIndex\`, \`speciesEntries\`, \`undoStack\`, and \`cachedDB\` are all still valid.
- Just call \`applyFilter(autoSelectFirst: false)\` to bump \`filterToken\` so ContentView's \`.task(id:)\` re-selects display-first.

Reprocess (\`reprocessFolder\`) and \`onAppear\` continue to call \`loadPhotos\` with the default \`deferSelection: false\` and keep their full-reload semantics.

## Test plan
- [x] L1: 601 / 60 suites passing
- [x] New L1 \`sameFolderReclickPreservesUndoStack\` pins the undo-survival behavior
- [x] Existing \`loadPhotosWithDeferSelectionBumpsTokenOnSameFolderReclick\` still green
- [x] Existing \`loadPhotosOnFolderSwitchDefersSelectionAndBumpsFilterToken\` still green
- [ ] CI: full XCUITest matrix (test23/24/25 in particular still green on the new path)