### PR TITLE
perf(sharpness): cap decode at 3500 px (libjpeg 3/4 IDCT path)

### DIFF
--- a/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
+++ b/apps/mac-client/SuperPickyApp/PipelineCoordinator.swift
@@ -587,16 +587,9 @@ final class PipelineCoordinator: @unchecked Sendable {
         photo.flightConfidence = flight.confidence
 
         // Head-region sharpness (circular mask around eye, matches superpicky).
-        //
-        // Sharpness needs a higher-resolution input than ML inference does.
-        // At the 1280 max-side inference resolution a distant bird's head
-        // crop is 80–150 px and 1-pixel focus blur becomes unobservable;
-        // raw gradient² values for two visibly distinct shots tie within
-        // 0.1 % (verified on DSC09838 vs DSC09846). Decode the embedded
-        // full-res preview just for the sharpness pass and reuse the
-        // already-normalized YOLO bbox. Falls back to the inference image
-        // when the hi-res decode isn't available (older RAW with no
-        // embedded preview).
+        // Decode at `RAWConverter.maxSharpnessSize` for discrimination;
+        // fall back to the inference image when the hi-res decode isn't
+        // available (older RAW with no embedded preview).
         let sharpnessSource: CGImage = rawConverter.decodeForSharpness(fileURL: fileURL) ?? image
         let sharpnessBirdCrop = sharpnessSource.smartSquareBirdCrop(bbox: bird.bbox) ?? birdCrop
 

--- a/apps/mac-client/SuperPickyApp/RAWConverter.swift
+++ b/apps/mac-client/SuperPickyApp/RAWConverter.swift
@@ -8,14 +8,15 @@ struct RAWConverter: Sendable {
     private static let maxInferenceSize = 1280
 
     /// Max pixel dimension for sharpness measurement. The 1280 inference
-    /// crop is undersampled for sharpness — at that resolution a distant
-    /// bird's head circle is 80–150 px and 1-pixel focus blur is
-    /// unobservable. Decoding to ~5800 picks up the embedded full-res
-    /// JPEG preview that modern bodies (Sony A1/A7Rx/A9, Canon R5/R6,
-    /// Nikon Z9) write into ARW/CR3/NEF — fast enough to run per photo
-    /// and recovers the ~65% raw-gradient gap we see between visually
-    /// distinct shots that tied at 1280.
-    static let maxSharpnessSize = 5800
+    /// crop is undersampled — at that resolution a distant bird's head
+    /// circle is 80–150 px and 1-pixel focus blur is unobservable; two
+    /// visibly distinct shots tie within 0.1 %.
+    ///
+    /// Sized for libjpeg-turbo's scaled IDCT: for a Sony A1 5616-px
+    /// source, ≤3510 keeps the decoder on the 3/4-scale path; the next
+    /// step (7/8) costs substantially more wall time for negligible
+    /// discrimination gain.
+    static let maxSharpnessSize = 3500
 
     /// Decoded thumbnail plus the EXIF/TIFF property dictionary read from
     /// the same CGImageSource. `processOnePhoto` needs both for every


### PR DESCRIPTION
## Summary

The full-res sharpness path landed in #74 added a real ~30 s wall regression on 877 ARW (5616×3744 Sony A1) — much larger than #74's bench documented. Root cause: at `maxSharpnessSize = 5800` libjpeg-turbo runs its 1/1-scale IDCT (full pixel decode + color conversion) for every photo, sequentially in the per-photo critical path.

This PR caps `maxSharpnessSize` at **3500**, the highest value that keeps the decoder on the cheap 3/4-scale IDCT path for a 5616-px source. A 6-point sweep (3 rounds each, mtime-precise wall timing on SSD warm cache) showed a hard ~15 s wall cliff between 3500 and 4500 with negligible discrimination gain across it.

## Bench (Release, 877 ARW, SSD warm cache, 3 rounds × 6 sizes)

| `maxSharpnessSize` | Mean wall | DSC09838 (soft) | DSC09846 (sharp) | gap |
|---:|---:|---:|---:|---:|
| 1280 (pre-sharpness) | 21.0 s | 421.7 | 421.4 | 0.0 |
| 2000 | 25.5 s | 395.9 | 410.5 | 14.6 |
| 2500 | 28.5 s | 375.4 | 400.1 | 24.7 |
| 3000 | 32.3 s | 368.0 | 403.6 | 35.6 |
| **3500** | **35.4 s** | **358.5** | **399.9** | **41.4** |
| 4500 | 50.5 s | 345.8 | 392.2 | 46.4 |
| 5800 (before) | 52.3 s | 341.0 | 388.3 | 47.3 |

- Wall: **−17 s** vs HEAD (~33 % of the regression eliminated)
- Discrimination: 88 % of the full-res gap; sentinel pair stays on the correct side of the 380 keeper threshold with a comfortable 20-point margin
- Curve is monotonic; sub-cliff cost is ~3 s per +500 px

## Changes

- `RAWConverter.swift`: `maxSharpnessSize` 5800 → 3500; doc comment explains the libjpeg n/8 IDCT-step constraint that motivates the value.
- `PipelineCoordinator.swift`: trim the duplicated rationale at the call site to point at the constant; no logic change there.

## Test plan

- [x] `scripts/pre-commit.sh` (xcodebuild build + swiftlint + L1 unit tests) — green locally.
- [x] DSC09838 / DSC09846 sentinel pair: ranking + threshold split preserved (358.5 vs 399.9, gap 41.4).
- [x] 3-round bench repeatability: 34.6 / 35.7 / 36.0 s — < 2 s spread.
- [ ] CI: build + L1 + lint on macOS runner.