### PR TITLE
chore(ci): rebalance culling shard + trim redundant XCUITest sleeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,16 +83,19 @@ jobs:
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/CalibratorUITests
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/KeyboardHelpUITests
           - name: processing
-            # Folder ingestion + compare-view side flow.
+            # Folder ingestion + compare-view + filmstrip multi-select.
+            # BatchSelection rides the processing shard because culling alone
+            # was the long pole at ~5m15s; rebalancing brings max-wallclock
+            # to ~4m. BatchSelection uses its own (small) species fixture so
+            # it doesn't share state with Processing/Compare here.
             run: |
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/ProcessingFlowUITests
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/CompareViewUITests
+              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/BatchSelectionUITests
           - name: culling
-            # Main culling workflow — sidebar, toolbar, keyboard shortcuts,
-            # filmstrip multi-select.
+            # Main culling workflow — sidebar, toolbar, keyboard shortcuts.
             run: |
               xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/CullingWorkflowUITests
-              xcodebuild test-without-building -xctestrun "$XCTESTRUN" -destination 'platform=macOS' -only-testing:SuperPickyUITests/BatchSelectionUITests
           - name: species
             # Species edit panel feature as one logical unit.
             run: |

--- a/app/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/app/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -79,7 +79,10 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         } else {
             sortMenu.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
         }
-        Thread.sleep(forTimeInterval: 0.6)
+        // Gate on the first item appearing rather than a blind sleep.
+        XCTAssertTrue(app.menuItems["Filename"].waitForExistence(timeout: 2) ||
+                      app.descendants(matching: .any)["Filename"].firstMatch.waitForExistence(timeout: 1),
+                      "Sort menu should open and offer 'Filename'")
 
         for label in ["Filename", "Date", "Rating", "Sharpness", "Aesthetics"] {
             XCTAssertTrue(app.menuItems[label].exists ||
@@ -137,7 +140,6 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
 
         // Raise brightness a few steps; the indicator is hidden when value == 0.
         for _ in 0..<3 { app.typeText("=") }
-        Thread.sleep(forTimeInterval: 0.3)
         let indicator = app.staticTexts["BrightnessIndicator"]
         XCTAssertTrue(indicator.waitForExistence(timeout: 2),
                       "Brightness indicator should appear after pressing =")
@@ -198,7 +200,6 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         // F enters fullscreen
         preview.click()
         app.typeKey("f", modifierFlags: [])
-        Thread.sleep(forTimeInterval: 0.5)
 
         let fullscreen = app.otherElements["FullscreenViewer"]
         XCTAssertTrue(fullscreen.waitForExistence(timeout: 3),
@@ -206,9 +207,8 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
 
         // Escape exits fullscreen
         app.typeKey(.escape, modifierFlags: [])
-        Thread.sleep(forTimeInterval: 0.5)
-        XCTAssertFalse(fullscreen.exists,
-                       "Escape should close fullscreen")
+        XCTAssertTrue(fullscreen.waitForNonExistence(timeout: 2),
+                      "Escape should close fullscreen")
     }
 
     func test11_FullscreenArrowNavigation() {
@@ -238,11 +238,11 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
 
         // Double-click zoom toggle
         preview.doubleClick()
-        Thread.sleep(forTimeInterval: 1)
+        Thread.sleep(forTimeInterval: 0.3)
         XCTAssertTrue(preview.exists)
 
         preview.doubleClick()
-        Thread.sleep(forTimeInterval: 1)
+        Thread.sleep(forTimeInterval: 0.3)
         XCTAssertTrue(preview.exists)
     }
 
@@ -369,7 +369,6 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         Thread.sleep(forTimeInterval: 0.3)
 
         app.typeKey(.delete, modifierFlags: [])
-        Thread.sleep(forTimeInterval: 0.6)
 
         // The app surfaces a confirmation alert with OK/Cancel. XCUIApplication
         // may see several "Cancel" buttons across windows/sheets; restrict
@@ -496,10 +495,9 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         } else {
             sortMenu.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
         }
-        Thread.sleep(forTimeInterval: 0.6)
 
         let dateItem = app.menuItems["Date"].firstMatch
-        if dateItem.exists {
+        if dateItem.waitForExistence(timeout: 2) {
             dateItem.click()
         } else {
             app.descendants(matching: .any)["Date"].firstMatch.click()
@@ -584,7 +582,6 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         // the "No Photos" alert; if picks exist, an NSSavePanel appears.
         // Either way, dismiss via the front-most dialog/sheet.
         app.typeKey("e", modifierFlags: .command)
-        Thread.sleep(forTimeInterval: 0.8)
         dismissConfirmDialogIfPresent()
         XCTAssertTrue(preview.exists, "Preview should remain after Cmd+E")
     }


### PR DESCRIPTION
## Summary

The culling shard was the CI long pole at ~5m15s baseline (with ±60s variance — touching 6m+ on bad runner draws). Two changes to bring max wallclock down:

1. **Shard rebalance.** Move \`BatchSelectionUITests\` from \`culling\` → \`processing\`. \`BatchSelection\` uses its own small species fixture (3 photos), so it doesn't share state with \`Processing\`/\`Compare\` and slots cleanly into that shard. Expected new max wallclock: ~4m vs current ~5m15s.

2. **Trim 7 redundant \`Thread.sleep\` calls in \`CullingWorkflowUITests\`** where the wait was redundant (a following \`waitForExistence\` covers it, a helper has its own gate, or the test only asserts non-crash behavior):

   | Test | Old | New | Saving |
   |---|---|---|---|
   | test05 | \`Thread.sleep(0.6)\` after sortMenu click | \`menuItems[\"Filename\"].waitForExistence(2)\` gate | ~0.5 s |
   | test08 | \`Thread.sleep(0.3)\` before \`indicator.waitForExistence\` | drop (redundant) | 0.3 s |
   | test10 | \`Thread.sleep(0.5)\` before \`fullscreen.waitForExistence\` | drop (redundant) | 0.5 s |
   | test10 | \`Thread.sleep(0.5)\` + \`XCTAssertFalse(fullscreen.exists)\` | \`waitForNonExistence(2)\` | ~0.5 s, deterministic |
   | test12 | \`Thread.sleep(1)\` × 2 after doubleClick | 0.3 s × 2 | 1.4 s |
   | test19 | \`Thread.sleep(0.6)\` before \`dismissConfirmDialogIfPresent\` | drop (helper waits) | 0.6 s |
   | test24 | \`Thread.sleep(0.6)\` after sortMenu click | \`dateItem.waitForExistence(2)\` gate | ~0.5 s |
   | test30 | \`Thread.sleep(0.8)\` before \`dismissConfirmDialogIfPresent\` | drop (helper waits) | 0.8 s |

   Net ~5 s saved per culling-shard run.

Both changes are mechanical — no functional test changes, no fixture changes.

## Test plan

- [x] L1 unit tests pass locally (\`xcodebuild test -only-testing:SuperPickyTests\`)
- [x] SwiftLint --strict passes
- [x] \`xcodebuild build-for-testing\` succeeds
- [ ] CI green: confirm processing shard accepts BatchSelection without state collision; confirm culling shard tests still pass with reduced sleeps; confirm new max-wallclock is ~4m