### PR TITLE
perf(test): expose display-first thumbnail via a11y marker

### DIFF
--- a/app/SuperPickyApp/ThumbnailStripView.swift
+++ b/app/SuperPickyApp/ThumbnailStripView.swift
@@ -54,17 +54,18 @@ struct ThumbnailStripView: View {
                 // a11y-only marker for finding the display-first thumbnail
                 // in O(1) from XCUITest. Test helpers used to iterate every
                 // visible cell to find leftmost-by-frame, which cost ~0.3 s
-                // per cell on macOS-15 hosted runners. Color.clear has no
-                // a11y representation by default, so accessibilityElement()
-                // forces it into the tree as a queryable leaf.
-                Color.clear
+                // per cell on macOS-15 hosted runners.
+                //
+                // Text (not Color.clear) because Color.clear +
+                // .accessibilityElement() + .accessibilityValue(...) surfaces
+                // an empty value on macOS XCUITest (verified via DIAG dump
+                // showing marker.exists=true but value="" on PR #84). Text
+                // reliably exposes its content as the a11y label.
+                Text(photos.first.map(ThumbnailCell.accessibilityID(for:)) ?? "")
                     .frame(width: 1, height: 1)
+                    .opacity(0)
                     .allowsHitTesting(false)
-                    .accessibilityElement(children: .ignore)
                     .accessibilityIdentifier("LeftmostThumbnail")
-                    .accessibilityValue(
-                        photos.first.map(ThumbnailCell.accessibilityID(for:)) ?? ""
-                    )
             }
             .onChange(of: selection.activeID) { _, _ in
                 scrollActiveIntoView(proxy, animated: true)

--- a/app/SuperPickyApp/ThumbnailStripView.swift
+++ b/app/SuperPickyApp/ThumbnailStripView.swift
@@ -54,14 +54,17 @@ struct ThumbnailStripView: View {
                 // a11y-only marker for finding the display-first thumbnail
                 // in O(1) from XCUITest. Test helpers used to iterate every
                 // visible cell to find leftmost-by-frame, which cost ~0.3 s
-                // per cell on macOS-15 hosted runners.
+                // per cell on macOS-15 hosted runners. Color.clear has no
+                // a11y representation by default, so accessibilityElement()
+                // forces it into the tree as a queryable leaf.
                 Color.clear
                     .frame(width: 1, height: 1)
+                    .allowsHitTesting(false)
+                    .accessibilityElement(children: .ignore)
                     .accessibilityIdentifier("LeftmostThumbnail")
                     .accessibilityValue(
                         photos.first.map(ThumbnailCell.accessibilityID(for:)) ?? ""
                     )
-                    .allowsHitTesting(false)
             }
             .onChange(of: selection.activeID) { _, _ in
                 scrollActiveIntoView(proxy, animated: true)

--- a/app/SuperPickyApp/ThumbnailStripView.swift
+++ b/app/SuperPickyApp/ThumbnailStripView.swift
@@ -50,6 +50,19 @@ struct ThumbnailStripView: View {
             }
             .background(ScrollWheelRedirector())
             .background(.bar)
+            .overlay(alignment: .topLeading) {
+                // a11y-only marker for finding the display-first thumbnail
+                // in O(1) from XCUITest. Test helpers used to iterate every
+                // visible cell to find leftmost-by-frame, which cost ~0.3 s
+                // per cell on macOS-15 hosted runners.
+                Color.clear
+                    .frame(width: 1, height: 1)
+                    .accessibilityIdentifier("LeftmostThumbnail")
+                    .accessibilityValue(
+                        photos.first.map(ThumbnailCell.accessibilityID(for:)) ?? ""
+                    )
+                    .allowsHitTesting(false)
+            }
             .onChange(of: selection.activeID) { _, _ in
                 scrollActiveIntoView(proxy, animated: true)
             }

--- a/app/SuperPickyUITests/A11y.swift
+++ b/app/SuperPickyUITests/A11y.swift
@@ -13,6 +13,7 @@ enum A11y {
     static let speciesEditPanelEmptyAssigned = "SpeciesEditPanel_EmptyAssigned"
     static let selectionCounter = "SelectionCounter"
     static let revealInFinderMenuItem = "RevealInFinder"
+    static let leftmostThumbnail = "LeftmostThumbnail"
 
     /// Accessibility values used by ThumbnailCell — match
     /// `ThumbnailCell.a11ySelectionValue`.

--- a/app/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/app/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -548,25 +548,16 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         return active.exists ? active.identifier : nil
     }
 
-    /// Identifier of the leftmost thumbnail in the visible viewport. The
-    /// LazyHStack only puts in-viewport items in the a11y tree, so this
-    /// query reliably returns the displayed-first thumbnail.
+    /// Identifier of the display-first thumbnail (i.e. `photos.first` in
+    /// the strip's data array). Reads the marker `accessibilityValue`
+    /// rendered by `ThumbnailStripView` — one direct query, no per-cell
+    /// iteration.
     private func leftmostVisibleThumbnailID(in app: XCUIApplication) -> String? {
-        let thumbs = app.images.matching(NSPredicate(
-            format: "identifier BEGINSWITH 'Thumbnail_'"
-        ))
-        var minX = CGFloat.greatestFiniteMagnitude
-        var result: String?
-        for i in 0..<thumbs.count {
-            let t = thumbs.element(boundBy: i)
-            guard t.exists, t.frame.size.width > 0 else { continue }
-            let x = t.frame.origin.x
-            if x.isFinite, x < minX {
-                minX = x
-                result = t.identifier
-            }
-        }
-        return result
+        let marker = app.descendants(matching: .any)
+            .matching(identifier: A11y.leftmostThumbnail).firstMatch
+        guard marker.exists else { return nil }
+        let value = marker.value as? String
+        return (value?.isEmpty ?? true) ? nil : value
     }
 
     // MARK: - 30-39: Export

--- a/app/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/app/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -549,24 +549,16 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
     }
 
     /// Identifier of the display-first thumbnail (i.e. `photos.first` in
-    /// the strip's data array). Reads the marker `accessibilityValue`
-    /// rendered by `ThumbnailStripView` — one direct query, no per-cell
-    /// iteration.
+    /// the strip's data array). Reads the marker rendered by
+    /// `ThumbnailStripView` — one direct query, no per-cell iteration.
+    /// The marker is a Text whose content carries the identifier, so
+    /// `.label` (not `.value`) is the right accessor.
     private func leftmostVisibleThumbnailID(in app: XCUIApplication) -> String? {
         let marker = app.descendants(matching: .any)
             .matching(identifier: A11y.leftmostThumbnail).firstMatch
-        let exists = marker.exists
-        let value = marker.value as? String
-        if !exists || (value?.isEmpty ?? true) {
-            // DIAG (PR #84): the marker query returned nil twice on CI.
-            // Dump the a11y tree so we can see whether the marker is in
-            // the tree at all, under which element type, and with what
-            // value. Remove once the marker scheme lands green.
-            print("[DIAG-leftmost] marker.exists=\(exists) value=\(value ?? "<nil>")")
-            print("[DIAG-leftmost] app.debugDescription:\n\(app.debugDescription)")
-        }
-        guard exists else { return nil }
-        return (value?.isEmpty ?? true) ? nil : value
+        guard marker.exists else { return nil }
+        let label = marker.label
+        return label.isEmpty ? nil : label
     }
 
     // MARK: - 30-39: Export

--- a/app/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/app/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -555,8 +555,17 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
     private func leftmostVisibleThumbnailID(in app: XCUIApplication) -> String? {
         let marker = app.descendants(matching: .any)
             .matching(identifier: A11y.leftmostThumbnail).firstMatch
-        guard marker.exists else { return nil }
+        let exists = marker.exists
         let value = marker.value as? String
+        if !exists || (value?.isEmpty ?? true) {
+            // DIAG (PR #84): the marker query returned nil twice on CI.
+            // Dump the a11y tree so we can see whether the marker is in
+            // the tree at all, under which element type, and with what
+            // value. Remove once the marker scheme lands green.
+            print("[DIAG-leftmost] marker.exists=\(exists) value=\(value ?? "<nil>")")
+            print("[DIAG-leftmost] app.debugDescription:\n\(app.debugDescription)")
+        }
+        guard exists else { return nil }
         return (value?.isEmpty ?? true) ? nil : value
     }
 


### PR DESCRIPTION
## Summary

Replaces a per-cell `XCUIElement` iteration in `leftmostVisibleThumbnailID` (test23 / test24 / test25 in `CullingWorkflowUITests`) with a single direct a11y query.

**Why:** the prior helper iterated `0..<thumbs.count`, accessing `.exists`, `.frame`, and `.identifier` on each. Each property access re-queries the live a11y tree at ~0.3 s per cell on macOS-15 hosted runners. Visible in CI logs as repeating \`Checking existence of \`Image (Element at index N)\`\` lines. With ~35 cells × 3 callers, that's ~30 s of pure query overhead per culling-shard run.

**How:** `ThumbnailStripView` now renders a 1×1 transparent overlay marker with `accessibilityIdentifier "LeftmostThumbnail"` and `accessibilityValue` set to the display-first photo's thumbnail identifier (\`Thumbnail_<filename>\`). The marker doesn't hit-test, is invisible, and only surfaces a value to the a11y tree. The test helper reads `marker.value` once.

## Test plan

- [x] L1 unit tests pass locally
- [x] SwiftLint --strict passes
- [x] `xcodebuild build-for-testing` succeeds
- [ ] CI green: confirm test23/test24/test25 still pass with the new lookup; expect culling-shard wallclock to drop further (~30 s) on top of #83's rebalance