### PR TITLE
perf(test): walk app.snapshot() to find leftmost thumbnail

### DIFF
--- a/app/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/app/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -548,23 +548,30 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         return active.exists ? active.identifier : nil
     }
 
-    /// Identifier of the leftmost thumbnail in the visible viewport. The
-    /// LazyHStack only puts in-viewport items in the a11y tree, so this
-    /// query reliably returns the displayed-first thumbnail.
+    /// Identifier of the leftmost thumbnail in the visible viewport. Walks
+    /// a single `app.snapshot()` of the a11y tree — properties on
+    /// `XCUIElementSnapshot` are pure reads, no per-element re-query. The
+    /// previous implementation used `for i in 0..<thumbs.count {
+    /// thumbs.element(boundBy: i).<prop> }` which paid ~0.3 s per cell on
+    /// macOS-15 hosted runners; with ~35 cells × 3 callers (test23/24/25)
+    /// that was ~30 s of pure query overhead per culling-shard run.
     private func leftmostVisibleThumbnailID(in app: XCUIApplication) -> String? {
-        let thumbs = app.images.matching(NSPredicate(
-            format: "identifier BEGINSWITH 'Thumbnail_'"
-        ))
+        guard let root = try? app.snapshot() else { return nil }
         var minX = CGFloat.greatestFiniteMagnitude
         var result: String?
-        for i in 0..<thumbs.count {
-            let t = thumbs.element(boundBy: i)
-            guard t.exists, t.frame.size.width > 0 else { continue }
-            let x = t.frame.origin.x
-            if x.isFinite, x < minX {
-                minX = x
-                result = t.identifier
+        var stack: [XCUIElementSnapshot] = [root]
+        while let node = stack.popLast() {
+            if node.elementType == .image,
+               node.identifier.hasPrefix("Thumbnail_") {
+                let frame = node.frame
+                if frame.size.width > 0,
+                   frame.origin.x.isFinite,
+                   frame.origin.x < minX {
+                    minX = frame.origin.x
+                    result = node.identifier
+                }
             }
+            stack.append(contentsOf: node.children)
         }
         return result
     }


### PR DESCRIPTION
## Summary

Pure test-side fix for the per-cell XCUIElement lookup that was costing ~30 s per culling-shard run.

\`leftmostVisibleThumbnailID\` (test23/24/25 in \`CullingWorkflowUITests\`) used to iterate \`for i in 0..<thumbs.count { thumbs.element(boundBy: i).<prop> }\`. Every \`.exists\`, \`.frame\`, \`.identifier\` access on a positionally-bound XCUIElement re-queries the live a11y tree at ~0.3 s per access on macOS-15 hosted runners. With ~35 thumbnails × 3 callers, that was ~30 s of overhead per shard. Visible in CI logs as repeating \`Checking existence of \`Image (Element at index N)\`\` lines.

This PR replaces the loop with a single \`app.snapshot()\` + depth-first walk over \`XCUIElementSnapshot\` nodes. Snapshot properties are pure reads — one fetch, no live queries. Same observable result (display-first thumbnail by \`frame.origin.x\`).

## Why not the a11y-marker approach (closed PR #84)

PR #84 tried adding an invisible \`Color.clear\` (then \`Text\`) overlay in \`ThumbnailStripView\` exposing the display-first identifier via \`accessibilityValue\` / \`accessibilityLabel\`. Diagnostic dump showed the marker reached the a11y tree (\`marker.exists=true\`) but its value was empty — \`accessibilityValue\` set on a content-less SwiftUI a11y element doesn't propagate to \`XCUIElement.value\` on macOS XCUITest. The Text variant failed too (likely \`opacity(0)\` removes from a11y on macOS). Snapshot walk avoids the marker-injection problem entirely.

## Test plan

- [x] L1 unit tests pass locally
- [x] SwiftLint --strict passes
- [x] \`xcodebuild build-for-testing\` succeeds
- [ ] CI green: confirm test23/test24/test25 pass with the new helper; expect culling shard wallclock to drop ~25 s on top of #83's 3m55s baseline