### PR TITLE
Preserve existing Lightroom XMP metadata

### DIFF
--- a/app/SuperPickyApp/XMPWriter.swift
+++ b/app/SuperPickyApp/XMPWriter.swift
@@ -1,6 +1,34 @@
 import Foundation
 
 struct XMPWriter {
+    private static let rdfURI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    private static let xmpURI = "http://ns.adobe.com/xap/1.0/"
+    private static let dcURI = "http://purl.org/dc/elements/1.1/"
+    private static let lrURI = "http://ns.adobe.com/lightroom/1.0/"
+    private static let photoshopURI = "http://ns.adobe.com/photoshop/1.0/"
+    private static let iptcURI = "http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/"
+    private static let superPickyURI = "https://halfhacked.com/ns/superpicky/1.0/"
+    // Track only values inserted by SuperPicky so an identical user keyword
+    // remains untouched when a species assignment is later removed.
+    private static let managedSubjectName = "ManagedSubject"
+    private static let managedHierarchicalSubjectName = "ManagedHierarchicalSubject"
+
+    private enum MergeError: LocalizedError {
+        case missingDescription
+        case invalidKeywordContainer(String)
+        case encodingFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .missingDescription:
+                return "The existing sidecar is not a supported XMP document."
+            case .invalidKeywordContainer(let name):
+                return "The existing XMP \(name) property is not an RDF bag."
+            case .encodingFailed:
+                return "Could not encode the XMP sidecar as UTF-8."
+            }
+        }
+    }
 
     /// Get the sidecar URL for a photo (replaces extension with .xmp)
     static func sidecarURL(for photo: Photo) -> URL {
@@ -15,6 +43,10 @@ struct XMPWriter {
         let hasLocation = photo.locationCity != nil || photo.locationState != nil
             || photo.locationCountry != nil || photo.locationCountryCode != nil
             || photo.locationSublocation != nil
+        let flatKeywords = hasKeywords ? keywordBag(for: assigned, isFlying: photo.isFlying) : []
+        let hierarchicalKeywords = hasKeywords
+            ? hierarchicalBag(for: assigned, isFlying: photo.isFlying)
+            : []
 
         var xml = """
         <?xml version="1.0" encoding="UTF-8"?>
@@ -26,14 +58,14 @@ struct XMPWriter {
               xmlns:lr="http://ns.adobe.com/lightroom/1.0/"
               xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/"
               xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/"
+              xmlns:sp="https://halfhacked.com/ns/superpicky/1.0/"
               xmp:Rating="\(photo.starRating)"
-              xmp:PickStatus="\(photo.isPick ? 1 : 0)">\n
+              xmp:PickStatus="\(photo.isPick ? 1 : 0)"
+              sp:ManagedSubject="\(encodeManaged(flatKeywords))"
+              sp:ManagedHierarchicalSubject="\(encodeManaged(hierarchicalKeywords))">\n
         """
 
         if hasKeywords {
-            let flatKeywords = keywordBag(for: assigned, isFlying: photo.isFlying)
-            let hierarchicalKeywords = hierarchicalBag(for: assigned, isFlying: photo.isFlying)
-
             xml += "      <dc:subject>\n"
             xml += "        <rdf:Bag>\n"
             for keyword in flatKeywords {
@@ -82,8 +114,17 @@ struct XMPWriter {
     /// Returns the URL of the written .xmp file.
     static func write(photo: Photo) throws -> URL {
         let url = sidecarURL(for: photo)
-        let content = generate(photo: photo)
-        try content.data(using: .utf8)!.write(to: url)
+        let data: Data
+        if FileManager.default.fileExists(atPath: url.path) {
+            let existing = try Data(contentsOf: url)
+            data = try merge(photo: photo, into: existing)
+        } else {
+            guard let generated = generate(photo: photo).data(using: .utf8) else {
+                throw MergeError.encodingFailed
+            }
+            data = generated
+        }
+        try data.write(to: url, options: .atomic)
         return url
     }
 
@@ -125,6 +166,378 @@ struct XMPWriter {
     }
 
     // MARK: - Private
+
+    private static func merge(photo: Photo, into data: Data) throws -> Data {
+        let document = try XMLDocument(data: data, options: [.nodePreserveAll])
+        let descriptions = descendantElements(
+            in: document,
+            localName: "Description",
+            uri: rdfURI
+        )
+        guard let primaryDescription = descriptions.first else {
+            throw MergeError.missingDescription
+        }
+
+        setSimpleProperty(
+            localName: "Rating",
+            uri: xmpURI,
+            preferredPrefix: "xmp",
+            value: String(photo.starRating),
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+        setSimpleProperty(
+            localName: "PickStatus",
+            uri: xmpURI,
+            preferredPrefix: "xmp",
+            value: photo.isPick ? "1" : "0",
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+
+        let previousFlat = decodeManagedProperty(
+            localName: managedSubjectName,
+            descriptions: descriptions
+        )
+        let previousHierarchical = decodeManagedProperty(
+            localName: managedHierarchicalSubjectName,
+            descriptions: descriptions
+        )
+        let assigned = photo.assignedSpecies
+        let desiredFlat = keywordBag(for: assigned, isFlying: photo.isFlying)
+        let desiredHierarchical = hierarchicalBag(for: assigned, isFlying: photo.isFlying)
+        let managedFlat = try updateKeywordBag(
+            propertyName: "subject",
+            propertyURI: dcURI,
+            preferredPrefix: "dc",
+            desired: desiredFlat,
+            previouslyManaged: previousFlat,
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+        let managedHierarchical = try updateKeywordBag(
+            propertyName: "hierarchicalSubject",
+            propertyURI: lrURI,
+            preferredPrefix: "lr",
+            desired: desiredHierarchical,
+            previouslyManaged: previousHierarchical,
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+        setSimpleProperty(
+            localName: managedSubjectName,
+            uri: superPickyURI,
+            preferredPrefix: "sp",
+            value: encodeManaged(managedFlat),
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+        setSimpleProperty(
+            localName: managedHierarchicalSubjectName,
+            uri: superPickyURI,
+            preferredPrefix: "sp",
+            value: encodeManaged(managedHierarchical),
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+
+        setOptionalElementProperty(
+            localName: "City",
+            uri: photoshopURI,
+            preferredPrefix: "photoshop",
+            value: photo.locationCity,
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+        setOptionalElementProperty(
+            localName: "State",
+            uri: photoshopURI,
+            preferredPrefix: "photoshop",
+            value: photo.locationState,
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+        setOptionalElementProperty(
+            localName: "Country",
+            uri: photoshopURI,
+            preferredPrefix: "photoshop",
+            value: photo.locationCountry,
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+        setOptionalElementProperty(
+            localName: "CountryCode",
+            uri: iptcURI,
+            preferredPrefix: "Iptc4xmpCore",
+            value: photo.locationCountryCode,
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+        setOptionalElementProperty(
+            localName: "Location",
+            uri: iptcURI,
+            preferredPrefix: "Iptc4xmpCore",
+            value: photo.locationSublocation,
+            descriptions: descriptions,
+            fallback: primaryDescription
+        )
+
+        return document.xmlData(options: [.nodePrettyPrint])
+    }
+
+    private static func updateKeywordBag(
+        propertyName: String,
+        propertyURI: String,
+        preferredPrefix: String,
+        desired: [String],
+        previouslyManaged: [String]?,
+        descriptions: [XMLElement],
+        fallback: XMLElement
+    ) throws -> [String] {
+        let existingProperty = descriptions.compactMap {
+            directElement(in: $0, localName: propertyName, uri: propertyURI)
+        }.first
+
+        let property: XMLElement
+        let bag: XMLElement
+        if let existingProperty {
+            property = existingProperty
+            guard let existingBag = directElement(
+                in: property,
+                localName: "Bag",
+                uri: rdfURI
+            ) else {
+                throw MergeError.invalidKeywordContainer(propertyName)
+            }
+            bag = existingBag
+        } else {
+            guard !desired.isEmpty else { return [] }
+            let propertyPrefix = ensureNamespace(
+                preferredPrefix,
+                uri: propertyURI,
+                on: fallback
+            )
+            property = XMLElement(
+                name: "\(propertyPrefix):\(propertyName)",
+                uri: propertyURI
+            )
+            let rdfPrefix = ensureNamespace("rdf", uri: rdfURI, on: fallback)
+            bag = XMLElement(name: "\(rdfPrefix):Bag", uri: rdfURI)
+            property.addChild(bag)
+            fallback.addChild(property)
+        }
+
+        if let previouslyManaged {
+            var remainingCounts = previouslyManaged.reduce(into: [String: Int]()) {
+                $0[$1, default: 0] += 1
+            }
+            let items = directElements(in: bag, localName: "li", uri: rdfURI)
+            for item in items.reversed() {
+                guard let value = item.stringValue,
+                      let count = remainingCounts[value],
+                      count > 0 else { continue }
+                item.detach()
+                remainingCounts[value] = count - 1
+            }
+        }
+
+        var present = Set(
+            directElements(in: bag, localName: "li", uri: rdfURI)
+                .compactMap(\.stringValue)
+        )
+        var managed: [String] = []
+        let owner = property.parent as? XMLElement ?? fallback
+        let rdfPrefix = ensureNamespace("rdf", uri: rdfURI, on: owner)
+        for value in desired where present.insert(value).inserted {
+            let item = XMLElement(name: "\(rdfPrefix):li", uri: rdfURI)
+            item.stringValue = value
+            bag.addChild(item)
+            managed.append(value)
+        }
+        return managed
+    }
+
+    /// Finds an existing attribute or child element with the given name/URI across
+    /// `descriptions`, sets its value, and returns `true` when found.
+    @discardableResult
+    private static func updateExistingProperty(
+        localName: String,
+        uri: String,
+        value: String,
+        in descriptions: [XMLElement]
+    ) -> Bool {
+        if let attribute = descriptions.compactMap({
+            namespacedAttribute(in: $0, localName: localName, uri: uri)
+        }).first {
+            attribute.stringValue = value
+            return true
+        }
+        if let element = descriptions.compactMap({
+            directElement(in: $0, localName: localName, uri: uri)
+        }).first {
+            element.stringValue = value
+            return true
+        }
+        return false
+    }
+
+    private static func setSimpleProperty(
+        localName: String,
+        uri: String,
+        preferredPrefix: String,
+        value: String,
+        descriptions: [XMLElement],
+        fallback: XMLElement
+    ) {
+        if updateExistingProperty(localName: localName, uri: uri, value: value, in: descriptions) { return }
+        let prefix = ensureNamespace(preferredPrefix, uri: uri, on: fallback)
+        let attribute = XMLNode.attribute(
+            withName: "\(prefix):\(localName)",
+            uri: uri,
+            stringValue: value
+        ) as! XMLNode
+        fallback.addAttribute(attribute)
+    }
+
+    private static func setOptionalElementProperty(
+        localName: String,
+        uri: String,
+        preferredPrefix: String,
+        value: String?,
+        descriptions: [XMLElement],
+        fallback: XMLElement
+    ) {
+        guard let value else { return }
+        if updateExistingProperty(localName: localName, uri: uri, value: value, in: descriptions) { return }
+        let prefix = ensureNamespace(preferredPrefix, uri: uri, on: fallback)
+        let element = XMLElement(name: "\(prefix):\(localName)", uri: uri)
+        element.stringValue = value
+        fallback.addChild(element)
+    }
+
+    private static func decodeManagedProperty(
+        localName: String,
+        descriptions: [XMLElement]
+    ) -> [String]? {
+        guard let encoded = descriptions.compactMap({
+            namespacedAttribute(
+                in: $0,
+                localName: localName,
+                uri: superPickyURI
+            )?.stringValue
+        }).first else {
+            return nil
+        }
+        guard !encoded.isEmpty else { return [] }
+        guard let data = Data(base64Encoded: encoded),
+              let decoded = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return decoded.split(
+            separator: "\0",
+            omittingEmptySubsequences: false
+        ).map(String.init)
+    }
+
+    private static func encodeManaged(_ values: [String]) -> String {
+        Data(values.joined(separator: "\0").utf8).base64EncodedString()
+    }
+
+    private static func descendantElements(
+        in node: XMLNode,
+        localName: String,
+        uri: String
+    ) -> [XMLElement] {
+        var matches: [XMLElement] = []
+        if let element = node as? XMLElement,
+           element.localName == localName,
+           element.uri == uri {
+            matches.append(element)
+        }
+        for child in node.children ?? [] {
+            matches.append(contentsOf: descendantElements(
+                in: child,
+                localName: localName,
+                uri: uri
+            ))
+        }
+        return matches
+    }
+
+    private static func directElements(
+        in element: XMLElement,
+        localName: String,
+        uri: String
+    ) -> [XMLElement] {
+        (element.children ?? []).compactMap {
+            guard let child = $0 as? XMLElement,
+                  child.localName == localName,
+                  child.uri == uri else { return nil }
+            return child
+        }
+    }
+
+    private static func directElement(
+        in element: XMLElement,
+        localName: String,
+        uri: String
+    ) -> XMLElement? {
+        directElements(in: element, localName: localName, uri: uri).first
+    }
+
+    private static func namespacedAttribute(
+        in element: XMLElement,
+        localName: String,
+        uri: String
+    ) -> XMLNode? {
+        element.attributes?.first {
+            $0.localName == localName && $0.uri == uri
+        }
+    }
+
+    private static func ensureNamespace(
+        _ preferredPrefix: String,
+        uri: String,
+        on element: XMLElement
+    ) -> String {
+        if let existing = element.resolvePrefix(forNamespaceURI: uri),
+           !existing.isEmpty {
+            return existing
+        }
+
+        var prefix = preferredPrefix
+        var suffix = 2
+        while let mappedURI = namespaceURI(for: prefix, from: element),
+              mappedURI != uri {
+            prefix = "\(preferredPrefix)\(suffix)"
+            suffix += 1
+        }
+        if namespaceURI(for: prefix, from: element) == nil {
+            let namespace = XMLNode.namespace(
+                withName: prefix,
+                stringValue: uri
+            ) as! XMLNode
+            element.addNamespace(namespace)
+        }
+        return prefix
+    }
+
+    private static func namespaceURI(
+        for prefix: String,
+        from element: XMLElement
+    ) -> String? {
+        var node: XMLNode? = element
+        while let current = node {
+            if let currentElement = current as? XMLElement,
+               let namespace = currentElement.namespaces?.first(where: {
+                   $0.name == prefix
+               }) {
+                return namespace.stringValue
+            }
+            node = current.parent
+        }
+        return nil
+    }
 
     private static func xmlEscape(_ string: String) -> String {
         string

--- a/app/SuperPickyTests/Core/XMPWriterTests.swift
+++ b/app/SuperPickyTests/Core/XMPWriterTests.swift
@@ -4,7 +4,14 @@ import Foundation
 
 @Suite struct XMPWriterTests {
 
-    // MARK: - Helper
+    // MARK: - Helpers
+
+    private func withTempDir(_ body: (URL) throws -> Void) throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try body(dir)
+    }
 
     private func makePhoto(
         filename: String = "IMG_1234.CR3",
@@ -107,31 +114,236 @@ import Foundation
     // MARK: - Write to disk
 
     @Test func writeToDisk() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try withTempDir { tempDir in
+            let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
+            let photo = makePhoto(
+                filename: "IMG_5678.CR3",
+                filePath: filePath,
+                starRating: 5,
+                speciesCommonName: "Peregrine Falcon",
+                speciesScientificName: "Falco peregrinus",
+                isFlying: true
+            )
 
-        let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
-        let photo = makePhoto(
-            filename: "IMG_5678.CR3",
-            filePath: filePath,
-            starRating: 5,
-            speciesCommonName: "Peregrine Falcon",
-            speciesScientificName: "Falco peregrinus",
-            isFlying: true
-        )
+            let sidecarURL = try XMPWriter.write(photo: photo)
+            #expect(FileManager.default.fileExists(atPath: sidecarURL.path))
 
-        let sidecarURL = try XMPWriter.write(photo: photo)
-        #expect(FileManager.default.fileExists(atPath: sidecarURL.path))
+            let content = try String(contentsOf: sidecarURL, encoding: .utf8)
+            #expect(content.contains("xmp:Rating=\"5\""))
+            #expect(content.contains("<rdf:li>Peregrine Falcon</rdf:li>"))
+            #expect(content.contains("<rdf:li>Falco peregrinus</rdf:li>"))
+            #expect(content.contains("<rdf:li>In Flight</rdf:li>"))
+            #expect(content.contains("<rdf:li>Bird|Peregrine Falcon</rdf:li>"))
+            #expect(content.contains("<rdf:li>Behavior|In Flight</rdf:li>"))
+        }
+    }
 
-        let content = try String(contentsOf: sidecarURL, encoding: .utf8)
-        #expect(content.contains("xmp:Rating=\"5\""))
-        #expect(content.contains("<rdf:li>Peregrine Falcon</rdf:li>"))
-        #expect(content.contains("<rdf:li>Falco peregrinus</rdf:li>"))
-        #expect(content.contains("<rdf:li>In Flight</rdf:li>"))
-        #expect(content.contains("<rdf:li>Bird|Peregrine Falcon</rdf:li>"))
-        #expect(content.contains("<rdf:li>Behavior|In Flight</rdf:li>"))
+    @Test func writePreservesExistingLightroomMetadataAndKeywords() throws {
+        try withTempDir { tempDir in
+            let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
+            let sidecarURL = tempDir.appendingPathComponent("IMG_5678.xmp")
+            let existing = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <x:xmpmeta xmlns:x="adobe:ns:meta/">
+              <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description
+                  xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:crs="http://ns.adobe.com/camera-raw-settings/1.0/"
+                  xmp:Rating="1"
+                  crs:Exposure2012="+0.75">
+                  <dc:subject>
+                    <rdf:Bag>
+                      <rdf:li>Portfolio</rdf:li>
+                    </rdf:Bag>
+                  </dc:subject>
+                  <crs:ToneCurvePV2012>
+                    <rdf:Seq>
+                      <rdf:li>0, 0</rdf:li>
+                      <rdf:li>255, 255</rdf:li>
+                    </rdf:Seq>
+                  </crs:ToneCurvePV2012>
+                </rdf:Description>
+              </rdf:RDF>
+            </x:xmpmeta>
+            """
+            try Data(existing.utf8).write(to: sidecarURL)
+
+            let photo = makePhoto(
+                filename: "IMG_5678.CR3",
+                filePath: filePath,
+                starRating: 5,
+                speciesCommonName: "Peregrine Falcon",
+                speciesScientificName: "Falco peregrinus"
+            )
+
+            _ = try XMPWriter.write(photo: photo)
+
+            let content = try String(contentsOf: sidecarURL, encoding: .utf8)
+            #expect(content.contains("xmp:Rating=\"5\""))
+            #expect(content.contains("crs:Exposure2012=\"+0.75\""))
+            #expect(content.contains("<crs:ToneCurvePV2012>"))
+            #expect(content.contains("<rdf:li>Portfolio</rdf:li>"))
+            #expect(content.contains("<rdf:li>Peregrine Falcon</rdf:li>"))
+        }
+    }
+
+    @Test func subsequentWritesReplaceOnlySuperPickyKeywords() throws {
+        try withTempDir { tempDir in
+            let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
+            let sidecarURL = tempDir.appendingPathComponent("IMG_5678.xmp")
+            let existing = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <x:xmpmeta xmlns:x="adobe:ns:meta/">
+              <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:subject>
+                    <rdf:Bag>
+                      <rdf:li>Portfolio</rdf:li>
+                    </rdf:Bag>
+                  </dc:subject>
+                </rdf:Description>
+              </rdf:RDF>
+            </x:xmpmeta>
+            """
+            try Data(existing.utf8).write(to: sidecarURL)
+
+            var photo = makePhoto(
+                filename: "IMG_5678.CR3",
+                filePath: filePath,
+                starRating: 4,
+                speciesCommonName: "Robin",
+                speciesScientificName: "Turdus migratorius"
+            )
+            _ = try XMPWriter.write(photo: photo)
+
+            photo.speciesCommonName = "Osprey"
+            photo.speciesScientificName = "Pandion haliaetus"
+            _ = try XMPWriter.write(photo: photo)
+
+            let content = try String(contentsOf: sidecarURL, encoding: .utf8)
+            #expect(content.contains("<rdf:li>Portfolio</rdf:li>"))
+            #expect(content.contains("<rdf:li>Osprey</rdf:li>"))
+            #expect(content.contains("<rdf:li>Pandion haliaetus</rdf:li>"))
+            #expect(!content.contains("<rdf:li>Robin</rdf:li>"))
+            #expect(!content.contains("<rdf:li>Turdus migratorius</rdf:li>"))
+            #expect(!content.contains("<rdf:li>Bird|Robin</rdf:li>"))
+        }
+    }
+
+    @Test func existingMatchingKeywordRemainsUserOwned() throws {
+        try withTempDir { tempDir in
+            let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
+            let sidecarURL = tempDir.appendingPathComponent("IMG_5678.xmp")
+            let existing = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <x:xmpmeta xmlns:x="adobe:ns:meta/">
+              <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:subject>
+                    <rdf:Bag>
+                      <rdf:li>Robin</rdf:li>
+                    </rdf:Bag>
+                  </dc:subject>
+                </rdf:Description>
+              </rdf:RDF>
+            </x:xmpmeta>
+            """
+            try Data(existing.utf8).write(to: sidecarURL)
+
+            var photo = makePhoto(
+                filename: "IMG_5678.CR3",
+                filePath: filePath,
+                starRating: 4,
+                speciesCommonName: "Robin",
+                speciesScientificName: "Turdus migratorius"
+            )
+            _ = try XMPWriter.write(photo: photo)
+
+            photo.speciesCommonName = "Osprey"
+            photo.speciesScientificName = "Pandion haliaetus"
+            _ = try XMPWriter.write(photo: photo)
+
+            let content = try String(contentsOf: sidecarURL, encoding: .utf8)
+            #expect(content.contains("<rdf:li>Robin</rdf:li>"))
+            #expect(content.contains("<rdf:li>Osprey</rdf:li>"))
+            #expect(!content.contains("<rdf:li>Turdus migratorius</rdf:li>"))
+        }
+    }
+
+    @Test func writeUpdatesLocationWithoutRemovingDevelopSettings() throws {
+        try withTempDir { tempDir in
+            let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
+            let sidecarURL = tempDir.appendingPathComponent("IMG_5678.xmp")
+            let existing = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <x:xmpmeta xmlns:x="adobe:ns:meta/">
+              <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description
+                  xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/"
+                  xmlns:crs="http://ns.adobe.com/camera-raw-settings/1.0/"
+                  crs:Contrast2012="+20"
+                  photoshop:City="Old City"/>
+              </rdf:RDF>
+            </x:xmpmeta>
+            """
+            try Data(existing.utf8).write(to: sidecarURL)
+
+            var photo = makePhoto(filename: "IMG_5678.CR3", filePath: filePath, starRating: 4)
+            photo.locationCity = "New City"
+            photo.locationCountryCode = "US"
+            _ = try XMPWriter.write(photo: photo)
+
+            let content = try String(contentsOf: sidecarURL, encoding: .utf8)
+            #expect(content.contains("crs:Contrast2012=\"+20\""))
+            #expect(content.contains("photoshop:City=\"New City\""))
+            #expect(content.contains("<Iptc4xmpCore:CountryCode>US</Iptc4xmpCore:CountryCode>"))
+            #expect(!content.contains("Old City"))
+        }
+    }
+
+    @Test func unsupportedKeywordContainerIsNotOverwritten() throws {
+        try withTempDir { tempDir in
+            let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
+            let sidecarURL = tempDir.appendingPathComponent("IMG_5678.xmp")
+            let existing = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <x:xmpmeta xmlns:x="adobe:ns:meta/">
+              <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:subject>Portfolio</dc:subject>
+                </rdf:Description>
+              </rdf:RDF>
+            </x:xmpmeta>
+            """
+            try Data(existing.utf8).write(to: sidecarURL)
+            let photo = makePhoto(
+                filename: "IMG_5678.CR3",
+                filePath: filePath,
+                starRating: 5,
+                speciesCommonName: "Osprey"
+            )
+
+            #expect(throws: (any Error).self) {
+                _ = try XMPWriter.write(photo: photo)
+            }
+            #expect(try String(contentsOf: sidecarURL, encoding: .utf8) == existing)
+        }
+    }
+
+    @Test func malformedExistingSidecarIsNotOverwritten() throws {
+        try withTempDir { tempDir in
+            let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
+            let sidecarURL = tempDir.appendingPathComponent("IMG_5678.xmp")
+            let existing = "<not-valid-xmp"
+            try Data(existing.utf8).write(to: sidecarURL)
+            let photo = makePhoto(filename: "IMG_5678.CR3", filePath: filePath, starRating: 5)
+
+            #expect(throws: (any Error).self) {
+                _ = try XMPWriter.write(photo: photo)
+            }
+            #expect(try String(contentsOf: sidecarURL, encoding: .utf8) == existing)
+        }
     }
 
     // MARK: - Valid XML structure


### PR DESCRIPTION
## Summary
- merge SuperPicky ratings, locations, and species/flight keywords into existing XMP sidecars
- preserve Lightroom develop settings and user-owned flat and hierarchical keywords
- track only keyword entries inserted by SuperPicky so later species edits remove only owned values
- leave malformed or unsupported sidecars untouched instead of replacing them

## Test plan
- `scripts/pre-commit.sh`
- regression coverage for existing Lightroom metadata, repeated species edits, matching user keywords, location attributes, and invalid XMP