### PR TITLE
Remove temporary CI diagnostics

### DIFF
--- a/app/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/app/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -80,15 +80,8 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
             sortMenu.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).click()
         }
         // Gate on the first item appearing rather than a blind sleep.
-        // TEMP DIAGNOSTIC — remove before merge.
-        let screenSize = XCUIScreen.main.screenshot().image.size
-        print("DIAG-CULL screen=\(screenSize) window=\(app.windows.firstMatch.frame)")
-        print("DIAG-CULL SortMenu exists=\(sortMenu.exists) hittable=\(sortMenu.isHittable) frame=\(sortMenu.frame)")
-        let firstItemAppeared = app.menuItems["Filename"].waitForExistence(timeout: 2) ||
-                      app.descendants(matching: .any)["Filename"].firstMatch.waitForExistence(timeout: 1)
-        print("DIAG-CULL afterClick menusCount=\(app.menus.count) menuItemsCount=\(app.menuItems.count) popUpButtonsCount=\(app.popUpButtons.count) firstItemAppeared=\(firstItemAppeared)")
-        print("DIAG-CULL TREE START\n\(app.debugDescription)\nDIAG-CULL TREE END")
-        XCTAssertTrue(firstItemAppeared,
+        XCTAssertTrue(app.menuItems["Filename"].waitForExistence(timeout: 2) ||
+                      app.descendants(matching: .any)["Filename"].firstMatch.waitForExistence(timeout: 1),
                       "Sort menu should open and offer 'Filename'")
 
         for label in ["Filename", "Date", "Rating", "Sharpness", "Aesthetics"] {

--- a/app/SuperPickyUITests/SpeciesEditPanelUITests.swift
+++ b/app/SuperPickyUITests/SpeciesEditPanelUITests.swift
@@ -254,45 +254,6 @@ final class SpeciesEditPanelUITests: SuperPickyUITestCase {
     // end so the following eagle test correctly takes the slow path and
     // re-selects DSC09969.
 
-    // TEMP DIAGNOSTIC — remove before merge. Runs first (test00) so it
-    // captures the exact post-open/post-scroll state test41 sees. Prints
-    // screen/window/panel/element frames + full a11y tree to the CI log.
-    func test00_DiagnosticDump() {
-        let app = Self.app!
-        let screenSize = XCUIScreen.main.screenshot().image.size
-        print("DIAG screen=\(screenSize)")
-        print("DIAG window=\(app.windows.firstMatch.frame)")
-
-        ensurePanelClosed()
-        selectThumbnail(filename: "DSC09969.jpg")
-        exifToggleButton.click()
-        let panel = app.scrollViews[A11y.exifPanel]
-        _ = panel.waitForExistence(timeout: 3)
-        let panelBefore = panel.exists ? String(describing: panel.frame) : "n/a"
-        print("DIAG panelExists=\(panel.exists) panelFrameBeforeScroll=\(panelBefore)")
-
-        scrollPanelToBottom()
-        let panelAfter = panel.exists ? String(describing: panel.frame) : "n/a"
-        print("DIAG panelFrameAfterScroll=\(panelAfter)")
-
-        dumpElement("Remove_baleag", app.buttons[A11y.speciesEditRemove("baleag")])
-        dumpElement("Add_goleag", app.buttons[A11y.speciesEditAdd("goleag")])
-        dumpElement("Add_osprey", app.buttons[A11y.speciesEditAdd("osprey")])
-        dumpElement("SearchField", app.textFields[A11y.speciesEditPanelSearchField])
-        print("DIAG scrollViewsCount=\(app.scrollViews.count) buttonsCount=\(app.buttons.count) textFieldsCount=\(app.textFields.count)")
-        print("DIAG TREE START\n\(app.debugDescription)\nDIAG TREE END")
-
-        ensurePanelClosed()
-        Self.currentPhotoFilename = nil
-    }
-
-    private func dumpElement(_ name: String, _ element: XCUIElement) {
-        let exists = element.exists
-        let frame = exists ? String(describing: element.frame) : "n/a"
-        let hittable = exists ? String(describing: element.isHittable) : "n/a"
-        print("DIAG \(name) exists=\(exists) hittable=\(hittable) frame=\(frame)")
-    }
-
     func test41_ToggleOpensPanelWithAssignedSpecies() {
         openPanelOnEagle()
         XCTAssertTrue(Self.app.buttons[A11y.speciesEditRemove("baleag")].waitForExistence(timeout: 2))


### PR DESCRIPTION
Follow-up to #90. Removes the temporary `DIAG` dumps (species `test00_DiagnosticDump` + `dumpElement` helper, and the culling `test05` print statements) that were merged onto main alongside the TEST_MODE model-download fix.

They existed only to capture the runner-environment state that pinpointed the root cause; the actual fix in `SuperPickyApp.swift` is untouched. Pure test-file cleanup — removes 48 lines of print-only diagnostics.