### PR TITLE
Make manual species edits immediate

### DIFF
--- a/app/SuperPickyApp/AppDelegate.swift
+++ b/app/SuperPickyApp/AppDelegate.swift
@@ -23,4 +23,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
     }
+
+    /// Opportunistic write-behind flush when the app loses focus, so a normal
+    /// app switch narrows the crash-loss window without waiting for the debounce.
+    func applicationWillResignActive(_ notification: Notification) {
+        Task { @MainActor in
+            await FlushCoordinator.shared.flushAll()
+        }
+    }
+
+    /// Defer termination until every registered `AppState` has drained its
+    /// pending SQLite + write-behind XMP. Replies exactly once.
+    func applicationShouldTerminate(
+        _ sender: NSApplication
+    ) -> NSApplication.TerminateReply {
+        MainActor.assumeIsolated {
+            FlushCoordinator.shared.handleTerminate(sender)
+        }
+    }
 }

--- a/app/SuperPickyApp/AppState.swift
+++ b/app/SuperPickyApp/AppState.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import os
 
 enum SidebarSelection: Hashable {
@@ -63,12 +64,44 @@ struct BurstGroupEntry: Identifiable {
     }
 }
 
+private struct PendingSpeciesEditRender {
+    let operation: String
+    let targetPhotoCount: Int
+    let startedAt: TimeInterval
+    let signpostID: OSSignpostID
+}
+
+/// Result of a deferred species overlay run against SQLite.
+private struct SpeciesPersistResult: Sendable {
+    let written: [Photo]
+    let databaseMilliseconds: Double
+}
+
+/// Summary of one XMP write-behind drain, reported back to `AppState` so it can
+/// surface persistent failures and log deferred sidecar latency separately from
+/// the synchronous edit.
+private struct XMPFlushSummary: Sendable {
+    let writeCount: Int
+    let failureCount: Int
+    let slowestMilliseconds: Double
+    let totalMilliseconds: Double
+    let failedPhotos: [Photo]
+    /// Sidecar paths written successfully in this drain. Used by `AppState` to
+    /// clear durable XMP failure state for exactly the paths that recovered.
+    let succeededSidecarPaths: [String]
+    /// Sidecar paths that failed to write in this drain (still pending).
+    let failedSidecarPaths: [String]
+}
+
 private actor PhotoMutationWorker {
     private let logger = Logger(
         subsystem: "com.halfhacked.superpicky",
         category: "PhotoMutationWorker"
     )
 
+    /// Full read-modify-write used by pick / rate / reject and field-undo.
+    /// XMP is written synchronously here to preserve existing behavior for
+    /// those non-species mutations.
     func apply(
         database: ReportDatabase,
         ids: [UUID],
@@ -85,6 +118,21 @@ private actor PhotoMutationWorker {
         return results
     }
 
+    /// Deferred species overlay: applies captured desired species onto fresh
+    /// rows. XMP is NOT written here — the returned rows are handed to the
+    /// debounced write-behind queue by the caller.
+    func persistSpecies(
+        database: ReportDatabase,
+        snapshots: [SpeciesSnapshot]
+    ) throws -> SpeciesPersistResult {
+        let startedAt = SpeciesEditProfiler.now()
+        let written = try database.overlaySpecies(snapshots)
+        return SpeciesPersistResult(
+            written: written,
+            databaseMilliseconds: SpeciesEditProfiler.elapsedMilliseconds(since: startedAt)
+        )
+    }
+
     func delete(database: ReportDatabase, id: UUID) throws -> Photo? {
         guard let photo = try database.fetchPhoto(id: id) else { return nil }
         try FileManager.default.trashItem(
@@ -93,6 +141,146 @@ private actor PhotoMutationWorker {
         )
         try database.delete(id: id)
         return photo
+    }
+}
+
+/// Debounced, path-keyed XMP write-behind queue.
+///
+/// Species edits are optimistic: SQLite is overlaid on the serialized mutation
+/// chain, but the durable XMP sidecar is written *behind* the UI. Each sidecar
+/// path retains only the latest `Photo`, so rapid edits coalesce into a single
+/// write. Failed writes stay pending (path-keyed, so a newer edit supersedes
+/// them). `flush()` drains deterministically for tests and termination — no
+/// test ever waits on the debounce timer.
+private actor XMPWriteBehindQueue {
+    private var pending: [String: Photo] = [:]
+    private var debounceTask: Task<Void, Never>?
+    private let debounceNanoseconds: UInt64
+    private let onFlush: @Sendable (XMPFlushSummary) -> Void
+
+    init(
+        debounceMilliseconds: Double,
+        onFlush: @escaping @Sendable (XMPFlushSummary) -> Void
+    ) {
+        self.debounceNanoseconds = UInt64(max(0, debounceMilliseconds) * 1_000_000)
+        self.onFlush = onFlush
+    }
+
+    func enqueue(_ photos: [Photo]) {
+        guard !photos.isEmpty else { return }
+        for photo in photos {
+            pending[XMPWriter.sidecarURL(for: photo).path] = photo
+        }
+        scheduleDebounce()
+    }
+
+    /// Drop any pending write for a sidecar path — used when the underlying
+    /// photo is deleted so we don't resurrect an orphan sidecar.
+    func evict(sidecarPath: String) {
+        pending.removeValue(forKey: sidecarPath)
+    }
+
+    func pendingCount() -> Int { pending.count }
+
+    @discardableResult
+    func flush() -> XMPFlushSummary {
+        debounceTask?.cancel()
+        debounceTask = nil
+        return drain()
+    }
+
+    private func scheduleDebounce() {
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self, debounceNanoseconds] in
+            try? await Task.sleep(nanoseconds: debounceNanoseconds)
+            guard let self, !Task.isCancelled else { return }
+            let summary = await self.drain()
+            if summary.writeCount + summary.failureCount > 0 {
+                self.onFlush(summary)
+            }
+        }
+    }
+
+    /// Synchronous within the actor: `XMPWriter.write` never suspends, so no
+    /// `enqueue` can interleave with the write loop. Failures are re-queued.
+    @discardableResult
+    private func drain() -> XMPFlushSummary {
+        guard !pending.isEmpty else {
+            return XMPFlushSummary(
+                writeCount: 0, failureCount: 0,
+                slowestMilliseconds: 0, totalMilliseconds: 0, failedPhotos: [],
+                succeededSidecarPaths: [], failedSidecarPaths: []
+            )
+        }
+        let started = SpeciesEditProfiler.now()
+        let batch = pending
+        pending = [:]
+        var writeCount = 0
+        var failedPhotos: [Photo] = []
+        var succeededSidecarPaths: [String] = []
+        var failedSidecarPaths: [String] = []
+        var slowest = 0.0
+        for (path, photo) in batch {
+            let writeStart = SpeciesEditProfiler.now()
+            do {
+                _ = try XMPWriter.write(photo: photo)
+                writeCount += 1
+                succeededSidecarPaths.append(path)
+            } catch {
+                // Keep the failed write pending unless a newer edit already
+                // superseded this path during the (non-suspending) loop.
+                if pending[path] == nil { pending[path] = photo }
+                failedPhotos.append(photo)
+                failedSidecarPaths.append(path)
+            }
+            slowest = max(slowest, SpeciesEditProfiler.elapsedMilliseconds(since: writeStart))
+        }
+        return XMPFlushSummary(
+            writeCount: writeCount,
+            failureCount: failedPhotos.count,
+            slowestMilliseconds: slowest,
+            totalMilliseconds: SpeciesEditProfiler.elapsedMilliseconds(since: started),
+            failedPhotos: failedPhotos,
+            succeededSidecarPaths: succeededSidecarPaths,
+            failedSidecarPaths: failedSidecarPaths
+        )
+    }
+}
+
+/// Coordinates a bounded, single-reply drain of every registered `AppState`
+/// before the app terminates, and an opportunistic flush when the app resigns
+/// active. Lives here (rather than a new file) to avoid pbxproj churn.
+@MainActor
+final class FlushCoordinator {
+    static let shared = FlushCoordinator()
+
+    private var handlers: [(id: ObjectIdentifier, flush: () async -> Void)] = []
+    private var isTerminationReplyPending = false
+
+    /// Register (or replace) a flush handler keyed by owner identity so repeat
+    /// `onAppear` calls don't accumulate duplicates.
+    func register(owner: AnyObject, flush: @escaping () async -> Void) {
+        let id = ObjectIdentifier(owner)
+        handlers.removeAll { $0.id == id }
+        handlers.append((id, flush))
+    }
+
+    func flushAll() async {
+        for handler in handlers {
+            await handler.flush()
+        }
+    }
+
+    /// AppKit `applicationShouldTerminate` bridge. Returns `.terminateLater`
+    /// once and replies exactly once after every handler drains.
+    func handleTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !isTerminationReplyPending else { return .terminateLater }
+        isTerminationReplyPending = true
+        Task { @MainActor in
+            await flushAll()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
     }
 }
 
@@ -146,6 +334,13 @@ final class AppState {
     var picksCount: Int { allPhotos.lazy.filter(\.isPick).count }
 
     struct UndoAction: Sendable {
+        /// Distinguishes species edits (optimistic: observable state is applied
+        /// synchronously and only species is persisted) from field mutations
+        /// (pick / rate / reject — persist-first, full-row restore on undo).
+        enum Kind: Sendable {
+            case fields
+            case species
+        }
         struct Entry: Sendable {
             let photoID: UUID
             let previousRating: Int
@@ -154,6 +349,7 @@ final class AppState {
             let previousAssignedSpecies: [SpeciesMatch]
             let wasHidden: Bool
         }
+        var kind: Kind = .fields
         let entries: [Entry]
     }
 
@@ -193,6 +389,63 @@ final class AppState {
     private var cachedDB: ReportDatabase?
     @ObservationIgnored private let mutationWorker = PhotoMutationWorker()
     @ObservationIgnored private var pendingMutationTask: Task<Void, Never>?
+    @ObservationIgnored private var lastSpeciesEditProfile: SpeciesEditProfile?
+    @ObservationIgnored private var pendingSpeciesEditRender: PendingSpeciesEditRender?
+    private(set) var speciesEditRenderToken = 0
+
+    // MARK: Optimistic species-edit persistence
+
+    /// Monotonic generation stamped on every optimistic species edit (and undo).
+    /// Used to supersede older failed snapshots and stale optimistic overrides.
+    @ObservationIgnored private var speciesEditGeneration = 0
+
+    /// Desired species applied optimistically but not yet confirmed persisted.
+    /// Keyed by photo id; keeps `appendProcessedPhoto` from clobbering a user
+    /// edit with a pipeline row while persistence is still in flight.
+    @ObservationIgnored private var pendingOptimisticSpecies: [UUID: (generation: Int, species: [SpeciesMatch])] = [:]
+
+    /// Latest failed SQLite species snapshot per photo, retained with its
+    /// original folder/database so retry works even after a folder switch.
+    @ObservationIgnored private var failedSpeciesEdits: [UUID: FailedSpeciesEdit] = [:]
+
+    /// Durable set of XMP sidecar paths whose write-behind write failed and is
+    /// still pending in the queue. Keeps the retry banner visible independently
+    /// of SQLite failure state, so an unrelated success/delete can't clear it
+    /// while a failed sidecar remains. A path is removed only when it later
+    /// writes successfully or its photo is deleted (queue eviction).
+    @ObservationIgnored private var failedXMPSidecars: Set<String> = []
+
+    private struct FailedSpeciesEdit {
+        let generation: Int
+        let folder: URL
+        let database: ReportDatabase
+        let snapshot: SpeciesSnapshot
+    }
+
+    /// Observable, user-facing persistence failure surface (drives the retry
+    /// banner in the species edit panel). `nil` when everything is saved.
+    private(set) var speciesPersistenceFailureMessage: String?
+    var hasSpeciesPersistenceFailure: Bool { speciesPersistenceFailureMessage != nil }
+
+    @ObservationIgnored private let xmpDebounceMilliseconds: Double
+    @ObservationIgnored private var _xmpQueue: XMPWriteBehindQueue?
+    private var xmpQueue: XMPWriteBehindQueue {
+        if let queue = _xmpQueue { return queue }
+        let queue = XMPWriteBehindQueue(
+            debounceMilliseconds: xmpDebounceMilliseconds
+        ) { [weak self] summary in
+            Task { @MainActor in self?.handleXMPFlush(summary) }
+        }
+        _xmpQueue = queue
+        return queue
+    }
+
+    /// - Parameter xmpDebounceMilliseconds: write-behind debounce window. Capped
+    ///   at 150 ms in production; tests never wait on it (they call
+    ///   `flushPendingPersistence()`), so its value is irrelevant to them.
+    init(xmpDebounceMilliseconds: Double = 150) {
+        self.xmpDebounceMilliseconds = min(max(0, xmpDebounceMilliseconds), 150)
+    }
 
     // Per-folder processing state
     var processingFolder: URL?
@@ -346,6 +599,14 @@ final class AppState {
     /// (photo updates in place) via the two index dicts. Leaving the
     /// current filter is the only path that does an O(M) index fix-up.
     func appendProcessedPhoto(_ photo: Photo) {
+        // Preserve an in-flight optimistic species edit: the pipeline row would
+        // otherwise clobber the user's just-made change with model output.
+        // Persistence still merges species onto a freshly-fetched DB row, so the
+        // durable copy stays correct regardless of what we show here.
+        var photo = photo
+        if let optimistic = pendingOptimisticSpecies[photo.id] {
+            photo.assignedSpecies = optimistic.species
+        }
         let oldPhoto: Photo?
         if let idx = allPhotoIndex[photo.id] {
             oldPhoto = allPhotos[idx]
@@ -457,6 +718,14 @@ final class AppState {
     #if DEBUG
     func allPhotosForTesting() -> [Photo] { allPhotos }
     func undoStackSizeForTesting() -> Int { undoStack.count }
+    func lastSpeciesEditProfileForTesting() -> SpeciesEditProfile? {
+        lastSpeciesEditProfile
+    }
+    func pendingXMPWriteCountForTesting() async -> Int {
+        await xmpQueue.pendingCount()
+    }
+    func failedSpeciesEditCountForTesting() -> Int { failedSpeciesEdits.count }
+    func failedXMPSidecarCountForTesting() -> Int { failedXMPSidecars.count }
     #endif
 
     // MARK: - Set-based mutation: pick / rate / reject
@@ -527,10 +796,12 @@ final class AppState {
         }
     }
 
-    // MARK: - Batch primitive
+    // MARK: - Batch primitive (pick / rate / reject: persist-first)
 
     /// Persist a batch away from the main actor, then commit its resulting
-    /// photos and one undo action to observable state.
+    /// photos and one undo action to observable state. Used only by the
+    /// non-species field mutations, which keep their existing persist-first,
+    /// synchronous-XMP behavior. Species edits use the optimistic path below.
     @MainActor
     private func applyBatch(
         context: MutationContext,
@@ -570,7 +841,7 @@ final class AppState {
                 afterEach?(photo)
             }
             if !entries.isEmpty {
-                undoStack.append(UndoAction(entries: entries))
+                undoStack.append(UndoAction(kind: .fields, entries: entries))
                 if undoStack.count > Self.maxUndoDepth { undoStack.removeFirst() }
             }
             afterAll?(mutated)
@@ -593,7 +864,18 @@ final class AppState {
                 ) else {
                     return
                 }
-                guard state.currentFolder == context.folder else { return }
+                // Evict any pending write-behind XMP for this sidecar so a
+                // deferred flush can't recreate an orphan sidecar next to the
+                // now-trashed original. Drop any failed/optimistic state too.
+                let sidecarPath = XMPWriter.sidecarURL(for: photo).path
+                await state.xmpQueue.evict(sidecarPath: sidecarPath)
+                state.pendingOptimisticSpecies.removeValue(forKey: id)
+                state.failedSpeciesEdits.removeValue(forKey: id)
+                state.failedXMPSidecars.remove(sidecarPath)
+                guard state.currentFolder == context.folder else {
+                    state.refreshSpeciesFailureMessage()
+                    return
+                }
 
                 state.allPhotos.removeAll { $0.id == id }
                 state.photos.removeAll { $0.id == id }
@@ -602,6 +884,7 @@ final class AppState {
                 state.undoStack.removeAll {
                     $0.entries.contains(where: { $0.photoID == id })
                 }
+                state.refreshSpeciesFailureMessage()
                 state.logger.info("Deleted photo: \(photo.filename)")
             } catch {
                 state.logger.error("deletePhoto failed: \(error)")
@@ -618,7 +901,7 @@ final class AppState {
     @discardableResult
     func correctSpecies(ids: Set<UUID>, commonName: String) -> Task<Void, Never> {
         let trimmed = commonName.trimmingCharacters(in: .whitespaces)
-        return applySpeciesBatch(ids: ids) { photos in
+        return applySpeciesBatch(ids: ids, operation: "rename") { photos in
             for index in photos.indices {
                 var list = photos[index].assignedSpecies
                 if var first = list.first {
@@ -653,7 +936,7 @@ final class AppState {
     @MainActor
     @discardableResult
     func setPrimarySpecies(ids: Set<UUID>, species: SpeciesMatch) -> Task<Void, Never> {
-        applySpeciesBatch(ids: ids) { photos in
+        applySpeciesBatch(ids: ids, operation: "set-primary") { photos in
             for index in photos.indices {
                 var list = photos[index].assignedSpecies
                 if let matchIndex = list.firstIndex(where: {
@@ -673,7 +956,7 @@ final class AppState {
     @MainActor
     @discardableResult
     func addSpecies(ids: Set<UUID>, species: SpeciesMatch) -> Task<Void, Never> {
-        applySpeciesBatch(ids: ids) { photos in
+        applySpeciesBatch(ids: ids, operation: "add") { photos in
             for index in photos.indices {
                 if let updated = SpeciesAssignmentEditor.add(
                     species,
@@ -690,7 +973,7 @@ final class AppState {
     @MainActor
     @discardableResult
     func removeSpecies(ids: Set<UUID>, species: SpeciesMatch) -> Task<Void, Never> {
-        applySpeciesBatch(ids: ids) { photos in
+        applySpeciesBatch(ids: ids, operation: "remove") { photos in
             for index in photos.indices {
                 let assigned = photos[index].assignedSpecies
                 if let matchIndex = assigned.firstIndex(where: {
@@ -705,27 +988,322 @@ final class AppState {
         }
     }
 
-    /// Common shape for every species mutation: expand burst membership,
-    /// run the batch, rebuild the sidebar hierarchy once afterwards.
+    /// Common shape for every species mutation. Applies the edit to observable
+    /// state *synchronously* (optimistic), registers one undo action for the
+    /// genuinely-changed rows, updates the sidebar hierarchy, then enqueues the
+    /// deferred persistence (serialized SQLite overlay + write-behind XMP). The
+    /// returned task resolves once SQLite has committed and XMP has been queued.
     @MainActor
     private func applySpeciesBatch(
         ids: Set<UUID>,
+        operation: String,
         mutate: @escaping @Sendable (inout [Photo]) -> Void
     ) -> Task<Void, Never> {
+        let totalStartedAt = SpeciesEditProfiler.now()
+        let traceID = SpeciesEditProfiler.signposter.makeSignpostID()
+        let totalInterval = SpeciesEditProfiler.signposter.beginInterval(
+            "Species Edit",
+            id: traceID,
+            "operation: \(operation, privacy: .public), requested: \(ids.count)"
+        )
+
+        let expansionStartedAt = SpeciesEditProfiler.now()
         let targets = expandBurstMembers(of: ids)
+        let expansionMilliseconds = SpeciesEditProfiler.elapsedMilliseconds(since: expansionStartedAt)
         guard !targets.isEmpty, let context = mutationContext() else {
+            SpeciesEditProfiler.signposter.endInterval("Species Edit", totalInterval, "applied: false")
             return completedMutationTask()
         }
+
+        // --- Immediate optimistic apply (synchronous, before returning) ---
+        let stateStartedAt = SpeciesEditProfiler.now()
+        var working: [Photo] = []
+        working.reserveCapacity(targets.count)
+        for id in targets {
+            guard let idx = allPhotoIndex[id] else { continue }
+            working.append(allPhotos[idx])
+        }
+        let previousPhotos = working
+        let previousSpecies = working.map { $0.assignedSpecies }
+        mutate(&working)
+
+        var undoEntries: [UndoAction.Entry] = []
+        var snapshots: [SpeciesSnapshot] = []
+        let generation = nextSpeciesEditGeneration()
+        for (offset, photo) in working.enumerated() {
+            let before = previousSpecies[offset]
+            let after = photo.assignedSpecies
+            guard before != after else { continue }
+            if let idx = allPhotoIndex[photo.id] { allPhotos[idx] = photo }
+            if let fIdx = filteredPhotoIndex[photo.id] { photos[fIdx] = photo }
+            undoEntries.append(UndoAction.Entry(
+                photoID: photo.id,
+                previousRating: photo.starRating,
+                previousIsPick: photo.isPick,
+                previousIsManualRating: photo.isManualRating,
+                previousAssignedSpecies: before,
+                wasHidden: false
+            ))
+            snapshots.append(SpeciesSnapshot(id: photo.id, species: after))
+            pendingOptimisticSpecies[photo.id] = (generation, after)
+        }
+
+        let stateApplyMilliseconds = SpeciesEditProfiler.elapsedMilliseconds(since: stateStartedAt)
+
+        guard !undoEntries.isEmpty else {
+            // Logical no-op: no undo entry, no DB update, no XMP write.
+            lastSpeciesEditProfile = SpeciesEditProfile(
+                operation: operation,
+                requestedPhotoCount: ids.count,
+                targetPhotoCount: targets.count,
+                changedPhotoCount: 0,
+                expansionMilliseconds: expansionMilliseconds,
+                stateApplyMilliseconds: stateApplyMilliseconds,
+                hierarchyMilliseconds: 0,
+                immediateMilliseconds: SpeciesEditProfiler.elapsedMilliseconds(since: totalStartedAt)
+            )
+            SpeciesEditProfiler.signposter.endInterval("Species Edit", totalInterval, "applied: false")
+            return completedMutationTask()
+        }
+
+        undoStack.append(UndoAction(kind: .species, entries: undoEntries))
+        if undoStack.count > Self.maxUndoDepth { undoStack.removeFirst() }
+
+        let hierarchyStartedAt = SpeciesEditProfiler.now()
+        speciesEntries = SpeciesHierarchyBuilder.applySpeciesChanges(
+            entries: speciesEntries,
+            changes: zip(previousPhotos, working).map {
+                SpeciesHierarchyChange(previous: $0.0, updated: $0.1)
+            },
+            sortOrder: speciesSortOrder,
+            displayName: speciesDisplayName,
+            locale: speciesSortLocale
+        )
+        let hierarchyMilliseconds = SpeciesEditProfiler.elapsedMilliseconds(since: hierarchyStartedAt)
+
+        let profile = SpeciesEditProfile(
+            operation: operation,
+            requestedPhotoCount: ids.count,
+            targetPhotoCount: targets.count,
+            changedPhotoCount: snapshots.count,
+            expansionMilliseconds: expansionMilliseconds,
+            stateApplyMilliseconds: stateApplyMilliseconds,
+            hierarchyMilliseconds: hierarchyMilliseconds,
+            immediateMilliseconds: SpeciesEditProfiler.elapsedMilliseconds(since: totalStartedAt)
+        )
+        lastSpeciesEditProfile = profile
+
+        pendingSpeciesEditRender = PendingSpeciesEditRender(
+            operation: operation,
+            targetPhotoCount: targets.count,
+            startedAt: totalStartedAt,
+            signpostID: traceID
+        )
+        speciesEditRenderToken &+= 1
+        SpeciesEditProfiler.signposter.endInterval(
+            "Species Edit",
+            totalInterval,
+            "operation: \(operation, privacy: .public), immediate_ms: \(profile.immediateMilliseconds)"
+        )
+
+        // --- Deferred persistence, serialized on the mutation chain ---
         return enqueueMutation { state in
-            await state.applyBatch(
+            await state.persistSpeciesSnapshots(
                 context: context,
-                ids: targets,
-                mutate,
-                afterAll: { [weak state] _ in
-                    state?.buildSpeciesHierarchy()
-                }
+                snapshots: snapshots,
+                generation: generation,
+                operation: operation,
+                profile: profile
             )
         }
+    }
+
+    private func nextSpeciesEditGeneration() -> Int {
+        speciesEditGeneration &+= 1
+        return speciesEditGeneration
+    }
+
+    /// Overlay captured desired species onto fresh DB rows (off the main actor),
+    /// then hand the written rows to the write-behind XMP queue. Never publishes
+    /// DB results back into observable state — the UI already holds them.
+    @MainActor
+    private func persistSpeciesSnapshots(
+        context: MutationContext,
+        snapshots: [SpeciesSnapshot],
+        generation: Int,
+        operation: String,
+        profile: SpeciesEditProfile?
+    ) async {
+        guard !snapshots.isEmpty else { return }
+        do {
+            let result = try await mutationWorker.persistSpecies(
+                database: context.database,
+                snapshots: snapshots
+            )
+            await xmpQueue.enqueue(result.written)
+            clearOptimisticState(for: snapshots, upTo: generation)
+            if var profile {
+                profile.persistedPhotoCount = result.written.count
+                profile.databaseMilliseconds = result.databaseMilliseconds
+                profile.queuedXMPWriteCount = result.written.count
+                lastSpeciesEditProfile = profile
+                SpeciesEditProfiler.logger.info("\(profile.summary, privacy: .public)")
+            }
+            refreshSpeciesFailureMessage()
+        } catch {
+            recordSpeciesFailures(context: context, snapshots: snapshots, generation: generation)
+            if var profile {
+                profile.persistenceFailed = true
+                lastSpeciesEditProfile = profile
+            }
+            logger.error("species persistence failed (\(operation)): \(error)")
+        }
+    }
+
+    /// Drop optimistic overrides that this persisted generation satisfies. A
+    /// newer edit (higher generation) is left in place so its own persistence
+    /// completes it.
+    private func clearOptimisticState(for snapshots: [SpeciesSnapshot], upTo generation: Int) {
+        for snapshot in snapshots {
+            if let entry = pendingOptimisticSpecies[snapshot.id], entry.generation <= generation {
+                pendingOptimisticSpecies.removeValue(forKey: snapshot.id)
+            }
+            if let failed = failedSpeciesEdits[snapshot.id], failed.generation <= generation {
+                failedSpeciesEdits.removeValue(forKey: snapshot.id)
+            }
+        }
+    }
+
+    private func recordSpeciesFailures(
+        context: MutationContext,
+        snapshots: [SpeciesSnapshot],
+        generation: Int
+    ) {
+        for snapshot in snapshots {
+            // Only supersede an older failure — a newer edit's failure wins.
+            if let existing = failedSpeciesEdits[snapshot.id], existing.generation > generation {
+                continue
+            }
+            failedSpeciesEdits[snapshot.id] = FailedSpeciesEdit(
+                generation: generation,
+                folder: context.folder,
+                database: context.database,
+                snapshot: snapshot
+            )
+        }
+        speciesPersistenceFailureMessage = Self.persistenceFailureMessage
+    }
+
+    @MainActor
+    private func handleXMPFlush(_ summary: XMPFlushSummary) {
+        if summary.writeCount + summary.failureCount > 0 {
+            SpeciesEditProfiler.logger.info(
+                "species_xmp_flush writes=\(summary.writeCount) failures=\(summary.failureCount) max_ms=\(String(format: "%.1f", summary.slowestMilliseconds)) total_ms=\(String(format: "%.1f", summary.totalMilliseconds))"
+            )
+        }
+        // Reconcile durable XMP failure state: paths that recovered clear, paths
+        // that failed (still pending) are retained.
+        for path in summary.succeededSidecarPaths { failedXMPSidecars.remove(path) }
+        for path in summary.failedSidecarPaths { failedXMPSidecars.insert(path) }
+        refreshSpeciesFailureMessage()
+    }
+
+    /// Recompute the observable failure surface from tracked failure state. The
+    /// banner stays visible while either SQLite failures or retained XMP
+    /// write-behind failures exist. Merely-pending (not-yet-failed) XMP writes
+    /// are not failures and are ignored here.
+    private func refreshSpeciesFailureMessage() {
+        if failedSpeciesEdits.isEmpty && failedXMPSidecars.isEmpty {
+            speciesPersistenceFailureMessage = nil
+        } else {
+            speciesPersistenceFailureMessage = Self.persistenceFailureMessage
+        }
+    }
+
+    private static let persistenceFailureMessage = "species_persistence_failed"
+
+    /// Drain SQLite work then flush the write-behind XMP queue deterministically.
+    /// Used by tests, resign-active, and termination — never waits on the
+    /// debounce timer.
+    @MainActor
+    func flushPendingPersistence() async {
+        await pendingMutationTask?.value
+        let summary = await xmpQueue.flush()
+        handleXMPFlush(summary)
+    }
+
+    /// Retry the latest failed species snapshots (SQLite) and re-flush any
+    /// pending/failed write-behind XMP. Retains each failure's original
+    /// folder/database so it works even after a folder switch.
+    @MainActor
+    @discardableResult
+    func retrySpeciesPersistence() -> Task<Void, Never> {
+        guard hasSpeciesPersistenceFailure else { return completedMutationTask() }
+        let failures = Array(failedSpeciesEdits.values)
+        return enqueueMutation { state in
+            // Group SQLite retries by their captured database.
+            var order: [ObjectIdentifier] = []
+            var grouped: [ObjectIdentifier: (database: ReportDatabase, snapshots: [SpeciesSnapshot], ids: [UUID], maxGeneration: Int)] = [:]
+            for failure in failures {
+                let key = ObjectIdentifier(failure.database)
+                if var group = grouped[key] {
+                    group.snapshots.append(failure.snapshot)
+                    group.ids.append(failure.snapshot.id)
+                    group.maxGeneration = max(group.maxGeneration, failure.generation)
+                    grouped[key] = group
+                } else {
+                    order.append(key)
+                    grouped[key] = (failure.database, [failure.snapshot], [failure.snapshot.id], failure.generation)
+                }
+            }
+            for key in order {
+                guard let group = grouped[key] else { continue }
+                do {
+                    let result = try await state.mutationWorker.persistSpecies(
+                        database: group.database,
+                        snapshots: group.snapshots
+                    )
+                    await state.xmpQueue.enqueue(result.written)
+                    for id in group.ids {
+                        if let failed = state.failedSpeciesEdits[id],
+                           failed.generation <= group.maxGeneration {
+                            state.failedSpeciesEdits.removeValue(forKey: id)
+                            if let optimistic = state.pendingOptimisticSpecies[id],
+                               optimistic.generation <= group.maxGeneration {
+                                state.pendingOptimisticSpecies.removeValue(forKey: id)
+                            }
+                        }
+                    }
+                } catch {
+                    state.logger.error("species retry (SQLite) failed: \(error)")
+                }
+            }
+            // Re-flush pending XMP (path-keyed, so folder-independent). This
+            // also retries XMP-only failures where SQLite already succeeded.
+            let summary = await state.xmpQueue.flush()
+            state.handleXMPFlush(summary)
+            state.refreshSpeciesFailureMessage()
+        }
+    }
+
+    @MainActor
+    func noteSpeciesEditRowsRendered(token: Int) {
+        guard token == speciesEditRenderToken,
+              let pending = pendingSpeciesEditRender else {
+            return
+        }
+        pendingSpeciesEditRender = nil
+        let visibleMilliseconds = SpeciesEditProfiler.elapsedMilliseconds(
+            since: pending.startedAt
+        )
+        SpeciesEditProfiler.signposter.emitEvent(
+            "Species Rows Rendered",
+            id: pending.signpostID,
+            "operation: \(pending.operation, privacy: .public), targets: \(pending.targetPhotoCount), visible_ms: \(visibleMilliseconds)"
+        )
+        SpeciesEditProfiler.logger.info(
+            "species_edit_visible operation=\(pending.operation, privacy: .public) targets=\(pending.targetPhotoCount) visible_ms=\(visibleMilliseconds)"
+        )
     }
 
     /// Expand `ids` to include every burst member of every selected photo.
@@ -757,8 +1335,83 @@ final class AppState {
     @MainActor
     @discardableResult
     func undoLastAction() -> Task<Void, Never> {
-        guard let context = mutationContext() else {
+        guard let context = mutationContext(), let action = undoStack.last else {
             return completedMutationTask()
+        }
+        // Species undo is optimistic: apply the captured previous species to
+        // observable state synchronously (mirroring the forward edit), then
+        // enqueue only the species persistence. Field undo (pick/rate/reject)
+        // keeps its existing persist-first restore.
+        if action.kind == .species {
+            undoStack.removeLast()
+            let generation = nextSpeciesEditGeneration()
+            let entriesByID = Dictionary(
+                uniqueKeysWithValues: action.entries.map { ($0.photoID, $0) }
+            )
+            var affectedBurstGroups: Set<UUID> = []
+            for id in entriesByID.keys {
+                if let index = allPhotoIndex[id],
+                   let groupID = allPhotos[index].burstGroupID {
+                    affectedBurstGroups.insert(groupID)
+                }
+            }
+            var hierarchyTargetIDs = Set(entriesByID.keys)
+            if !affectedBurstGroups.isEmpty {
+                for photo in allPhotos {
+                    if let groupID = photo.burstGroupID,
+                       affectedBurstGroups.contains(groupID) {
+                        hierarchyTargetIDs.insert(photo.id)
+                    }
+                }
+            }
+
+            var snapshots: [SpeciesSnapshot] = []
+            var hierarchyChanges: [SpeciesHierarchyChange] = []
+            snapshots.reserveCapacity(action.entries.count)
+            hierarchyChanges.reserveCapacity(hierarchyTargetIDs.count)
+            for index in allPhotos.indices where hierarchyTargetIDs.contains(allPhotos[index].id) {
+                let previous = allPhotos[index]
+                var updated = previous
+                if let entry = entriesByID[previous.id] {
+                    updated.assignedSpecies = entry.previousAssignedSpecies
+                    allPhotos[index] = updated
+                    if let filteredIndex = filteredPhotoIndex[previous.id] {
+                        photos[filteredIndex] = updated
+                    }
+                    snapshots.append(SpeciesSnapshot(
+                        id: previous.id,
+                        species: entry.previousAssignedSpecies
+                    ))
+                    pendingOptimisticSpecies[previous.id] = (
+                        generation,
+                        entry.previousAssignedSpecies
+                    )
+                }
+                hierarchyChanges.append(SpeciesHierarchyChange(
+                    previous: previous,
+                    updated: updated
+                ))
+            }
+            speciesEntries = SpeciesHierarchyBuilder.applySpeciesChanges(
+                entries: speciesEntries,
+                changes: hierarchyChanges,
+                sortOrder: speciesSortOrder,
+                displayName: speciesDisplayName,
+                locale: speciesSortLocale
+            )
+            let lastID = action.entries.last?.photoID
+            if let id = lastID, photos.contains(where: { $0.id == id }) {
+                selection.click(id, photos: photos)
+            }
+            return enqueueMutation { state in
+                await state.persistSpeciesSnapshots(
+                    context: context,
+                    snapshots: snapshots,
+                    generation: generation,
+                    operation: "undo",
+                    profile: nil
+                )
+            }
         }
         return enqueueMutation { state in
             await state.performUndo(context: context)

--- a/app/SuperPickyApp/AppState.swift
+++ b/app/SuperPickyApp/AppState.swift
@@ -392,6 +392,7 @@ final class AppState {
     @ObservationIgnored private var lastSpeciesEditProfile: SpeciesEditProfile?
     @ObservationIgnored private var pendingSpeciesEditRender: PendingSpeciesEditRender?
     private(set) var speciesEditRenderToken = 0
+    private(set) var speciesXMPFlushToken = 0
 
     // MARK: Optimistic species-edit persistence
 
@@ -1200,6 +1201,9 @@ final class AppState {
             SpeciesEditProfiler.logger.info(
                 "species_xmp_flush writes=\(summary.writeCount) failures=\(summary.failureCount) max_ms=\(String(format: "%.1f", summary.slowestMilliseconds)) total_ms=\(String(format: "%.1f", summary.totalMilliseconds))"
             )
+        }
+        if summary.writeCount > 0 {
+            speciesXMPFlushToken &+= 1
         }
         // Reconcile durable XMP failure state: paths that recovered clear, paths
         // that failed (still pending) are retained.

--- a/app/SuperPickyApp/ExifPanelView.swift
+++ b/app/SuperPickyApp/ExifPanelView.swift
@@ -65,11 +65,16 @@ struct ExifPanelView: View {
         .shadow(color: .black.opacity(0.2), radius: 8, x: -2, y: 2)
         .padding(8)
         .accessibilityIdentifier("ExifPanel")
-        // Re-fire on assignedSpeciesJSON changes too: keywords come from the
-        // XMP sidecar, which the species edit panel rewrites on every edit.
+        // Re-fire on assignment changes and again after write-behind XMP
+        // completes. The optimistic assignment can render before its debounced
+        // sidecar, so the flush token performs the authoritative keyword read.
         // Swap atomically — clearing exifData between photos flashes the
         // species sections up and back down on every switch.
-        .task(id: [photo.id.uuidString, photo.assignedSpeciesJSON ?? ""]) {
+        .task(id: [
+            photo.id.uuidString,
+            photo.assignedSpeciesJSON ?? "",
+            String(appState.speciesXMPFlushToken),
+        ]) {
             let newData = await Task.detached {
                 EXIFReader.read(from: photo.filePath)
             }.value

--- a/app/SuperPickyApp/ExifPanelView.swift
+++ b/app/SuperPickyApp/ExifPanelView.swift
@@ -80,6 +80,9 @@ struct ExifPanelView: View {
             searchQuery = ""
             searchResults = []
         }
+        .onChange(of: appState.speciesEditRenderToken) { _, token in
+            appState.noteSpeciesEditRowsRendered(token: token)
+        }
     }
 
     // MARK: - EXIF sections
@@ -198,9 +201,36 @@ struct ExifPanelView: View {
 
     @ViewBuilder
     private var speciesSections: some View {
+        retryBanner
         assignedSection
         candidatesSection
         searchSection
+    }
+
+    @ViewBuilder
+    private var retryBanner: some View {
+        if appState.hasSpeciesPersistenceFailure {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.orange)
+                Text(config.localized("Some species edits couldn't be saved"))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 4)
+                Button(config.localized("Retry")) {
+                    appState.retrySpeciesPersistence()
+                }
+                .font(.system(size: 11))
+                .buttonStyle(.borderless)
+                .accessibilityIdentifier("SpeciesEditPanel_RetrySave")
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Color.orange.opacity(0.12))
+            .accessibilityIdentifier("SpeciesEditPanel_RetryBanner")
+        }
     }
 
     @ViewBuilder

--- a/app/SuperPickyApp/Logger.swift
+++ b/app/SuperPickyApp/Logger.swift
@@ -1,4 +1,76 @@
+import Foundation
 import os
+
+/// Latency profile for a single species edit. The fields are split into two
+/// phases so profiling never conflates the *immediate* optimistic UI work with
+/// the *deferred* persistence that runs behind it:
+///
+/// - Immediate: `expansion`, `stateApply`, `hierarchy`, `immediate` — all of
+///   this happens synchronously before the edit method returns and is what the
+///   user perceives as latency.
+/// - Deferred: `database` (serialized SQLite overlay) and `queuedXMPWrite`
+///   (rows handed to the debounced write-behind queue). XMP *file* latency is
+///   never recorded here — it is logged separately by the queue on flush so we
+///   don't attribute deferred sidecar I/O to the synchronous edit.
+struct SpeciesEditProfile: Sendable {
+    let operation: String
+    let requestedPhotoCount: Int
+    let targetPhotoCount: Int
+    /// Rows whose assigned species actually changed (drives undo/persistence).
+    let changedPhotoCount: Int
+
+    // Immediate (synchronous, before the edit method returns).
+    let expansionMilliseconds: Double
+    let stateApplyMilliseconds: Double
+    let hierarchyMilliseconds: Double
+    let immediateMilliseconds: Double
+
+    // Deferred persistence (populated when the serialized SQLite task finishes).
+    var persistedPhotoCount: Int = 0
+    var databaseMilliseconds: Double = 0
+    var queuedXMPWriteCount: Int = 0
+    var persistenceFailed: Bool = false
+
+    var summary: String {
+        [
+            "species_edit",
+            "operation=\(operation)",
+            "requested=\(requestedPhotoCount)",
+            "targets=\(targetPhotoCount)",
+            "changed=\(changedPhotoCount)",
+            "expand_ms=\(Self.format(expansionMilliseconds))",
+            "state_ms=\(Self.format(stateApplyMilliseconds))",
+            "hierarchy_ms=\(Self.format(hierarchyMilliseconds))",
+            "immediate_ms=\(Self.format(immediateMilliseconds))",
+            "persisted=\(persistedPhotoCount)",
+            "db_ms=\(Self.format(databaseMilliseconds))",
+            "xmp_queued=\(queuedXMPWriteCount)",
+            "persist_failed=\(persistenceFailed)",
+        ].joined(separator: " ")
+    }
+
+    private static func format(_ milliseconds: Double) -> String {
+        String(format: "%.1f", milliseconds)
+    }
+}
+
+enum SpeciesEditProfiler {
+    static let logger = Logger(
+        subsystem: "com.halfhacked.superpicky",
+        category: "SpeciesEdit"
+    )
+    static let signposter = OSSignposter(
+        subsystem: "com.halfhacked.superpicky",
+        category: "SpeciesEdit"
+    )
+    static func now() -> TimeInterval {
+        ProcessInfo.processInfo.systemUptime
+    }
+
+    static func elapsedMilliseconds(since start: TimeInterval) -> Double {
+        (now() - start) * 1_000
+    }
+}
 
 extension Logger {
     static let pipeline = Logger(subsystem: "com.halfhacked.superpicky", category: "Pipeline")

--- a/app/SuperPickyApp/MainView.swift
+++ b/app/SuperPickyApp/MainView.swift
@@ -174,6 +174,9 @@ struct MainView: View {
             appState.speciesSortOrder = config.speciesSortOrder
             syncSpeciesDisplay()
             loadSpeciesDatabase()
+            FlushCoordinator.shared.register(owner: appState) { [weak appState] in
+                await appState?.flushPendingPersistence()
+            }
             if let testFolder = ProcessInfo.processInfo.environment["TEST_FOLDER"] {
                 let folder = URL(fileURLWithPath: testFolder)
                 Task {

--- a/app/SuperPickyApp/ReportDatabase.swift
+++ b/app/SuperPickyApp/ReportDatabase.swift
@@ -6,6 +6,14 @@ struct PhotoMutationResult: Sendable {
     let updated: Photo
 }
 
+/// A captured "desired" species assignment for one photo. Persistence overlays
+/// this list onto a freshly-fetched database row so concurrent pipeline writes
+/// to non-species fields are preserved.
+struct SpeciesSnapshot: Sendable {
+    let id: UUID
+    let species: [SpeciesMatch]
+}
+
 final class ReportDatabase: Sendable {
     private let dbQueue: DatabaseQueue
 
@@ -198,6 +206,29 @@ final class ReportDatabase: Sendable {
             return zip(previous, updated).map {
                 PhotoMutationResult(previous: $0.0, updated: $0.1)
             }
+        }
+    }
+
+    /// Overlay captured species assignments onto freshly-fetched rows.
+    ///
+    /// Each snapshot is applied to the *current* database row for that photo so
+    /// concurrent pipeline writes to non-species fields survive. Rows whose
+    /// assigned species already equal the desired list are skipped (no write).
+    /// Returns the rows that were actually updated so the caller can queue XMP
+    /// writes for them — the caller must NOT publish these back into the UI,
+    /// which already holds the optimistic state.
+    func overlaySpecies(_ snapshots: [SpeciesSnapshot]) throws -> [Photo] {
+        try dbQueue.write { db in
+            var written: [Photo] = []
+            written.reserveCapacity(snapshots.count)
+            for snapshot in snapshots {
+                guard var photo = try Photo.fetchOne(db, key: snapshot.id) else { continue }
+                if photo.assignedSpecies == snapshot.species { continue }
+                photo.assignedSpecies = snapshot.species
+                try photo.save(db)
+                written.append(photo)
+            }
+            return written
         }
     }
 

--- a/app/SuperPickyApp/SpeciesHierarchyBuilder.swift
+++ b/app/SuperPickyApp/SpeciesHierarchyBuilder.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct SpeciesHierarchyChange {
+    let previous: Photo
+    let updated: Photo
+}
+
 /// Pure computation: groups photos into species hierarchy entries.
 ///
 /// A photo may carry multiple species in its `assignedSpecies` list; the
@@ -18,6 +23,17 @@ struct SpeciesHierarchyBuilder {
     /// value. Rendered as `isUnidentified: true` with `speciesID == nil` in
     /// the emitted `SpeciesEntry`.
     private static let unidentifiedKey = "__unidentified__"
+
+    private struct BucketDelta {
+        var count = 0
+        var picks = 0
+        var singlePhotos = 0
+        var singlePicks = 0
+        var metadata: SpeciesMatch?
+        var replacesMetadata = false
+        var upsertedBursts: [UUID: BurstGroupEntry] = [:]
+        var removedBursts: Set<UUID> = []
+    }
 
     static func build(
         from photos: [Photo],
@@ -115,6 +131,173 @@ struct SpeciesHierarchyBuilder {
             )
         }
         return sorted(entries: entries, by: sortOrder, displayName: displayName, locale: locale)
+    }
+
+    /// Apply a batch of species-only photo changes without rebuilding from the
+    /// full library. For every touched burst, `changes` must include all of its
+    /// members (unchanged members included) so burst membership remains exact.
+    static func applySpeciesChanges(
+        entries: [SpeciesEntry],
+        changes: [SpeciesHierarchyChange],
+        sortOrder: SpeciesSortOrder = .name,
+        displayName: (SpeciesEntry) -> String = { $0.name },
+        locale: Locale = .current
+    ) -> [SpeciesEntry] {
+        guard !changes.isEmpty else { return entries }
+
+        var deltas: [String: BucketDelta] = [:]
+        var changesByBurst: [UUID: [SpeciesHierarchyChange]] = [:]
+
+        for change in changes {
+            let beforeMatches = matchesByKey(for: change.previous)
+            let afterMatches = matchesByKey(for: change.updated)
+            let beforeKeys = bucketKeys(for: beforeMatches)
+            let afterKeys = bucketKeys(for: afterMatches)
+
+            for key in beforeKeys.union(afterKeys) {
+                let wasMember = beforeKeys.contains(key)
+                let isMember = afterKeys.contains(key)
+                var delta = deltas[key, default: BucketDelta()]
+                delta.count += (isMember ? 1 : 0) - (wasMember ? 1 : 0)
+                delta.picks += (isMember && change.updated.isPick ? 1 : 0)
+                    - (wasMember && change.previous.isPick ? 1 : 0)
+
+                if change.previous.burstGroupID == nil && change.updated.burstGroupID == nil {
+                    delta.singlePhotos += (isMember ? 1 : 0) - (wasMember ? 1 : 0)
+                    delta.singlePicks += (isMember && change.updated.isPick ? 1 : 0)
+                        - (wasMember && change.previous.isPick ? 1 : 0)
+                }
+
+                if let after = afterMatches[key] {
+                    if let before = beforeMatches[key],
+                       hierarchyMetadataDiffers(before, after) {
+                        delta.metadata = after
+                        delta.replacesMetadata = true
+                    } else if delta.metadata == nil {
+                        delta.metadata = after
+                    }
+                }
+                deltas[key] = delta
+            }
+
+            if let groupID = change.updated.burstGroupID ?? change.previous.burstGroupID {
+                changesByBurst[groupID, default: []].append(change)
+            }
+        }
+
+        for (groupID, groupChanges) in changesByBurst {
+            let beforeKeys = groupChanges.reduce(into: Set<String>()) { result, change in
+                result.formUnion(bucketKeys(for: matchesByKey(for: change.previous)))
+            }
+            let afterKeys = groupChanges.reduce(into: Set<String>()) { result, change in
+                result.formUnion(bucketKeys(for: matchesByKey(for: change.updated)))
+            }
+            let updatedPhotos = groupChanges.map(\.updated)
+            let best = updatedPhotos.first { $0.isBurstBest }
+            let burst = BurstGroupEntry(
+                id: groupID,
+                count: updatedPhotos.count,
+                pickCount: updatedPhotos.lazy.filter(\.isPick).count,
+                bestFilename: best?.filename ?? updatedPhotos.first?.filename
+            )
+
+            for key in beforeKeys.union(afterKeys) {
+                var delta = deltas[key, default: BucketDelta()]
+                if afterKeys.contains(key) {
+                    delta.upsertedBursts[groupID] = burst
+                    delta.removedBursts.remove(groupID)
+                } else {
+                    delta.upsertedBursts.removeValue(forKey: groupID)
+                    delta.removedBursts.insert(groupID)
+                }
+                deltas[key] = delta
+            }
+        }
+
+        var entriesByKey = Dictionary(
+            uniqueKeysWithValues: entries.map { (($0.speciesID ?? unidentifiedKey), $0) }
+        )
+        for (key, delta) in deltas {
+            let existing = entriesByKey[key]
+            let count = max(0, (existing?.count ?? 0) + delta.count)
+            guard count > 0 else {
+                entriesByKey.removeValue(forKey: key)
+                continue
+            }
+
+            var burstsByID = Dictionary(
+                uniqueKeysWithValues: (existing?.burstGroups ?? []).map { ($0.id, $0) }
+            )
+            for groupID in delta.removedBursts {
+                burstsByID.removeValue(forKey: groupID)
+            }
+            for (groupID, burst) in delta.upsertedBursts {
+                burstsByID[groupID] = burst
+            }
+
+            let isUnidentified = key == unidentifiedKey
+            let scientificName = delta.replacesMetadata
+                ? delta.metadata?.scientificName
+                : existing?.scientificName ?? delta.metadata?.scientificName
+            let name: String
+            if isUnidentified {
+                name = String(localized: "Unidentified")
+            } else if delta.replacesMetadata {
+                name = delta.metadata?.commonName
+                    ?? delta.metadata?.scientificName
+                    ?? existing?.name
+                    ?? key
+            } else {
+                name = existing?.name
+                    ?? delta.metadata?.commonName
+                    ?? delta.metadata?.scientificName
+                    ?? key
+            }
+            let cnName = delta.replacesMetadata
+                ? delta.metadata?.cnName
+                : existing?.cnName ?? delta.metadata?.cnName
+
+            entriesByKey[key] = SpeciesEntry(
+                speciesID: isUnidentified ? nil : key,
+                scientificName: scientificName,
+                name: name,
+                cnName: cnName,
+                count: count,
+                picks: max(0, (existing?.picks ?? 0) + delta.picks),
+                burstGroups: burstsByID.values.sorted { $0.count > $1.count },
+                singlePhotos: max(0, (existing?.singlePhotos ?? 0) + delta.singlePhotos),
+                singlePicks: max(0, (existing?.singlePicks ?? 0) + delta.singlePicks),
+                isUnidentified: isUnidentified
+            )
+        }
+
+        return sorted(
+            entries: Array(entriesByKey.values),
+            by: sortOrder,
+            displayName: displayName,
+            locale: locale
+        )
+    }
+
+    private static func matchesByKey(for photo: Photo) -> [String: SpeciesMatch] {
+        var result: [String: SpeciesMatch] = [:]
+        for match in photo.assignedSpecies where result[match.speciesID] == nil {
+            result[match.speciesID] = match
+        }
+        return result
+    }
+
+    private static func bucketKeys(for matches: [String: SpeciesMatch]) -> Set<String> {
+        matches.isEmpty ? [unidentifiedKey] : Set(matches.keys)
+    }
+
+    private static func hierarchyMetadataDiffers(
+        _ before: SpeciesMatch,
+        _ after: SpeciesMatch
+    ) -> Bool {
+        before.scientificName != after.scientificName
+            || before.commonName != after.commonName
+            || before.cnName != after.cnName
     }
 
     /// Apply a single-photo delta — `remove` an old primary-bucket

--- a/app/SuperPickyApp/en.lproj/Localizable.strings
+++ b/app/SuperPickyApp/en.lproj/Localizable.strings
@@ -203,3 +203,4 @@
 "Editing %lld photos" = "Editing %lld photos";
 "%lld selected" = "%lld selected";
 "(%lld selected)" = "(%lld selected)";
+"Some species edits couldn't be saved" = "Some species edits couldn't be saved";

--- a/app/SuperPickyApp/zh-Hans.lproj/Localizable.strings
+++ b/app/SuperPickyApp/zh-Hans.lproj/Localizable.strings
@@ -203,3 +203,4 @@
 "Editing %lld photos" = "正在编辑 %lld 张照片";
 "%lld selected" = "已选 %lld 张";
 "(%lld selected)" = "(已选 %lld 张)";
+"Some species edits couldn't be saved" = "部分鸟种修改未能保存";

--- a/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
+++ b/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
@@ -253,6 +253,29 @@ struct AppStateBatchMutationTests {
         }
     }
 
+    @Test func addAndRemoveSpeciesRecordLatencyProfiles() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(2, into: folder)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+        let eagle = match("eagle")
+
+        await app.addSpecies(ids: Set(ids), species: eagle).value
+        let addProfile = try #require(app.lastSpeciesEditProfileForTesting())
+        #expect(addProfile.operation == "add")
+        #expect(addProfile.targetPhotoCount == 2)
+        #expect(addProfile.changedPhotoCount == 2)
+        #expect(addProfile.persistedPhotoCount == 2)
+
+        await app.removeSpecies(ids: Set(ids), species: eagle).value
+        let removeProfile = try #require(app.lastSpeciesEditProfileForTesting())
+        #expect(removeProfile.operation == "remove")
+        #expect(removeProfile.targetPhotoCount == 2)
+        #expect(removeProfile.changedPhotoCount == 2)
+        #expect(removeProfile.persistedPhotoCount == 2)
+    }
+
     // MARK: - Burst fan-out
 
     @Test func setPrimarySpeciesFansOutToBurstMembers() async throws {
@@ -303,7 +326,7 @@ struct AppStateBatchMutationTests {
         let app = AppState()
         app.loadPhotos(for: folder)
         let start = ProcessInfo.processInfo.systemUptime
-        let mutation = app.setPrimarySpecies(
+        let mutation = app.addSpecies(
             ids: [try #require(firstID)],
             species: match("eagle")
         )
@@ -311,6 +334,17 @@ struct AppStateBatchMutationTests {
         #expect(elapsedMS < 100, "Species edit blocked the caller for \(elapsedMS) ms")
 
         await mutation.value
+        let profile = try #require(app.lastSpeciesEditProfileForTesting())
+        #expect(profile.operation == "add")
+        #expect(profile.requestedPhotoCount == 1)
+        #expect(profile.targetPhotoCount == 200)
+        #expect(profile.changedPhotoCount == 200)
+        #expect(profile.persistedPhotoCount == 200)
+        #expect(profile.queuedXMPWriteCount == 200)
+        #expect(!profile.persistenceFailed)
+        // Immediate work is measured separately from deferred DB latency.
+        #expect(profile.immediateMilliseconds >= profile.stateApplyMilliseconds)
+
         let photos = app.allPhotosForTesting()
         for i in 0..<200 {
             let photo = try #require(try db.fetchPhoto(
@@ -318,6 +352,8 @@ struct AppStateBatchMutationTests {
             ))
             #expect(photo.assignedSpecies.first?.speciesID == "eagle")
         }
+        // XMP is write-behind — assert sidecars only after an explicit flush.
+        await app.flushPendingPersistence()
         let sidecar = XMPWriter.sidecarURL(for: photos[0])
         let xmp = try String(contentsOf: sidecar, encoding: .utf8)
         #expect(xmp.contains("Eagle"))
@@ -464,5 +500,237 @@ struct AppStateBatchMutationTests {
             let p = try db.fetchPhoto(id: id)!
             #expect(p.assignedSpecies.map(\.speciesID) == ["eagle"])
         }
+    }
+
+    // MARK: - Optimistic (immediate) state visibility
+
+    @Test func speciesEditUpdatesObservableStateBeforeTaskAwait() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(1, into: folder)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+
+        // Do NOT await — the observable arrays must already reflect the edit.
+        let task = app.addSpecies(ids: Set(ids), species: match("eagle"))
+        #expect(app.allPhotosForTesting().first?.assignedSpecies.first?.speciesID == "eagle")
+        #expect(app.photos.first?.assignedSpecies.first?.speciesID == "eagle")
+        #expect(app.speciesEntries.contains { $0.speciesID == "eagle" })
+
+        await task.value
+        let db = try ReportDatabase(folderPath: folder)
+        #expect(try db.fetchPhoto(id: ids[0])?.assignedSpecies.first?.speciesID == "eagle")
+    }
+
+    @Test func speciesEditImmediateLatencyAtLargeLibraryScale() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let db = try ReportDatabase(folderPath: folder)
+        var seeded = (0..<2_000).map { index in
+            Photo(
+                filename: "large_\(index).CR3",
+                filePath: folder.appendingPathComponent("large_\(index).CR3").path,
+                folderPath: folder.path
+            )
+        }
+        try db.saveAll(&seeded)
+
+        let app = AppState()
+        app.loadPhotos(for: folder)
+        let mutation = app.addSpecies(ids: [seeded[0].id], species: match("eagle"))
+        let profile = try #require(app.lastSpeciesEditProfileForTesting())
+
+        #expect(
+            profile.immediateMilliseconds < 100,
+            "Large-library species edit took \(profile.immediateMilliseconds) ms before returning"
+        )
+
+        await mutation.value
+        await app.flushPendingPersistence()
+    }
+
+    @Test func rapidSpeciesEditsKeepOrderedStateWithoutStaleCompletion() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(1, into: folder)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+
+        let addEagle = app.addSpecies(ids: Set(ids), species: match("eagle"))
+        let promoteHawk = app.setPrimarySpecies(ids: Set(ids), species: match("hawk"))
+        // Synchronously the UI already shows both edits applied in call order.
+        #expect(app.allPhotosForTesting().first?.assignedSpecies.map(\.speciesID) == ["hawk", "eagle"])
+
+        await addEagle.value
+        await promoteHawk.value
+        // Deferred persistence never republishes stale rows over the UI.
+        #expect(app.allPhotosForTesting().first?.assignedSpecies.map(\.speciesID) == ["hawk", "eagle"])
+        let db = try ReportDatabase(folderPath: folder)
+        #expect(try db.fetchPhoto(id: ids[0])?.assignedSpecies.map(\.speciesID) == ["hawk", "eagle"])
+    }
+
+    @Test func immediateUndoRevertsObservableStateBeforeAwait() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(1, into: folder)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+        await app.addSpecies(ids: Set(ids), species: match("eagle")).value
+
+        let undo = app.undoLastAction()
+        // Undo must revert observable state synchronously, before persistence.
+        #expect(app.allPhotosForTesting().first?.assignedSpecies.isEmpty == true)
+        #expect(!app.speciesEntries.contains { $0.speciesID == "eagle" })
+        #expect(app.speciesEntries.first(where: \.isUnidentified)?.count == 1)
+
+        await undo.value
+        let db = try ReportDatabase(folderPath: folder)
+        #expect(try db.fetchPhoto(id: ids[0])?.assignedSpecies.isEmpty == true)
+    }
+
+    // MARK: - Logical no-ops
+
+    @Test func noOpSpeciesEditSkipsUndoDatabaseAndXMP() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(1, into: folder)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+        await app.addSpecies(ids: Set(ids), species: match("eagle")).value
+        await app.flushPendingPersistence()
+
+        let undoBefore = app.undoStackSizeForTesting()
+        // Re-adding the same species is a logical no-op.
+        await app.addSpecies(ids: Set(ids), species: match("eagle")).value
+
+        #expect(app.undoStackSizeForTesting() == undoBefore)
+        let profile = try #require(app.lastSpeciesEditProfileForTesting())
+        #expect(profile.changedPhotoCount == 0)
+        #expect(profile.persistedPhotoCount == 0)
+        let pendingXMP = await app.pendingXMPWriteCountForTesting()
+        #expect(pendingXMP == 0)
+    }
+
+    // MARK: - Write-behind XMP coalescing
+
+    @Test func coalescedXMPWritesLatestSpeciesAfterFlush() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(1, into: folder)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+
+        // Three rapid edits collapse to the final desired state.
+        await app.addSpecies(ids: Set(ids), species: match("eagle")).value
+        await app.removeSpecies(ids: Set(ids), species: match("eagle")).value
+        await app.addSpecies(ids: Set(ids), species: match("hawk")).value
+
+        // One coalesced sidecar per path — flush deterministically (no sleep).
+        await app.flushPendingPersistence()
+        let sidecar = XMPWriter.sidecarURL(for: app.allPhotosForTesting()[0])
+        let xmp = try String(contentsOf: sidecar, encoding: .utf8)
+        #expect(xmp.contains("Hawk"))
+        #expect(!xmp.contains("Eagle"))
+        let pendingXMP = await app.pendingXMPWriteCountForTesting()
+        #expect(pendingXMP == 0)
+    }
+
+    // MARK: - Retryable XMP failure
+
+    @Test func xmpWriteFailureIsRetryableAndKeepsOptimisticState() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(1, into: folder)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+        await app.addSpecies(ids: Set(ids), species: match("eagle")).value
+
+        // Block the sidecar path with a directory so the write-behind XMP fails.
+        let sidecar = XMPWriter.sidecarURL(for: app.allPhotosForTesting()[0])
+        try FileManager.default.createDirectory(at: sidecar, withIntermediateDirectories: true)
+
+        await app.flushPendingPersistence()
+        #expect(app.hasSpeciesPersistenceFailure)
+        // Optimistic state survives the failed write.
+        #expect(app.allPhotosForTesting().first?.assignedSpecies.first?.speciesID == "eagle")
+
+        // Clear the obstruction and retry — the pending XMP write drains.
+        try FileManager.default.removeItem(at: sidecar)
+        await app.retrySpeciesPersistence().value
+
+        #expect(!app.hasSpeciesPersistenceFailure)
+        let xmp = try String(contentsOf: sidecar, encoding: .utf8)
+        #expect(xmp.contains("Eagle"))
+    }
+
+    /// Regression: an XMP-only failure must stay durably represented in
+    /// `AppState` so an unrelated successful edit cannot clear the retry banner
+    /// while a failed sidecar is still pending. See handleXMPFlush /
+    /// refreshSpeciesFailureMessage / failedXMPSidecars.
+    @Test func retainedXMPFailureSurvivesUnrelatedSuccessAndClearsOnRetry() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(2, into: folder)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+
+        // Edit photo 0, then block its sidecar so only the write-behind XMP
+        // fails (SQLite already committed).
+        await app.addSpecies(ids: [ids[0]], species: match("eagle")).value
+        let target = try #require(app.allPhotosForTesting().first { $0.id == ids[0] })
+        let sidecar = XMPWriter.sidecarURL(for: target)
+        try FileManager.default.createDirectory(at: sidecar, withIntermediateDirectories: true)
+
+        await app.flushPendingPersistence()
+        // XMP-only failure: no SQLite failure, exactly one retained sidecar.
+        #expect(app.hasSpeciesPersistenceFailure)
+        #expect(app.failedSpeciesEditCountForTesting() == 0)
+        #expect(app.failedXMPSidecarCountForTesting() == 1)
+
+        // An unrelated SUCCESSFUL species edit refreshes the banner state but
+        // must NOT clear it while the failed sidecar is still pending.
+        await app.addSpecies(ids: [ids[1]], species: match("hawk")).value
+        #expect(app.hasSpeciesPersistenceFailure)
+        #expect(app.failedXMPSidecarCountForTesting() == 1)
+
+        // Fix the filesystem and retry — the retained failed sidecar drains and
+        // the banner clears.
+        try FileManager.default.removeItem(at: sidecar)
+        await app.retrySpeciesPersistence().value
+
+        #expect(!app.hasSpeciesPersistenceFailure)
+        #expect(app.failedXMPSidecarCountForTesting() == 0)
+        let xmp = try String(contentsOf: sidecar, encoding: .utf8)
+        #expect(xmp.contains("Eagle"))
+    }
+
+    /// Deleting a photo with a retained XMP failure must evict it from both the
+    /// write-behind queue and the durable failure state so no impossible retry
+    /// (a sidecar for a now-trashed photo) remains.
+    @Test func deletingPhotoEvictsRetainedXMPFailure() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(1, into: folder)
+        // Delete trashes the underlying file, so it must actually exist.
+        FileManager.default.createFile(
+            atPath: folder.appendingPathComponent("p0.CR3").path, contents: Data()
+        )
+        let app = AppState()
+        app.loadPhotos(for: folder)
+
+        await app.addSpecies(ids: [ids[0]], species: match("eagle")).value
+        let target = try #require(app.allPhotosForTesting().first { $0.id == ids[0] })
+        let sidecar = XMPWriter.sidecarURL(for: target)
+        try FileManager.default.createDirectory(at: sidecar, withIntermediateDirectories: true)
+
+        await app.flushPendingPersistence()
+        #expect(app.hasSpeciesPersistenceFailure)
+        #expect(app.failedXMPSidecarCountForTesting() == 1)
+
+        await app.deletePhoto(id: ids[0]).value
+        #expect(!app.hasSpeciesPersistenceFailure)
+        #expect(app.failedXMPSidecarCountForTesting() == 0)
+        let pendingXMP = await app.pendingXMPWriteCountForTesting()
+        #expect(pendingXMP == 0)
     }
 }

--- a/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
+++ b/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
@@ -619,6 +619,7 @@ struct AppStateBatchMutationTests {
         let ids = try seedPhotos(1, into: folder)
         let app = AppState()
         app.loadPhotos(for: folder)
+        let flushTokenBefore = app.speciesXMPFlushToken
 
         // Three rapid edits collapse to the final desired state.
         await app.addSpecies(ids: Set(ids), species: match("eagle")).value
@@ -633,6 +634,7 @@ struct AppStateBatchMutationTests {
         #expect(!xmp.contains("Eagle"))
         let pendingXMP = await app.pendingXMPWriteCountForTesting()
         #expect(pendingXMP == 0)
+        #expect(app.speciesXMPFlushToken > flushTokenBefore)
     }
 
     // MARK: - Retryable XMP failure

--- a/app/SuperPickyTests/Core/SpeciesHierarchyIncrementalTests.swift
+++ b/app/SuperPickyTests/Core/SpeciesHierarchyIncrementalTests.swift
@@ -33,6 +33,27 @@ import Foundation
         )
     }
 
+    private func signature(_ entries: [SpeciesEntry]) -> [String] {
+        entries.map { entry in
+            let bursts = entry.burstGroups
+                .map { "\($0.id.uuidString):\($0.count):\($0.pickCount):\($0.bestFilename ?? "")" }
+                .sorted()
+                .joined(separator: ",")
+            return [
+                entry.id,
+                entry.scientificName ?? "",
+                entry.name,
+                entry.cnName ?? "",
+                String(entry.count),
+                String(entry.picks),
+                String(entry.singlePhotos),
+                String(entry.singlePicks),
+                String(entry.isUnidentified),
+                bursts,
+            ].joined(separator: "|")
+        }.sorted()
+    }
+
     // MARK: - add
 
     @Test func addToEmptyCreatesBucket() {
@@ -179,5 +200,114 @@ import Foundation
         #expect(entries[0].isUnidentified == true)
         entries = SpeciesHierarchyBuilder.applyIncremental(entries: entries, removing: b)
         #expect(entries.isEmpty)
+    }
+
+    // MARK: - exact batch species changes
+
+    @Test func batchSpeciesChangeMatchesFullBuildForMultiSpeciesSingle() {
+        let eagle = match("eagle")
+        let hawk = match("hawk")
+        let owl = match("owl")
+        let original = photo(species: [eagle, hawk])
+        let untouched = photo(species: [eagle])
+        var updated = original
+        updated.assignedSpecies = [hawk, owl]
+
+        let incremental = SpeciesHierarchyBuilder.applySpeciesChanges(
+            entries: SpeciesHierarchyBuilder.build(from: [original, untouched]),
+            changes: [SpeciesHierarchyChange(previous: original, updated: updated)]
+        )
+        let rebuilt = SpeciesHierarchyBuilder.build(from: [updated, untouched])
+
+        #expect(signature(incremental) == signature(rebuilt))
+    }
+
+    @Test func batchSpeciesChangeMatchesFullBuildForCompleteBurst() {
+        let groupID = UUID()
+        let eagle = match("eagle")
+        let hawk = match("hawk")
+        var first = photo(species: [eagle], burstGroupID: groupID)
+        var second = photo(species: [eagle], burstGroupID: groupID)
+        let third = photo(species: [hawk], burstGroupID: groupID)
+        first.filename = "first.jpg"
+        first.isBurstBest = true
+        first.isPick = true
+        second.filename = "second.jpg"
+
+        var updatedFirst = first
+        var updatedSecond = second
+        updatedFirst.assignedSpecies = [eagle, hawk]
+        updatedSecond.assignedSpecies = [eagle, hawk]
+
+        let initialPhotos = [first, second, third]
+        let updatedPhotos = [updatedFirst, updatedSecond, third]
+        let incremental = SpeciesHierarchyBuilder.applySpeciesChanges(
+            entries: SpeciesHierarchyBuilder.build(from: initialPhotos),
+            changes: zip(initialPhotos, updatedPhotos).map {
+                SpeciesHierarchyChange(previous: $0.0, updated: $0.1)
+            }
+        )
+        let rebuilt = SpeciesHierarchyBuilder.build(from: updatedPhotos)
+
+        #expect(signature(incremental) == signature(rebuilt))
+    }
+
+    @Test func batchSpeciesRenameUpdatesBucketMetadata() {
+        let original = photo(species: [
+            match("eagle", common: "Wrong Eagle", scientific: "Aquila")
+        ])
+        var updated = original
+        updated.assignedSpecies = [
+            match("eagle", common: "Golden Eagle", scientific: "Aquila")
+        ]
+
+        let incremental = SpeciesHierarchyBuilder.applySpeciesChanges(
+            entries: SpeciesHierarchyBuilder.build(from: [original]),
+            changes: [SpeciesHierarchyChange(previous: original, updated: updated)]
+        )
+        let rebuilt = SpeciesHierarchyBuilder.build(from: [updated])
+
+        #expect(signature(incremental) == signature(rebuilt))
+        #expect(incremental.first?.name == "Golden Eagle")
+    }
+
+    @Test func batchPrimaryReorderDoesNotChangeHierarchy() {
+        let eagle = match("eagle")
+        let hawk = match("hawk")
+        let original = photo(species: [eagle, hawk])
+        var updated = original
+        updated.assignedSpecies = [hawk, eagle]
+
+        let initial = SpeciesHierarchyBuilder.build(from: [original])
+        let incremental = SpeciesHierarchyBuilder.applySpeciesChanges(
+            entries: initial,
+            changes: [SpeciesHierarchyChange(previous: original, updated: updated)]
+        )
+
+        #expect(signature(incremental) == signature(initial))
+    }
+
+    @Test func batchBurstRemovalMatchesFullBuildAndCreatesUnidentifiedBucket() {
+        let groupID = UUID()
+        let eagle = match("eagle")
+        let first = photo(species: [eagle], burstGroupID: groupID)
+        let second = photo(species: [eagle], burstGroupID: groupID)
+        var updatedFirst = first
+        var updatedSecond = second
+        updatedFirst.assignedSpecies = []
+        updatedSecond.assignedSpecies = []
+
+        let original = [first, second]
+        let updated = [updatedFirst, updatedSecond]
+        let incremental = SpeciesHierarchyBuilder.applySpeciesChanges(
+            entries: SpeciesHierarchyBuilder.build(from: original),
+            changes: zip(original, updated).map {
+                SpeciesHierarchyChange(previous: $0.0, updated: $0.1)
+            }
+        )
+        let rebuilt = SpeciesHierarchyBuilder.build(from: updated)
+
+        #expect(signature(incremental) == signature(rebuilt))
+        #expect(incremental.first(where: \.isUnidentified)?.burstGroups.first?.count == 2)
     }
 }


### PR DESCRIPTION
Manual species add, remove, promote, and rename still felt slow after persistence moved off the main thread. Observable state continued to wait on SQLite and XMP, and a 10,000-photo library exposed a second bottleneck: rebuilding the entire species hierarchy took about 4.55 seconds per edit.

## What changed

- Apply deterministic species changes optimistically so assigned rows and sidebar state update before persistence starts.
- Persist captured species snapshots in serialized order without republishing stale database results over newer UI state.
- Coalesce XMP writes by sidecar path, with explicit lifecycle flushing, retained failures, and retry UI.
- Replace full-library hierarchy rebuilds with exact batch deltas covering multi-species photos, bursts, unidentified transitions, metadata renames, and optimistic undo.
- Add correlated profiling plus deterministic ordering, failure, coalescing, hierarchy-equivalence, and large-library regression coverage.

## Performance

The 10,000-photo reproduction improved from `4553.9 ms` immediate latency (`4552.7 ms` hierarchy) to `1.2 ms` total (`0.1 ms` hierarchy).

## Verification

- 87 focused AppState, hierarchy, and species tests pass.
- Fresh macOS Debug build succeeds.
- Changed Swift files pass SwiftLint.