### PR TITLE
Distinguish rejected photos from zero-star ratings

### DIFF
--- a/app/SuperPickyApp/AppState.swift
+++ b/app/SuperPickyApp/AppState.swift
@@ -5,6 +5,7 @@ import os
 enum SidebarSelection: Hashable {
     case folder(URL)
     case rating(Int)
+    case rejected
     case flying
     case picks
     /// Species bucket keyed by stable `SpeciesMatch.speciesID` (eBird code
@@ -327,9 +328,12 @@ final class AppState {
 
     var ratingCounts: [Int: Int] {
         var counts: [Int: Int] = [:]
-        for p in allPhotos { counts[p.starRating, default: 0] += 1 }
+        for photo in allPhotos {
+            counts[photo.starRating, default: 0] += 1
+        }
         return counts
     }
+    var rejectedCount: Int { allPhotos.lazy.filter(\.isRejected).count }
     var flyingCount: Int { allPhotos.lazy.filter(\.isFlying).count }
     var picksCount: Int { allPhotos.lazy.filter(\.isPick).count }
 
@@ -346,8 +350,8 @@ final class AppState {
             let previousRating: Int
             let previousIsPick: Bool
             let previousIsManualRating: Bool
+            let previousIsRejected: Bool
             let previousAssignedSpecies: [SpeciesMatch]
-            let wasHidden: Bool
         }
         var kind: Kind = .fields
         let entries: [Entry]
@@ -659,6 +663,8 @@ final class AppState {
 
     private func photoMatchesCurrentFilter(_ photo: Photo) -> Bool {
         switch sidebarSelection {
+        case .rejected:
+            return photo.isRejected
         case .folder, nil:
             return true
         case .rating(let rating):
@@ -780,19 +786,10 @@ final class AppState {
             return completedMutationTask()
         }
         return enqueueMutation { state in
-            await state.applyBatch(
-                context: context,
-                ids: Array(ids),
-                wasHidden: true
-            ) { photos in
+            await state.applyBatch(context: context, ids: Array(ids)) { photos in
                 for index in photos.indices {
-                    photos[index].starRating = 0
-                    photos[index].isManualRating = true
+                    photos[index].isRejected = true
                 }
-            } afterAll: { [weak state] _ in
-                guard let state else { return }
-                state.photos.removeAll { ids.contains($0.id) }
-                state.rebuildFilteredPhotoIndex()
             }
         }
     }
@@ -807,10 +804,8 @@ final class AppState {
     private func applyBatch(
         context: MutationContext,
         ids: [UUID],
-        wasHidden: Bool = false,
         _ mutate: @escaping @Sendable (inout [Photo]) -> Void,
-        afterEach: ((Photo) -> Void)? = nil,
-        afterAll: ((_ mutated: [Photo]) -> Void)? = nil
+        afterEach: ((Photo) -> Void)? = nil
     ) async {
         guard !ids.isEmpty else { return }
         do {
@@ -822,9 +817,7 @@ final class AppState {
             guard currentFolder == context.folder else { return }
 
             var entries: [UndoAction.Entry] = []
-            var mutated: [Photo] = []
             entries.reserveCapacity(results.count)
-            mutated.reserveCapacity(results.count)
             for result in results {
                 let previous = result.previous
                 let photo = result.updated
@@ -833,19 +826,17 @@ final class AppState {
                     previousRating: previous.starRating,
                     previousIsPick: previous.isPick,
                     previousIsManualRating: previous.isManualRating,
-                    previousAssignedSpecies: previous.assignedSpecies,
-                    wasHidden: wasHidden
+                    previousIsRejected: previous.isRejected,
+                    previousAssignedSpecies: previous.assignedSpecies
                 ))
                 if let idx = allPhotoIndex[photo.id] { allPhotos[idx] = photo }
-                if let fIdx = filteredPhotoIndex[photo.id] { photos[fIdx] = photo }
-                mutated.append(photo)
                 afterEach?(photo)
             }
             if !entries.isEmpty {
                 undoStack.append(UndoAction(kind: .fields, entries: entries))
                 if undoStack.count > Self.maxUndoDepth { undoStack.removeFirst() }
             }
-            afterAll?(mutated)
+            applyFilter()
         } catch {
             logger.error("applyBatch failed: \(error)")
         }
@@ -1042,8 +1033,8 @@ final class AppState {
                 previousRating: photo.starRating,
                 previousIsPick: photo.isPick,
                 previousIsManualRating: photo.isManualRating,
-                previousAssignedSpecies: before,
-                wasHidden: false
+                previousIsRejected: photo.isRejected,
+                previousAssignedSpecies: before
             ))
             snapshots.append(SpeciesSnapshot(id: photo.id, species: after))
             pendingOptimisticSpecies[photo.id] = (generation, after)
@@ -1440,6 +1431,7 @@ final class AppState {
                     photos[index].starRating = entry.previousRating
                     photos[index].isPick = entry.previousIsPick
                     photos[index].isManualRating = entry.previousIsManualRating
+                    photos[index].isRejected = entry.previousIsRejected
                     photos[index].assignedSpecies = entry.previousAssignedSpecies
                 }
             }
@@ -1449,7 +1441,7 @@ final class AppState {
             var anySpeciesChanged = false
             for result in results {
                 let photo = result.updated
-                guard let entry = entriesByID[photo.id] else { continue }
+                guard entriesByID[photo.id] != nil else { continue }
                 let pickChanged = result.previous.isPick != photo.isPick
                 let speciesChanged = result.previous.assignedSpecies.map(\.speciesID)
                     != photo.assignedSpecies.map(\.speciesID)
@@ -1466,19 +1458,12 @@ final class AppState {
                 }
                 if speciesChanged { anySpeciesChanged = true }
 
-                if entry.wasHidden {
-                    if filteredPhotoIndex[photo.id] == nil {
-                        filteredPhotoIndex[photo.id] = photos.count
-                        photos.append(photo)
-                    }
-                } else if let idx = filteredPhotoIndex[photo.id] {
-                    photos[idx] = photo
-                }
                 lastID = photo.id
             }
             if anySpeciesChanged {
                 buildSpeciesHierarchy()
             }
+            applyFilter()
             if let id = lastID, photos.contains(where: { $0.id == id }) {
                 selection.click(id, photos: photos)
             }
@@ -1498,26 +1483,7 @@ final class AppState {
     /// bumped so the view layer can pick the displayed-first photo using
     /// its own sort order.
     func applyFilter(autoSelectFirst: Bool = true) {
-        switch sidebarSelection {
-        case .folder:
-            photos = allPhotos
-        case .rating(let rating):
-            photos = allPhotos.filter { $0.starRating == rating }
-        case .flying:
-            photos = allPhotos.filter { $0.isFlying }
-        case .picks:
-            photos = allPhotos.filter { $0.isPick }
-        case .species(let speciesID):
-            photos = allPhotos.filter { photoHasSpeciesID($0, speciesID: speciesID) }
-        case .burstGroup(let groupID):
-            photos = allPhotos.filter { $0.burstGroupID == groupID }
-        case .singles(let speciesID):
-            photos = allPhotos.filter { photo in
-                photo.burstGroupID == nil && photoHasSpeciesID(photo, speciesID: speciesID)
-            }
-        case nil:
-            photos = allPhotos
-        }
+        photos = allPhotos.filter(photoMatchesCurrentFilter)
         rebuildFilteredPhotoIndex()
         selection.reconcile(with: photos)
         if autoSelectFirst {

--- a/app/SuperPickyApp/AppState.swift
+++ b/app/SuperPickyApp/AppState.swift
@@ -78,6 +78,11 @@ private struct SpeciesPersistResult: Sendable {
     let databaseMilliseconds: Double
 }
 
+private struct PhotoDeletionBatchResult: Sendable {
+    let deleted: [Photo]
+    let failureCount: Int
+}
+
 /// Summary of one XMP write-behind drain, reported back to `AppState` so it can
 /// surface persistent failures and log deferred sidecar latency separately from
 /// the synchronous edit.
@@ -99,6 +104,11 @@ private actor PhotoMutationWorker {
         subsystem: "com.halfhacked.superpicky",
         category: "PhotoMutationWorker"
     )
+    private let trashPhoto: @Sendable (URL) throws -> Void
+
+    init(trashPhoto: @escaping @Sendable (URL) throws -> Void) {
+        self.trashPhoto = trashPhoto
+    }
 
     /// Full read-modify-write used by pick / rate / reject and field-undo.
     /// XMP is written synchronously here to preserve existing behavior for
@@ -136,12 +146,26 @@ private actor PhotoMutationWorker {
 
     func delete(database: ReportDatabase, id: UUID) throws -> Photo? {
         guard let photo = try database.fetchPhoto(id: id) else { return nil }
-        try FileManager.default.trashItem(
-            at: URL(fileURLWithPath: photo.filePath),
-            resultingItemURL: nil
-        )
+        try trashPhoto(URL(fileURLWithPath: photo.filePath))
         try database.delete(id: id)
         return photo
+    }
+
+    func delete(database: ReportDatabase, ids: [UUID]) -> PhotoDeletionBatchResult {
+        var deleted: [Photo] = []
+        var failureCount = 0
+        deleted.reserveCapacity(ids.count)
+        for id in ids {
+            do {
+                if let photo = try delete(database: database, id: id) {
+                    deleted.append(photo)
+                }
+            } catch {
+                failureCount += 1
+                logger.error("Failed to delete photo \(id): \(error)")
+            }
+        }
+        return PhotoDeletionBatchResult(deleted: deleted, failureCount: failureCount)
     }
 }
 
@@ -391,7 +415,7 @@ final class AppState {
     var canUndo: Bool { !undoStack.isEmpty }
 
     private var cachedDB: ReportDatabase?
-    @ObservationIgnored private let mutationWorker = PhotoMutationWorker()
+    @ObservationIgnored private let mutationWorker: PhotoMutationWorker
     @ObservationIgnored private var pendingMutationTask: Task<Void, Never>?
     @ObservationIgnored private var lastSpeciesEditProfile: SpeciesEditProfile?
     @ObservationIgnored private var pendingSpeciesEditRender: PendingSpeciesEditRender?
@@ -448,8 +472,14 @@ final class AppState {
     /// - Parameter xmpDebounceMilliseconds: write-behind debounce window. Capped
     ///   at 150 ms in production; tests never wait on it (they call
     ///   `flushPendingPersistence()`), so its value is irrelevant to them.
-    init(xmpDebounceMilliseconds: Double = 150) {
+    init(
+        xmpDebounceMilliseconds: Double = 150,
+        trashPhoto: @escaping @Sendable (URL) throws -> Void = { url in
+            try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+        }
+    ) {
         self.xmpDebounceMilliseconds = min(max(0, xmpDebounceMilliseconds), 150)
+        self.mutationWorker = PhotoMutationWorker(trashPhoto: trashPhoto)
     }
 
     // Per-folder processing state
@@ -856,32 +886,70 @@ final class AppState {
                 ) else {
                     return
                 }
-                // Evict any pending write-behind XMP for this sidecar so a
-                // deferred flush can't recreate an orphan sidecar next to the
-                // now-trashed original. Drop any failed/optimistic state too.
-                let sidecarPath = XMPWriter.sidecarURL(for: photo).path
-                await state.xmpQueue.evict(sidecarPath: sidecarPath)
-                state.pendingOptimisticSpecies.removeValue(forKey: id)
-                state.failedSpeciesEdits.removeValue(forKey: id)
-                state.failedXMPSidecars.remove(sidecarPath)
-                guard state.currentFolder == context.folder else {
-                    state.refreshSpeciesFailureMessage()
-                    return
-                }
-
-                state.allPhotos.removeAll { $0.id == id }
-                state.photos.removeAll { $0.id == id }
-                state.rebuildAllPhotoIndex()
-                state.rebuildFilteredPhotoIndex()
-                state.undoStack.removeAll {
-                    $0.entries.contains(where: { $0.photoID == id })
-                }
-                state.refreshSpeciesFailureMessage()
+                await state.finalizeDeletedPhotos([photo], context: context)
                 state.logger.info("Deleted photo: \(photo.filename)")
             } catch {
                 state.logger.error("deletePhoto failed: \(error)")
             }
         }
+    }
+
+    @MainActor
+    @discardableResult
+    func deleteRejectedPhotos() -> Task<Void, Never> {
+        guard let context = mutationContext() else {
+            return completedMutationTask()
+        }
+        return enqueueMutation { state in
+            guard state.currentFolder == context.folder else { return }
+            let ids = state.allPhotos.filter(\.isRejected).map(\.id)
+            guard !ids.isEmpty else {
+                state.logger.info("Delete rejected photos skipped: no rejected photos")
+                return
+            }
+
+            let result = await state.mutationWorker.delete(
+                database: context.database,
+                ids: ids
+            )
+            await state.finalizeDeletedPhotos(result.deleted, context: context)
+            state.logger.info(
+                "Deleted \(result.deleted.count) rejected photos; \(result.failureCount) failed"
+            )
+        }
+    }
+
+    @MainActor
+    private func finalizeDeletedPhotos(
+        _ deleted: [Photo],
+        context: MutationContext
+    ) async {
+        guard !deleted.isEmpty else { return }
+        let ids = Set(deleted.map(\.id))
+
+        // Evict pending write-behind XMP before changing folders or observable
+        // state so no deferred flush can recreate an orphan sidecar.
+        for photo in deleted {
+            let sidecarPath = XMPWriter.sidecarURL(for: photo).path
+            await xmpQueue.evict(sidecarPath: sidecarPath)
+            pendingOptimisticSpecies.removeValue(forKey: photo.id)
+            failedSpeciesEdits.removeValue(forKey: photo.id)
+            failedXMPSidecars.remove(sidecarPath)
+        }
+
+        guard currentFolder == context.folder else {
+            refreshSpeciesFailureMessage()
+            return
+        }
+
+        allPhotos.removeAll { ids.contains($0.id) }
+        rebuildAllPhotoIndex()
+        undoStack.removeAll { action in
+            action.entries.contains { ids.contains($0.photoID) }
+        }
+        buildSpeciesHierarchy()
+        applyFilter()
+        refreshSpeciesFailureMessage()
     }
 
     // MARK: - Set-based mutation: species

--- a/app/SuperPickyApp/CompareView.swift
+++ b/app/SuperPickyApp/CompareView.swift
@@ -96,6 +96,12 @@ struct CompareView: View {
                             .font(.caption)
                             .transition(.opacity)
                     }
+                    if photo.isRejected {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.red)
+                            .font(.caption)
+                            .transition(.opacity)
+                    }
                     Spacer()
                     Text(photo.filename)
                         .font(.caption)
@@ -105,6 +111,7 @@ struct CompareView: View {
                 .padding(.vertical, 6)
                 .background(.black)
                 .animation(.easeInOut(duration: 0.2), value: photo.isPick)
+                .animation(.easeInOut(duration: 0.2), value: photo.isRejected)
             }
         }
     }

--- a/app/SuperPickyApp/ContentView.swift
+++ b/app/SuperPickyApp/ContentView.swift
@@ -22,6 +22,7 @@ struct ContentView: View {
     var onExportPicks: (() -> Void)?
     var onExportAllVisible: (([Photo]) -> Void)?
     var onDeletePhoto: ((UUID) -> Void)?
+    var onDeleteRejectedPhotos: (() -> Void)?
     var onCorrectSpecies: ((UUID, String) -> Void)?
     var searchSpecies: (String) async -> [SpeciesMatch] = { _ in [] }
     @Environment(CullingConfig.self) private var config
@@ -41,6 +42,8 @@ struct ContentView: View {
     @State private var showNoPhotosAlert = false
     @State private var showDeleteConfirm = false
     @State private var pendingDeleteID: UUID?
+    @State private var showDeleteRejectedConfirm = false
+    @State private var showNoRejectedPhotosAlert = false
     @State private var showKeyboardHelp = false
     @State private var showThresholdCalibrator = false
     @State private var showSharpnessOverlay = false
@@ -258,6 +261,25 @@ struct ContentView: View {
         } message: {
             Text(config.localized("Move to Trash?"))
         }
+        .alert(
+            config.localized("Delete All Rejected Photos?"),
+            isPresented: $showDeleteRejectedConfirm
+        ) {
+            Button(config.localized("Delete All"), role: .destructive) {
+                onDeleteRejectedPhotos?()
+            }
+            Button(config.localized("Cancel"), role: .cancel) {}
+        } message: {
+            Text(config.localized("Move every rejected photo to Trash?"))
+        }
+        .alert(
+            config.localized("No Rejected Photos"),
+            isPresented: $showNoRejectedPhotosAlert
+        ) {
+            Button(config.localized("OK"), role: .cancel) {}
+        } message: {
+            Text(config.localized("There are no rejected photos to delete."))
+        }
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 Menu {
@@ -443,8 +465,16 @@ struct ContentView: View {
         default: break
         }
 
-        // Delete/Backspace key (keyCode 51)
-        if key.keyCode == 51 {
+        // Delete/Backspace; Command deletes all rejected.
+        if key.isDelete {
+            if key.isCommandDelete {
+                if appState.rejectedCount > 0 {
+                    showDeleteRejectedConfirm = true
+                } else {
+                    showNoRejectedPhotosAlert = true
+                }
+                return true
+            }
             guard let id = selectedPhoto?.id else { return false }
             pendingDeleteID = id
             showDeleteConfirm = true

--- a/app/SuperPickyApp/KeyboardHelpView.swift
+++ b/app/SuperPickyApp/KeyboardHelpView.swift
@@ -18,6 +18,7 @@ struct KeyboardHelpView: View {
         ("P", "Pick / unpick selection"),
         ("X", "Reject selection"),
         ("⌫", "Delete photo to Trash"),
+        ("⌘⌫", "Delete all rejected photos to Trash"),
         ("⌘Z", "Undo last action"),
         ("⌘0–5", "Set minimum star filter"),
         ("⌘E", "Export picks"),

--- a/app/SuperPickyApp/KeyboardMonitor.swift
+++ b/app/SuperPickyApp/KeyboardMonitor.swift
@@ -14,6 +14,8 @@ struct KeyboardMonitor: NSViewRepresentable {
         let isReturn: Bool
         let isLeftArrow: Bool
         let isRightArrow: Bool
+        var isDelete: Bool { keyCode == 51 || keyCode == 117 }
+        var isCommandDelete: Bool { isDelete && modifiers.contains(.command) }
     }
 
     func makeNSView(context: Context) -> KeyboardMonitorView {

--- a/app/SuperPickyApp/MainView.swift
+++ b/app/SuperPickyApp/MainView.swift
@@ -75,6 +75,7 @@ struct MainView: View {
                 selection: $appState.sidebarSelection,
                 folders: $appState.folders,
                 ratingCounts: appState.ratingCounts,
+                rejectedCount: appState.rejectedCount,
                 flyingCount: appState.flyingCount,
                 picksCount: appState.picksCount,
                 speciesEntries: appState.speciesEntries,
@@ -164,7 +165,7 @@ struct MainView: View {
             switch newValue {
             case .folder(let url):
                 appState.loadPhotos(for: url, deferSelection: true)
-            case .rating, .flying, .picks, .species, .burstGroup, .singles:
+            case .rating, .rejected, .flying, .picks, .species, .burstGroup, .singles:
                 appState.applyFilter(autoSelectFirst: false)
             case nil:
                 break

--- a/app/SuperPickyApp/MainView.swift
+++ b/app/SuperPickyApp/MainView.swift
@@ -126,6 +126,9 @@ struct MainView: View {
                     onDeletePhoto: { id in
                         appState.deletePhoto(id: id)
                     },
+                    onDeleteRejectedPhotos: {
+                        appState.deleteRejectedPhotos()
+                    },
                     onCorrectSpecies: { id, name in
                         let ids: Set<UUID> = appState.selection.isMulti
                             ? appState.selection.selectedIDs

--- a/app/SuperPickyApp/Photo.swift
+++ b/app/SuperPickyApp/Photo.swift
@@ -23,6 +23,7 @@ struct Photo: Identifiable, Codable, Sendable, FetchableRecord, PersistableRecor
     var sharpnessScore: Float?
     var exposureStatus: String?
     var starRating: Int
+    var isRejected: Bool
     var isPick: Bool
     var speciesScientificName: String?
     var speciesCommonName: String?
@@ -68,6 +69,7 @@ struct Photo: Identifiable, Codable, Sendable, FetchableRecord, PersistableRecor
         self.dateCreated = dateCreated
         self.isFlying = false
         self.starRating = 0
+        self.isRejected = false
         self.isPick = false
         self.isBurstBest = false
         self.isManualRating = false

--- a/app/SuperPickyApp/PreviewView.swift
+++ b/app/SuperPickyApp/PreviewView.swift
@@ -195,6 +195,16 @@ struct InfoBarView: View {
                 }
             }
 
+            if photo.isRejected {
+                Label {
+                    Text(config.localized("Rejected"))
+                } icon: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .font(.caption)
+                .foregroundStyle(.red)
+            }
+
             if let sharpness = photo.sharpnessScore {
                 Label {
                     Text("\(config.localized("Sharp")): \(Int(sharpness))")

--- a/app/SuperPickyApp/ReportDatabase.swift
+++ b/app/SuperPickyApp/ReportDatabase.swift
@@ -160,6 +160,14 @@ final class ReportDatabase: Sendable {
                 }
             }
         }
+        migrator.registerMigration("v9_rejected_state") { db in
+            try db.alter(table: "photos") { t in
+                t.add(column: "isRejected", .boolean).notNull().defaults(to: false)
+            }
+            // Legacy zero-star rows are intentionally left non-rejected because
+            // the old schema cannot prove whether the user pressed 0 or X.
+            try db.create(indexOn: "photos", columns: ["isRejected"])
+        }
         try migrator.migrate(dbQueue)
     }
 
@@ -288,7 +296,10 @@ final class ReportDatabase: Sendable {
 
     func ratingCounts() throws -> [Int: Int] {
         try dbQueue.read { db in
-            let rows = try Row.fetchAll(db, sql: "SELECT starRating, COUNT(*) as cnt FROM photos GROUP BY starRating")
+            let rows = try Row.fetchAll(
+                db,
+                sql: "SELECT starRating, COUNT(*) as cnt FROM photos GROUP BY starRating"
+            )
             var result: [Int: Int] = [:]
             for row in rows {
                 result[row["starRating"]] = row["cnt"]
@@ -303,10 +314,13 @@ final class ReportDatabase: Sendable {
         }
     }
 
-    /// Delete all photos that were NOT manually rated (keep manual overrides).
+    /// Delete photos with no manual culling decision so the pipeline can
+    /// reprocess them. Manual ratings and explicit rejections are preserved.
     func deleteNonManualPhotos() throws {
         try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM photos WHERE isManualRating = 0")
+            try db.execute(
+                sql: "DELETE FROM photos WHERE isManualRating = 0 AND isRejected = 0"
+            )
         }
     }
 }

--- a/app/SuperPickyApp/SourceListView.swift
+++ b/app/SuperPickyApp/SourceListView.swift
@@ -5,6 +5,7 @@ struct SourceListView: View {
     @Binding var selection: SidebarSelection?
     @Binding var folders: [URL]
     let ratingCounts: [Int: Int]
+    let rejectedCount: Int
     let flyingCount: Int
     let picksCount: Int
     let speciesEntries: [SpeciesEntry]
@@ -87,6 +88,19 @@ struct SourceListView: View {
                     }
                     .tag(SidebarSelection.rating(rating))
                 }
+
+                Label {
+                    HStack {
+                        Text(config.localized("Rejected"))
+                        Spacer()
+                        Text("\(rejectedCount)")
+                            .foregroundStyle(.secondary)
+                    }
+                } icon: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.red)
+                }
+                .tag(SidebarSelection.rejected)
             }
 
             Section(config.localized("Tags")) {
@@ -223,7 +237,7 @@ struct SourceListView: View {
         case 3: config.localized("Average")
         case 2: config.localized("Below Average")
         case 1: config.localized("Poor")
-        case 0: config.localized("Reject")
+        case 0: config.localized("0 Stars")
         default: config.localized("Unknown")
         }
     }
@@ -235,7 +249,7 @@ struct SourceListView: View {
         case 3: "star.leadinghalf.filled"
         case 2: "star"
         case 1: "star"
-        case 0: "xmark"
+        case 0: "star"
         default: "questionmark"
         }
     }
@@ -247,7 +261,7 @@ struct SourceListView: View {
         case 3: .yellow
         case 2: .orange
         case 1: .secondary
-        case 0: .red
+        case 0: .secondary
         default: .secondary
         }
     }

--- a/app/SuperPickyApp/ThumbnailStripView.swift
+++ b/app/SuperPickyApp/ThumbnailStripView.swift
@@ -138,6 +138,16 @@ struct ThumbnailCell: View {
                     .accessibilityIdentifier("PickFlag_\(photo.filename)")
             }
 
+            if photo.isRejected {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.red)
+                    .padding(3)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 2))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+                    .padding(2)
+            }
+
             // Burst best bottom-right
             if photo.isBurstBest {
                 Image(systemName: "crown.fill")
@@ -157,6 +167,7 @@ struct ThumbnailCell: View {
                 .padding(2)
         }
         .animation(.easeInOut(duration: 0.2), value: photo.isPick)
+        .animation(.easeInOut(duration: 0.2), value: photo.isRejected)
         .clipShape(RoundedRectangle(cornerRadius: 4))
         .overlay(
             // strokeBorder draws inside the frame; plain stroke would center
@@ -236,5 +247,4 @@ struct AsyncThumbnailImage: View {
         await ImageLoader.load(path: filePath, maxPixelSize: 160)
     }
 }
-
 

--- a/app/SuperPickyApp/XMPWriter.swift
+++ b/app/SuperPickyApp/XMPWriter.swift
@@ -60,7 +60,7 @@ struct XMPWriter {
               xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/"
               xmlns:sp="https://halfhacked.com/ns/superpicky/1.0/"
               xmp:Rating="\(photo.starRating)"
-              xmp:PickStatus="\(photo.isPick ? 1 : 0)"
+              xmp:PickStatus="\(pickStatus(for: photo))"
               sp:ManagedSubject="\(encodeManaged(flatKeywords))"
               sp:ManagedHierarchicalSubject="\(encodeManaged(hierarchicalKeywords))">\n
         """
@@ -167,6 +167,11 @@ struct XMPWriter {
 
     // MARK: - Private
 
+    private static func pickStatus(for photo: Photo) -> Int {
+        if photo.isRejected { return -1 }
+        return photo.isPick ? 1 : 0
+    }
+
     private static func merge(photo: Photo, into data: Data) throws -> Data {
         let document = try XMLDocument(data: data, options: [.nodePreserveAll])
         let descriptions = descendantElements(
@@ -190,7 +195,7 @@ struct XMPWriter {
             localName: "PickStatus",
             uri: xmpURI,
             preferredPrefix: "xmp",
-            value: photo.isPick ? "1" : "0",
+            value: String(pickStatus(for: photo)),
             descriptions: descriptions,
             fallback: primaryDescription
         )

--- a/app/SuperPickyApp/en.lproj/Localizable.strings
+++ b/app/SuperPickyApp/en.lproj/Localizable.strings
@@ -1,3 +1,4 @@
+"0 Stars" = "0 Stars";
 "About" = "About";
 "Add a folder to get started" = "Add a folder to get started";
 "Advanced" = "Advanced";
@@ -83,6 +84,7 @@
 "Ratings" = "Ratings";
 "Redo" = "Redo";
 "Reject" = "Reject";
+"Rejected" = "Rejected";
 "Remove" = "Remove";
 "Retry" = "Retry";
 "Reveal in Finder" = "Reveal in Finder";

--- a/app/SuperPickyApp/en.lproj/Localizable.strings
+++ b/app/SuperPickyApp/en.lproj/Localizable.strings
@@ -165,6 +165,12 @@
 "Not measured" = "Not measured";
 "Delete Photo?" = "Delete Photo?";
 "Move to Trash?" = "Move to Trash?";
+"Delete All Rejected Photos?" = "Delete All Rejected Photos?";
+"Delete All" = "Delete All";
+"Move every rejected photo to Trash?" = "Move every rejected photo to Trash?";
+"No Rejected Photos" = "No Rejected Photos";
+"There are no rejected photos to delete." = "There are no rejected photos to delete.";
+"Delete all rejected photos to Trash" = "Delete all rejected photos to Trash";
 "Export All Visible" = "Export All Visible";
 "Sort photos" = "Sort photos";
 "Sort species" = "Sort species";

--- a/app/SuperPickyApp/zh-Hans.lproj/Localizable.strings
+++ b/app/SuperPickyApp/zh-Hans.lproj/Localizable.strings
@@ -1,3 +1,4 @@
+"0 Stars" = "0 星";
 "About" = "关于";
 "Add a folder to get started" = "添加文件夹以开始";
 "Advanced" = "高级";
@@ -83,6 +84,7 @@
 "Ratings" = "评分";
 "Redo" = "重做";
 "Reject" = "淘汰";
+"Rejected" = "已淘汰";
 "Remove" = "移除";
 "Retry" = "重试";
 "Reveal in Finder" = "在访达中显示";

--- a/app/SuperPickyApp/zh-Hans.lproj/Localizable.strings
+++ b/app/SuperPickyApp/zh-Hans.lproj/Localizable.strings
@@ -165,6 +165,12 @@
 "Not measured" = "未测量";
 "Delete Photo?" = "删除照片？";
 "Move to Trash?" = "移到废纸篓？";
+"Delete All Rejected Photos?" = "删除所有已淘汰照片？";
+"Delete All" = "全部删除";
+"Move every rejected photo to Trash?" = "将所有已淘汰照片移到废纸篓？";
+"No Rejected Photos" = "没有已淘汰照片";
+"There are no rejected photos to delete." = "没有可删除的已淘汰照片。";
+"Delete all rejected photos to Trash" = "将所有已淘汰照片删除到废纸篓";
 "Export All Visible" = "导出所有可见";
 "Sort photos" = "排序照片";
 "Sort species" = "排序鸟种";

--- a/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
+++ b/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import AppKit
 @testable import SuperPicky
 
 @Suite(.serialized)
@@ -218,6 +219,72 @@ struct AppStateBatchMutationTests {
         #expect(restored.starRating == 4)
         #expect(restored.isRejected == false)
         #expect(app.photos.map(\.id) == [id])
+    }
+
+    @Test func deleteRejectedPhotosDeletesAllRejectedPhotosOnly() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let db = try ReportDatabase(folderPath: folder)
+        let fixtures = [
+            (filename: "zero-rejected.CR3", rating: 0, rejected: true),
+            (filename: "rated-rejected.CR3", rating: 4, rejected: true),
+            (filename: "keep.CR3", rating: 0, rejected: false),
+        ]
+        var photos: [Photo] = []
+        for fixture in fixtures {
+            let url = folder.appendingPathComponent(fixture.filename)
+            FileManager.default.createFile(atPath: url.path, contents: Data())
+            var photo = Photo(
+                filename: fixture.filename,
+                filePath: url.path,
+                folderPath: folder.path
+            )
+            photo.starRating = fixture.rating
+            photo.isRejected = fixture.rejected
+            try db.save(&photo)
+            photos.append(photo)
+        }
+
+        let app = AppState(trashPhoto: { url in
+            try FileManager.default.removeItem(at: url)
+        })
+        app.loadPhotos(for: folder)
+        app.sidebarSelection = .rejected
+        app.applyFilter()
+        #expect(app.photos.count == 2)
+
+        await app.deleteRejectedPhotos().value
+
+        let remaining = try db.fetchAllPhotos()
+        #expect(remaining.map(\.filename) == ["keep.CR3"])
+        #expect(app.allPhotosForTesting().map(\.filename) == ["keep.CR3"])
+        #expect(app.photos.isEmpty)
+        #expect(app.rejectedCount == 0)
+        #expect(FileManager.default.fileExists(atPath: photos[2].filePath))
+        #expect(!FileManager.default.fileExists(atPath: photos[0].filePath))
+        #expect(!FileManager.default.fileExists(atPath: photos[1].filePath))
+    }
+
+    @Test func commandDeleteRecognizesBackspaceAndForwardDelete() {
+        func event(
+            keyCode: UInt16,
+            modifiers: NSEvent.ModifierFlags
+        ) -> KeyboardMonitor.KeyEvent {
+            KeyboardMonitor.KeyEvent(
+                characters: "",
+                keyCode: keyCode,
+                modifiers: modifiers,
+                isEscape: false,
+                isReturn: false,
+                isLeftArrow: false,
+                isRightArrow: false
+            )
+        }
+
+        #expect(event(keyCode: 51, modifiers: .command).isCommandDelete)
+        #expect(event(keyCode: 117, modifiers: .command).isCommandDelete)
+        #expect(!event(keyCode: 51, modifiers: []).isCommandDelete)
+        #expect(!event(keyCode: 0, modifiers: .command).isCommandDelete)
     }
 
     // MARK: - correctSpecies(ids:commonName:)

--- a/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
+++ b/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
@@ -131,13 +131,15 @@ struct AppStateBatchMutationTests {
 
         let db = try ReportDatabase(folderPath: folder)
         for id in ids {
-            #expect(try db.fetchPhoto(id: id)?.starRating == 4)
+            let photo = try db.fetchPhoto(id: id)
+            #expect(photo?.starRating == 4)
+            #expect(photo?.isRejected == false)
         }
     }
 
     // MARK: - reject(ids:)
 
-    @Test func rejectMakesPhotosLeaveFilteredArray() async throws {
+    @Test func rejectPreservesRatingFilterMembership() async throws {
         let folder = try makeTempFolder()
         defer { try? FileManager.default.removeItem(at: folder) }
         let ids = try seedPhotos(3, into: folder)
@@ -150,8 +152,72 @@ struct AppStateBatchMutationTests {
         #expect(app.photos.count == 3)
 
         await app.reject(ids: [ids[0]]).value
-        #expect(app.photos.count == 2)
-        #expect(!app.photos.contains(where: { $0.id == ids[0] }))
+        #expect(app.photos.count == 3)
+        #expect(app.photos.contains(where: { $0.id == ids[0] }))
+
+        let rejected = try #require(try ReportDatabase(folderPath: folder).fetchPhoto(id: ids[0]))
+        #expect(rejected.starRating == 3)
+        #expect(rejected.isManualRating)
+        #expect(rejected.isRejected)
+        #expect(app.ratingCounts[3] == 3)
+        #expect(app.rejectedCount == 1)
+    }
+
+    @Test func zeroRatingAndRejectionCanOverlap() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let ids = try seedPhotos(2, into: folder)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+
+        await app.setRating(ids: [ids[0]], rating: 0).value
+        await app.reject(ids: [ids[1]]).value
+
+        app.sidebarSelection = .rating(0)
+        app.applyFilter()
+        #expect(Set(app.photos.map(\.id)) == Set(ids))
+
+        let rejectedZero = try #require(
+            try ReportDatabase(folderPath: folder).fetchPhoto(id: ids[1])
+        )
+        #expect(rejectedZero.starRating == 0)
+        #expect(rejectedZero.isRejected)
+        #expect(rejectedZero.isManualRating == false)
+
+        app.sidebarSelection = .rejected
+        app.applyFilter()
+        #expect(app.photos.map(\.id) == [ids[1]])
+
+        await app.setRating(ids: [ids[1]], rating: 4).value
+        #expect(app.photos.map(\.id) == [ids[1]])
+        #expect(app.ratingCounts[0] == 1)
+        #expect(app.ratingCounts[4] == 1)
+        #expect(app.rejectedCount == 1)
+
+        let updated = try #require(try ReportDatabase(folderPath: folder).fetchPhoto(id: ids[1]))
+        #expect(updated.starRating == 4)
+        #expect(updated.isRejected)
+    }
+
+    @Test func undoRejectRestoresRatingAndRejectedState() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let id = try #require(try seedPhotos(1, into: folder).first)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+
+        await app.setRating(ids: [id], rating: 4).value
+        await app.reject(ids: [id]).value
+        app.sidebarSelection = .rating(4)
+        app.applyFilter()
+        #expect(app.photos.map(\.id) == [id])
+
+        await app.undoLastAction().value
+
+        let restored = try #require(try ReportDatabase(folderPath: folder).fetchPhoto(id: id))
+        #expect(restored.starRating == 4)
+        #expect(restored.isRejected == false)
+        #expect(app.photos.map(\.id) == [id])
     }
 
     // MARK: - correctSpecies(ids:commonName:)

--- a/app/SuperPickyTests/Core/XMPWriterTests.swift
+++ b/app/SuperPickyTests/Core/XMPWriterTests.swift
@@ -61,6 +61,17 @@ import Foundation
         #expect(xml.contains("xmp:PickStatus=\"0\""))
     }
 
+    @Test func xmpPreservesZeroRatingAlongsideRejectedPickStatus() {
+        var photo = makePhoto(starRating: 0)
+        photo.isPick = true
+        photo.isRejected = true
+
+        let xml = XMPWriter.generate(photo: photo)
+
+        #expect(xml.contains("xmp:Rating=\"0\""))
+        #expect(xml.contains("xmp:PickStatus=\"-1\""))
+    }
+
     // MARK: - Species keywords
 
     @Test func xmpContainsSpeciesKeywords() {

--- a/app/SuperPickyTests/Data/ReportDatabaseTests.swift
+++ b/app/SuperPickyTests/Data/ReportDatabaseTests.swift
@@ -15,12 +15,14 @@ import GRDB
         let db = try ReportDatabase(folderPath: tempDir)
         var photo = Photo(filename: "IMG_001.CR3", filePath: tempDir.appendingPathComponent("IMG_001.CR3").path, folderPath: tempDir.path)
         photo.starRating = 3
+        photo.isRejected = true
         photo.aestheticsScore = 6.5
         try db.save(&photo)
 
         let fetched = try db.fetchPhoto(id: photo.id)
         #expect(fetched != nil)
         #expect(fetched?.starRating == 3)
+        #expect(fetched?.isRejected == true)
         #expect(fetched?.aestheticsScore == 6.5)
     }
 
@@ -68,6 +70,30 @@ import GRDB
         let counts = try db.ratingCounts()
         #expect(counts[3] == 3)
         #expect(counts[1] == 3)
+    }
+
+    @Test func rejectedPhotosRemainInZeroStarQueries() throws {
+        let tempDir = try makeTempDir()
+        let db = try ReportDatabase(folderPath: tempDir)
+
+        var zeroStar = Photo(
+            filename: "zero.CR3",
+            filePath: "/tmp/zero.CR3",
+            folderPath: tempDir.path
+        )
+        try db.save(&zeroStar)
+
+        var rejected = Photo(
+            filename: "rejected.CR3",
+            filePath: "/tmp/rejected.CR3",
+            folderPath: tempDir.path
+        )
+        rejected.isRejected = true
+        try db.save(&rejected)
+
+        let zeroStarPhotos = try db.fetchPhotos(starRating: 0)
+        #expect(Set(zeroStarPhotos.map(\.id)) == [zeroStar.id, rejected.id])
+        #expect(try db.ratingCounts()[0] == 2)
     }
 
     @Test func v2MigrationAddsIsManualRatingAndRemapsMinus1() throws {
@@ -124,6 +150,8 @@ import GRDB
         #expect(allPhotos[0].starRating == 0)
         // isManualRating column should exist and default to false
         #expect(allPhotos[0].isManualRating == false)
+        // The migration cannot infer whether a legacy zero meant 0 or reject.
+        #expect(allPhotos[0].isRejected == false)
     }
 
     @Test func isManualRatingDefaultsFalseForNewPhotos() throws {
@@ -134,6 +162,7 @@ import GRDB
         let fetched = try db.fetchPhoto(id: photo.id)
         #expect(fetched != nil)
         #expect(fetched?.isManualRating == false)
+        #expect(fetched?.isRejected == false)
     }
 
     @Test func deletePhoto() throws {
@@ -190,7 +219,7 @@ import GRDB
         #expect(refetched.assignedSpecies.first?.commonName == "Peregrine Falcon")
     }
 
-    @Test func deleteNonManualPhotos_preservesManualRatings() throws {
+    @Test func deleteNonManualPhotosPreservesManualRatingsAndRejections() throws {
         let dir = try makeTempDir()
         let db = try ReportDatabase(folderPath: dir)
 
@@ -203,10 +232,17 @@ import GRDB
         manualPhoto.starRating = 4
         try db.save(&manualPhoto)
 
+        var rejectedPhoto = Photo(
+            filename: "rejected.jpg",
+            filePath: "/tmp/rejected.jpg",
+            folderPath: dir.path
+        )
+        rejectedPhoto.isRejected = true
+        try db.save(&rejectedPhoto)
+
         try db.deleteNonManualPhotos()
 
         let remaining = try db.fetchAllPhotos()
-        #expect(remaining.count == 1)
-        #expect(remaining[0].filename == "manual.jpg")
+        #expect(Set(remaining.map(\.filename)) == ["manual.jpg", "rejected.jpg"])
     }
 }

--- a/app/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/app/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -361,6 +361,11 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         XCTAssertTrue(counter.exists, "Counter should remain after reject")
         let after = counter.value as? String ?? ""
         XCTAssertFalse(after.isEmpty, "Counter value should still be readable: '\(before)' -> '\(after)'")
+
+        app.typeKey(.delete, modifierFlags: .command)
+        Thread.sleep(forTimeInterval: 0.3)
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(preview.exists, "Preview should remain after bulk-delete cancel")
     }
 
     func test19_DeleteAndUndo() {

--- a/app/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/app/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -27,12 +27,15 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         XCTAssertTrue(app.staticTexts["Average"].exists)
         XCTAssertTrue(app.staticTexts["Below Average"].exists)
         XCTAssertTrue(app.staticTexts["Poor"].exists)
-        XCTAssertTrue(app.staticTexts["Reject"].exists)
+        XCTAssertTrue(app.staticTexts["0 Stars"].exists)
+        XCTAssertTrue(app.staticTexts["Rejected"].exists)
 
         // Verify descending order
         let excellent = app.staticTexts["Excellent"]
-        let reject = app.staticTexts["Reject"]
-        XCTAssertLessThan(excellent.frame.minY, reject.frame.minY)
+        let zeroStars = app.staticTexts["0 Stars"]
+        let rejected = app.staticTexts["Rejected"]
+        XCTAssertLessThan(excellent.frame.minY, zeroStars.frame.minY)
+        XCTAssertLessThan(zeroStars.frame.minY, rejected.frame.minY)
     }
 
     func test02_PreviewAndInfoBar() {
@@ -351,9 +354,8 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         preview.click()
         Thread.sleep(forTimeInterval: 0.3)
 
-        // Rejecting hides the photo (starRating = 0, isReject flag). The
-        // visible total stays the same because reject doesn't filter by default;
-        // we assert the app doesn't crash and counter is still readable.
+        // Rejection records an explicit manual decision without replacing the
+        // independent star rating.
         app.typeText("x")
         Thread.sleep(forTimeInterval: 0.5)
         XCTAssertTrue(counter.exists, "Counter should remain after reject")

--- a/app/SuperPickyUITests/CullingWorkflowUITests.swift
+++ b/app/SuperPickyUITests/CullingWorkflowUITests.swift
@@ -172,7 +172,7 @@ final class CullingWorkflowUITests: SuperPickyUITestCase {
         // auto-select-first must repopulate the active and the preview must
         // stay visible. If the new filter is empty, the empty state is the
         // correct rendering — there's nothing to auto-select.
-        for label in ["Excellent", "Reject"] {
+        for label in ["Excellent", "0 Stars"] {
             app.staticTexts[label].click()
             Thread.sleep(forTimeInterval: 0.5)
             let count = currentFilteredCount()

--- a/app/SuperPickyUITests/MockUITests.swift
+++ b/app/SuperPickyUITests/MockUITests.swift
@@ -16,6 +16,7 @@ final class MockUITests: XCTestCase {
 
         // Sidebar still shows rating labels even without photos
         XCTAssertTrue(app.staticTexts["Excellent"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["Reject"].exists)
+        XCTAssertTrue(app.staticTexts["0 Stars"].exists)
+        XCTAssertTrue(app.staticTexts["Rejected"].exists)
     }
 }

--- a/app/SuperPickyUITests/ProcessingFlowUITests.swift
+++ b/app/SuperPickyUITests/ProcessingFlowUITests.swift
@@ -90,7 +90,8 @@ final class ProcessingFlowUITests: XCTestCase {
         XCTAssertTrue(Self.app.staticTexts["Excellent"].exists)
         XCTAssertTrue(Self.app.staticTexts["Good"].exists)
         XCTAssertTrue(Self.app.staticTexts["Average"].exists)
-        XCTAssertTrue(Self.app.staticTexts["Reject"].exists)
+        XCTAssertTrue(Self.app.staticTexts["0 Stars"].exists)
+        XCTAssertTrue(Self.app.staticTexts["Rejected"].exists)
     }
 
     /// 08: Species appears in sidebar


### PR DESCRIPTION
Zero-star ratings were being used as a proxy for rejection, making an automatic or manual 0-star rating indistinguishable from the deliberate X-key rejection action.

## Changes
- Persist rejection as an independent `isRejected` culling decision without changing the photo's star rating or manual-rating provenance.
- Add separate `0 Stars` and `Rejected` sidebar filters and counts. These categories intentionally overlap, so a photo can belong to both.
- Preserve explicit rejections during reprocessing, restore rejection independently through undo, and write rejection as XMP `PickStatus=-1` while retaining the original XMP rating.
- Show rejected-state badges in preview, thumbnail, and comparison views, with English and Simplified Chinese localization.
- Add Command-Backspace to move every rejected photo in the current folder to Trash after destructive confirmation. Bulk deletion retains non-rejected photos and reconciles database, filters, selection, undo, hierarchy, and pending XMP state.
- Keep legacy zero-star rows non-rejected because the previous schema cannot prove whether 0 came from rating or rejection.

## Testing
- `scripts/pre-commit.sh`
- `zeroRatingAndRejectionCanOverlap`
- `deleteRejectedPhotosDeletesAllRejectedPhotosOnly`
- `commandDeleteRecognizesBackspaceAndForwardDelete`