### PR TITLE
Fix rejected-state migration alias recovery

### DIFF
--- a/app/SuperPickyApp/ReportDatabase.swift
+++ b/app/SuperPickyApp/ReportDatabase.swift
@@ -161,12 +161,25 @@ final class ReportDatabase: Sendable {
             }
         }
         migrator.registerMigration("v9_rejected_state") { db in
-            try db.alter(table: "photos") { t in
-                t.add(column: "isRejected", .boolean).notNull().defaults(to: false)
+            let hasRejectedColumn = try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*)
+                    FROM pragma_table_info('photos')
+                    WHERE name = 'isRejected'
+                    """
+            ) == 1
+            if !hasRejectedColumn {
+                try db.alter(table: "photos") { t in
+                    t.add(column: "isRejected", .boolean).notNull().defaults(to: false)
+                }
             }
             // Legacy zero-star rows are intentionally left non-rejected because
             // the old schema cannot prove whether the user pressed 0 or X.
-            try db.create(indexOn: "photos", columns: ["isRejected"])
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS index_photos_on_isRejected
+                ON photos(isRejected)
+            """)
         }
         try migrator.migrate(dbQueue)
     }

--- a/app/SuperPickyTests/Data/ReportDatabaseTests.swift
+++ b/app/SuperPickyTests/Data/ReportDatabaseTests.swift
@@ -154,6 +154,64 @@ import GRDB
         #expect(allPhotos[0].isRejected == false)
     }
 
+    @Test func renamedRejectedMigrationAcceptsExistingColumn() throws {
+        let tempDir = try makeTempDir()
+        let dbPath = tempDir.appendingPathComponent(".report.db").path
+        let photoID = try {
+            let db = try ReportDatabase(folderPath: tempDir)
+            var photo = Photo(
+                filename: "rejected.CR3",
+                filePath: "/tmp/rejected.CR3",
+                folderPath: tempDir.path
+            )
+            photo.isRejected = true
+            try db.save(&photo)
+            return photo.id
+        }()
+
+        do {
+            let queue = try DatabaseQueue(path: dbPath)
+            try queue.write { db in
+                try db.execute(
+                    sql: "DELETE FROM grdb_migrations WHERE identifier = 'v9_rejected_state'"
+                )
+                try db.execute(
+                    sql: "INSERT INTO grdb_migrations (identifier) VALUES ('v9_rejected')"
+                )
+                try db.execute(sql: "DROP INDEX index_photos_on_isRejected")
+            }
+        }
+
+        let reopened = try ReportDatabase(folderPath: tempDir)
+        let reopenedPhoto = try reopened.fetchPhoto(id: photoID)
+        let fetched = try #require(reopenedPhoto)
+        #expect(fetched.isRejected)
+
+        let verificationQueue = try DatabaseQueue(path: dbPath)
+        let databaseState = try verificationQueue.read { db in
+            let migrationIdentifiers = Set(try String.fetchAll(
+                db,
+                sql: """
+                    SELECT identifier
+                    FROM grdb_migrations
+                    WHERE identifier IN ('v9_rejected', 'v9_rejected_state')
+                    """
+            ))
+            let hasRejectedIndex = try Int.fetchOne(
+                db,
+                sql: """
+                    SELECT COUNT(*)
+                    FROM sqlite_master
+                    WHERE type = 'index'
+                      AND name = 'index_photos_on_isRejected'
+                    """
+            ) == 1
+            return (migrationIdentifiers, hasRejectedIndex)
+        }
+        #expect(databaseState.0 == ["v9_rejected", "v9_rejected_state"])
+        #expect(databaseState.1)
+    }
+
     @Test func isManualRatingDefaultsFalseForNewPhotos() throws {
         let tempDir = try makeTempDir()
         let db = try ReportDatabase(folderPath: tempDir)


### PR DESCRIPTION
## Summary
- make `v9_rejected_state` skip the column add when `photos.isRejected` already exists
- always recreate `index_photos_on_isRejected` with `IF NOT EXISTS`
- cover the pre-release `v9_rejected` alias state while preserving rejected rows

## Root cause and recovery
A pre-release build recorded `v9_rejected` and added `isRejected`; v0.0.9 registers `v9_rejected_state` and retried the `ALTER`, failing on the duplicate column. Reopening now records the released identifier, keeps the legacy alias and existing rejection values, and repairs the missing index. Fresh legacy rows still default to non-rejected.

## Validation
- focused `ReportDatabaseTests`
- `scripts/pre-commit.sh`