### PR TITLE
Remove stale species keywords

### DIFF
--- a/app/SuperPickyApp/AppState.swift
+++ b/app/SuperPickyApp/AppState.swift
@@ -99,6 +99,32 @@ private struct XMPFlushSummary: Sendable {
     let failedSidecarPaths: [String]
 }
 
+private func mergingSpecies(
+    _ existing: [SpeciesMatch],
+    with additions: [SpeciesMatch]
+) -> [SpeciesMatch] {
+    var merged = existing
+    for species in additions where !merged.contains(species) {
+        merged.append(species)
+    }
+    return merged
+}
+
+private struct XMPWriteRequest: Sendable {
+    var photo: Photo
+    /// Prior assignments whose keyword variants may need one-time cleanup
+    /// when this path still contains an unmarked legacy SuperPicky sidecar.
+    var legacyManagedSpecies: [SpeciesMatch]
+
+    mutating func merge(_ newer: XMPWriteRequest) {
+        photo = newer.photo
+        legacyManagedSpecies = mergingSpecies(
+            legacyManagedSpecies,
+            with: newer.legacyManagedSpecies
+        )
+    }
+}
+
 private actor PhotoMutationWorker {
     private let logger = Logger(
         subsystem: "com.halfhacked.superpicky",
@@ -173,12 +199,12 @@ private actor PhotoMutationWorker {
 ///
 /// Species edits are optimistic: SQLite is overlaid on the serialized mutation
 /// chain, but the durable XMP sidecar is written *behind* the UI. Each sidecar
-/// path retains only the latest `Photo`, so rapid edits coalesce into a single
-/// write. Failed writes stay pending (path-keyed, so a newer edit supersedes
-/// them). `flush()` drains deterministically for tests and termination — no
-/// test ever waits on the debounce timer.
+/// path retains only the latest `Photo` plus accumulated legacy-cleanup
+/// candidates, so rapid edits coalesce into a single write without losing a
+/// removed assignment. Failed writes stay pending. `flush()` drains
+/// deterministically for tests and termination — no test waits on the timer.
 private actor XMPWriteBehindQueue {
-    private var pending: [String: Photo] = [:]
+    private var pending: [String: XMPWriteRequest] = [:]
     private var debounceTask: Task<Void, Never>?
     private let debounceNanoseconds: UInt64
     private let onFlush: @Sendable (XMPFlushSummary) -> Void
@@ -191,10 +217,16 @@ private actor XMPWriteBehindQueue {
         self.onFlush = onFlush
     }
 
-    func enqueue(_ photos: [Photo]) {
-        guard !photos.isEmpty else { return }
-        for photo in photos {
-            pending[XMPWriter.sidecarURL(for: photo).path] = photo
+    func enqueue(_ requests: [XMPWriteRequest]) {
+        guard !requests.isEmpty else { return }
+        for request in requests {
+            let path = XMPWriter.sidecarURL(for: request.photo).path
+            if var existing = pending[path] {
+                existing.merge(request)
+                pending[path] = existing
+            } else {
+                pending[path] = request
+            }
         }
         scheduleDebounce()
     }
@@ -245,17 +277,20 @@ private actor XMPWriteBehindQueue {
         var succeededSidecarPaths: [String] = []
         var failedSidecarPaths: [String] = []
         var slowest = 0.0
-        for (path, photo) in batch {
+        for (path, request) in batch {
             let writeStart = SpeciesEditProfiler.now()
             do {
-                _ = try XMPWriter.write(photo: photo)
+                _ = try XMPWriter.write(
+                    photo: request.photo,
+                    legacyManagedSpecies: request.legacyManagedSpecies
+                )
                 writeCount += 1
                 succeededSidecarPaths.append(path)
             } catch {
                 // Keep the failed write pending unless a newer edit already
                 // superseded this path during the (non-suspending) loop.
-                if pending[path] == nil { pending[path] = photo }
-                failedPhotos.append(photo)
+                if pending[path] == nil { pending[path] = request }
+                failedPhotos.append(request.photo)
                 failedSidecarPaths.append(path)
             }
             slowest = max(slowest, SpeciesEditProfiler.elapsedMilliseconds(since: writeStart))
@@ -1089,7 +1124,11 @@ final class AppState {
                 previousIsManualRating: photo.isManualRating,
                 previousAssignedSpecies: before
             ))
-            snapshots.append(SpeciesSnapshot(id: photo.id, species: after))
+            snapshots.append(SpeciesSnapshot(
+                id: photo.id,
+                species: after,
+                previousSpecies: before
+            ))
             pendingOptimisticSpecies[photo.id] = (generation, after)
         }
 
@@ -1185,7 +1224,10 @@ final class AppState {
                 database: context.database,
                 snapshots: snapshots
             )
-            await xmpQueue.enqueue(result.written)
+            await xmpQueue.enqueue(xmpWriteRequests(
+                for: result.written,
+                snapshots: snapshots
+            ))
             clearOptimisticState(for: snapshots, upTo: generation)
             if var profile {
                 profile.persistedPhotoCount = result.written.count
@@ -1202,6 +1244,28 @@ final class AppState {
                 lastSpeciesEditProfile = profile
             }
             logger.error("species persistence failed (\(operation)): \(error)")
+        }
+    }
+
+    private func xmpWriteRequests(
+        for photos: [Photo],
+        snapshots: [SpeciesSnapshot]
+    ) -> [XMPWriteRequest] {
+        let snapshotsByID = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0) })
+        return photos.compactMap { photo in
+            guard let snapshot = snapshotsByID[photo.id] else { return nil }
+            var legacySpecies = snapshot.previousSpecies
+            if let failed = failedSpeciesEdits[photo.id],
+               failed.folder.path == photo.folderPath {
+                legacySpecies = mergingSpecies(
+                    failed.snapshot.previousSpecies,
+                    with: legacySpecies
+                )
+            }
+            return XMPWriteRequest(
+                photo: photo,
+                legacyManagedSpecies: legacySpecies
+            )
         }
     }
 
@@ -1225,15 +1289,25 @@ final class AppState {
         generation: Int
     ) {
         for snapshot in snapshots {
-            // Only supersede an older failure — a newer edit's failure wins.
-            if let existing = failedSpeciesEdits[snapshot.id], existing.generation > generation {
-                continue
+            var retainedSnapshot = snapshot
+            if let existing = failedSpeciesEdits[snapshot.id] {
+                // The newest desired state wins, but every prior assignment is
+                // retained so a later retry can clean all legacy keywords.
+                guard existing.generation <= generation else { continue }
+                retainedSnapshot = SpeciesSnapshot(
+                    id: snapshot.id,
+                    species: snapshot.species,
+                    previousSpecies: mergingSpecies(
+                        existing.snapshot.previousSpecies,
+                        with: snapshot.previousSpecies
+                    )
+                )
             }
             failedSpeciesEdits[snapshot.id] = FailedSpeciesEdit(
                 generation: generation,
                 folder: context.folder,
                 database: context.database,
-                snapshot: snapshot
+                snapshot: retainedSnapshot
             )
         }
         speciesPersistenceFailureMessage = Self.persistenceFailureMessage
@@ -1311,7 +1385,10 @@ final class AppState {
                         database: group.database,
                         snapshots: group.snapshots
                     )
-                    await state.xmpQueue.enqueue(result.written)
+                    await state.xmpQueue.enqueue(state.xmpWriteRequests(
+                        for: result.written,
+                        snapshots: group.snapshots
+                    ))
                     for id in group.ids {
                         if let failed = state.failedSpeciesEdits[id],
                            failed.generation <= group.maxGeneration {
@@ -1428,7 +1505,8 @@ final class AppState {
                     }
                     snapshots.append(SpeciesSnapshot(
                         id: previous.id,
-                        species: entry.previousAssignedSpecies
+                        species: entry.previousAssignedSpecies,
+                        previousSpecies: previous.assignedSpecies
                     ))
                     pendingOptimisticSpecies[previous.id] = (
                         generation,

--- a/app/SuperPickyApp/AppState.swift
+++ b/app/SuperPickyApp/AppState.swift
@@ -112,15 +112,14 @@ private func mergingSpecies(
 
 private struct XMPWriteRequest: Sendable {
     var photo: Photo
-    /// Prior assignments whose keyword variants may need one-time cleanup
-    /// when this path still contains an unmarked legacy SuperPicky sidecar.
-    var legacyManagedSpecies: [SpeciesMatch]
+    /// Prior assignments whose keyword variants must be removed.
+    var replacedSpecies: [SpeciesMatch]
 
     mutating func merge(_ newer: XMPWriteRequest) {
         photo = newer.photo
-        legacyManagedSpecies = mergingSpecies(
-            legacyManagedSpecies,
-            with: newer.legacyManagedSpecies
+        replacedSpecies = mergingSpecies(
+            replacedSpecies,
+            with: newer.replacedSpecies
         )
     }
 }
@@ -199,9 +198,9 @@ private actor PhotoMutationWorker {
 ///
 /// Species edits are optimistic: SQLite is overlaid on the serialized mutation
 /// chain, but the durable XMP sidecar is written *behind* the UI. Each sidecar
-/// path retains only the latest `Photo` plus accumulated legacy-cleanup
-/// candidates, so rapid edits coalesce into a single write without losing a
-/// removed assignment. Failed writes stay pending. `flush()` drains
+/// path retains only the latest `Photo` plus every replaced assignment, so
+/// rapid edits coalesce without losing keywords that must be removed. Failed
+/// writes stay pending. `flush()` drains
 /// deterministically for tests and termination — no test waits on the timer.
 private actor XMPWriteBehindQueue {
     private var pending: [String: XMPWriteRequest] = [:]
@@ -282,7 +281,7 @@ private actor XMPWriteBehindQueue {
             do {
                 _ = try XMPWriter.write(
                     photo: request.photo,
-                    legacyManagedSpecies: request.legacyManagedSpecies
+                    replacingSpecies: request.replacedSpecies
                 )
                 writeCount += 1
                 succeededSidecarPaths.append(path)
@@ -1254,17 +1253,17 @@ final class AppState {
         let snapshotsByID = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0) })
         return photos.compactMap { photo in
             guard let snapshot = snapshotsByID[photo.id] else { return nil }
-            var legacySpecies = snapshot.previousSpecies
+            var replacedSpecies = snapshot.previousSpecies
             if let failed = failedSpeciesEdits[photo.id],
                failed.folder.path == photo.folderPath {
-                legacySpecies = mergingSpecies(
+                replacedSpecies = mergingSpecies(
                     failed.snapshot.previousSpecies,
-                    with: legacySpecies
+                    with: replacedSpecies
                 )
             }
             return XMPWriteRequest(
                 photo: photo,
-                legacyManagedSpecies: legacySpecies
+                replacedSpecies: replacedSpecies
             )
         }
     }
@@ -1291,8 +1290,8 @@ final class AppState {
         for snapshot in snapshots {
             var retainedSnapshot = snapshot
             if let existing = failedSpeciesEdits[snapshot.id] {
-                // The newest desired state wins, but every prior assignment is
-                // retained so a later retry can clean all legacy keywords.
+                // The newest desired state wins, but every replaced assignment
+                // is retained so a later retry can remove all of its keywords.
                 guard existing.generation <= generation else { continue }
                 retainedSnapshot = SpeciesSnapshot(
                     id: snapshot.id,

--- a/app/SuperPickyApp/ReportDatabase.swift
+++ b/app/SuperPickyApp/ReportDatabase.swift
@@ -12,8 +12,8 @@ struct PhotoMutationResult: Sendable {
 struct SpeciesSnapshot: Sendable {
     let id: UUID
     let species: [SpeciesMatch]
-    /// Assignment replaced by this snapshot. Used only to migrate keywords
-    /// from sidecars written before SuperPicky tracked keyword ownership.
+    /// Assignment replaced by this snapshot. Its keyword variants are removed
+    /// before the desired species keywords are written.
     let previousSpecies: [SpeciesMatch]
 }
 

--- a/app/SuperPickyApp/ReportDatabase.swift
+++ b/app/SuperPickyApp/ReportDatabase.swift
@@ -12,6 +12,9 @@ struct PhotoMutationResult: Sendable {
 struct SpeciesSnapshot: Sendable {
     let id: UUID
     let species: [SpeciesMatch]
+    /// Assignment replaced by this snapshot. Used only to migrate keywords
+    /// from sidecars written before SuperPicky tracked keyword ownership.
+    let previousSpecies: [SpeciesMatch]
 }
 
 final class ReportDatabase: Sendable {

--- a/app/SuperPickyApp/XMPWriter.swift
+++ b/app/SuperPickyApp/XMPWriter.swift
@@ -114,7 +114,7 @@ struct XMPWriter {
     /// Returns the URL of the written .xmp file.
     static func write(
         photo: Photo,
-        legacyManagedSpecies: [SpeciesMatch] = []
+        replacingSpecies: [SpeciesMatch] = []
     ) throws -> URL {
         let url = sidecarURL(for: photo)
         let data: Data
@@ -123,7 +123,7 @@ struct XMPWriter {
             data = try merge(
                 photo: photo,
                 into: existing,
-                legacyManagedSpecies: legacyManagedSpecies
+                replacingSpecies: replacingSpecies
             )
         } else {
             guard let generated = generate(photo: photo).data(using: .utf8) else {
@@ -177,7 +177,7 @@ struct XMPWriter {
     private static func merge(
         photo: Photo,
         into data: Data,
-        legacyManagedSpecies: [SpeciesMatch]
+        replacingSpecies: [SpeciesMatch]
     ) throws -> Data {
         let document = try XMLDocument(data: data, options: [.nodePreserveAll])
         let descriptions = descendantElements(
@@ -188,7 +188,6 @@ struct XMPWriter {
         guard let primaryDescription = descriptions.first else {
             throw MergeError.missingDescription
         }
-        let isLegacySidecar = isLegacySuperPickySidecar(descriptions: descriptions)
 
         setSimpleProperty(
             localName: "Rating",
@@ -216,15 +215,11 @@ struct XMPWriter {
             descriptions: descriptions
         )
         let assigned = photo.assignedSpecies
-        let legacySpecies = legacyManagedSpecies + assigned.filter {
-            !legacyManagedSpecies.contains($0)
-        }
-        let legacyFlat = isLegacySidecar
-            ? keywordBag(for: legacySpecies, isFlying: photo.isFlying)
-            : []
-        let legacyHierarchical = isLegacySidecar
-            ? hierarchicalBag(for: legacySpecies, isFlying: photo.isFlying)
-            : []
+        let replacedFlat = keywordBag(for: replacingSpecies, isFlying: photo.isFlying)
+        let replacedHierarchical = hierarchicalBag(
+            for: replacingSpecies,
+            isFlying: photo.isFlying
+        )
         let desiredFlat = keywordBag(for: assigned, isFlying: photo.isFlying)
         let desiredHierarchical = hierarchicalBag(for: assigned, isFlying: photo.isFlying)
         let managedFlat = try updateKeywordBag(
@@ -232,7 +227,7 @@ struct XMPWriter {
             propertyURI: dcURI,
             preferredPrefix: "dc",
             desired: desiredFlat,
-            previouslyManaged: previousFlat ?? legacyFlat,
+            removing: (previousFlat ?? []) + replacedFlat,
             descriptions: descriptions,
             fallback: primaryDescription
         )
@@ -241,7 +236,7 @@ struct XMPWriter {
             propertyURI: lrURI,
             preferredPrefix: "lr",
             desired: desiredHierarchical,
-            previouslyManaged: previousHierarchical ?? legacyHierarchical,
+            removing: (previousHierarchical ?? []) + replacedHierarchical,
             descriptions: descriptions,
             fallback: primaryDescription
         )
@@ -311,7 +306,7 @@ struct XMPWriter {
         propertyURI: String,
         preferredPrefix: String,
         desired: [String],
-        previouslyManaged: [String]?,
+        removing: [String],
         descriptions: [XMLElement],
         fallback: XMLElement
     ) throws -> [String] {
@@ -348,17 +343,13 @@ struct XMPWriter {
             fallback.addChild(property)
         }
 
-        if let previouslyManaged {
-            var remainingCounts = previouslyManaged.reduce(into: [String: Int]()) {
-                $0[$1, default: 0] += 1
-            }
+        if !removing.isEmpty {
+            let removedValues = Set(removing)
             let items = directElements(in: bag, localName: "li", uri: rdfURI)
             for item in items.reversed() {
                 guard let value = item.stringValue,
-                      let count = remainingCounts[value],
-                      count > 0 else { continue }
+                      removedValues.contains(value) else { continue }
                 item.detach()
-                remainingCounts[value] = count - 1
             }
         }
 
@@ -369,10 +360,12 @@ struct XMPWriter {
         var managed: [String] = []
         let owner = property.parent as? XMLElement ?? fallback
         let rdfPrefix = ensureNamespace("rdf", uri: rdfURI, on: owner)
-        for value in desired where present.insert(value).inserted {
-            let item = XMLElement(name: "\(rdfPrefix):li", uri: rdfURI)
-            item.stringValue = value
-            bag.addChild(item)
+        for value in desired {
+            if present.insert(value).inserted {
+                let item = XMLElement(name: "\(rdfPrefix):li", uri: rdfURI)
+                item.stringValue = value
+                bag.addChild(item)
+            }
             managed.append(value)
         }
         return managed
@@ -458,34 +451,6 @@ struct XMPWriter {
             separator: "\0",
             omittingEmptySubsequences: false
         ).map(String.init)
-    }
-
-    private static func isLegacySuperPickySidecar(
-        descriptions: [XMLElement]
-    ) -> Bool {
-        let hasManagedProperties = descriptions.contains {
-            namespacedAttribute(
-                in: $0,
-                localName: managedSubjectName,
-                uri: superPickyURI
-            ) != nil || namespacedAttribute(
-                in: $0,
-                localName: managedHierarchicalSubjectName,
-                uri: superPickyURI
-            ) != nil
-        }
-        guard !hasManagedProperties else { return false }
-
-        // PickStatus was emitted by every pre-ownership SuperPicky sidecar and
-        // is not an Adobe XMP property. It lets us migrate only our old files
-        // without claiming matching keywords from arbitrary existing sidecars.
-        return descriptions.contains {
-            namespacedAttribute(
-                in: $0,
-                localName: "PickStatus",
-                uri: xmpURI
-            ) != nil
-        }
     }
 
     private static func encodeManaged(_ values: [String]) -> String {

--- a/app/SuperPickyApp/XMPWriter.swift
+++ b/app/SuperPickyApp/XMPWriter.swift
@@ -112,12 +112,19 @@ struct XMPWriter {
 
     /// Write XMP sidecar file next to the original.
     /// Returns the URL of the written .xmp file.
-    static func write(photo: Photo) throws -> URL {
+    static func write(
+        photo: Photo,
+        legacyManagedSpecies: [SpeciesMatch] = []
+    ) throws -> URL {
         let url = sidecarURL(for: photo)
         let data: Data
         if FileManager.default.fileExists(atPath: url.path) {
             let existing = try Data(contentsOf: url)
-            data = try merge(photo: photo, into: existing)
+            data = try merge(
+                photo: photo,
+                into: existing,
+                legacyManagedSpecies: legacyManagedSpecies
+            )
         } else {
             guard let generated = generate(photo: photo).data(using: .utf8) else {
                 throw MergeError.encodingFailed
@@ -167,7 +174,11 @@ struct XMPWriter {
 
     // MARK: - Private
 
-    private static func merge(photo: Photo, into data: Data) throws -> Data {
+    private static func merge(
+        photo: Photo,
+        into data: Data,
+        legacyManagedSpecies: [SpeciesMatch]
+    ) throws -> Data {
         let document = try XMLDocument(data: data, options: [.nodePreserveAll])
         let descriptions = descendantElements(
             in: document,
@@ -177,6 +188,7 @@ struct XMPWriter {
         guard let primaryDescription = descriptions.first else {
             throw MergeError.missingDescription
         }
+        let isLegacySidecar = isLegacySuperPickySidecar(descriptions: descriptions)
 
         setSimpleProperty(
             localName: "Rating",
@@ -204,6 +216,15 @@ struct XMPWriter {
             descriptions: descriptions
         )
         let assigned = photo.assignedSpecies
+        let legacySpecies = legacyManagedSpecies + assigned.filter {
+            !legacyManagedSpecies.contains($0)
+        }
+        let legacyFlat = isLegacySidecar
+            ? keywordBag(for: legacySpecies, isFlying: photo.isFlying)
+            : []
+        let legacyHierarchical = isLegacySidecar
+            ? hierarchicalBag(for: legacySpecies, isFlying: photo.isFlying)
+            : []
         let desiredFlat = keywordBag(for: assigned, isFlying: photo.isFlying)
         let desiredHierarchical = hierarchicalBag(for: assigned, isFlying: photo.isFlying)
         let managedFlat = try updateKeywordBag(
@@ -211,7 +232,7 @@ struct XMPWriter {
             propertyURI: dcURI,
             preferredPrefix: "dc",
             desired: desiredFlat,
-            previouslyManaged: previousFlat,
+            previouslyManaged: previousFlat ?? legacyFlat,
             descriptions: descriptions,
             fallback: primaryDescription
         )
@@ -220,7 +241,7 @@ struct XMPWriter {
             propertyURI: lrURI,
             preferredPrefix: "lr",
             desired: desiredHierarchical,
-            previouslyManaged: previousHierarchical,
+            previouslyManaged: previousHierarchical ?? legacyHierarchical,
             descriptions: descriptions,
             fallback: primaryDescription
         )
@@ -437,6 +458,34 @@ struct XMPWriter {
             separator: "\0",
             omittingEmptySubsequences: false
         ).map(String.init)
+    }
+
+    private static func isLegacySuperPickySidecar(
+        descriptions: [XMLElement]
+    ) -> Bool {
+        let hasManagedProperties = descriptions.contains {
+            namespacedAttribute(
+                in: $0,
+                localName: managedSubjectName,
+                uri: superPickyURI
+            ) != nil || namespacedAttribute(
+                in: $0,
+                localName: managedHierarchicalSubjectName,
+                uri: superPickyURI
+            ) != nil
+        }
+        guard !hasManagedProperties else { return false }
+
+        // PickStatus was emitted by every pre-ownership SuperPicky sidecar and
+        // is not an Adobe XMP property. It lets us migrate only our old files
+        // without claiming matching keywords from arbitrary existing sidecars.
+        return descriptions.contains {
+            namespacedAttribute(
+                in: $0,
+                localName: "PickStatus",
+                uri: xmpURI
+            ) != nil
+        }
     }
 
     private static func encodeManaged(_ values: [String]) -> String {

--- a/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
+++ b/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
@@ -813,7 +813,7 @@ struct AppStateBatchMutationTests {
         #expect(app.speciesXMPFlushToken > flushTokenBefore)
     }
 
-    @Test func removingSpeciesCleansLegacySidecarAndPreservesUserKeywords() async throws {
+    @Test func removingSpeciesDeletesMatchingKeywordsAndPreservesUnrelatedKeywords() async throws {
         let folder = try makeTempFolder()
         defer { try? FileManager.default.removeItem(at: folder) }
         let eagle = match("eagle")
@@ -824,11 +824,8 @@ struct AppStateBatchMutationTests {
         <x:xmpmeta xmlns:x="adobe:ns:meta/">
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
             <rdf:Description
-              xmlns:xmp="http://ns.adobe.com/xap/1.0/"
               xmlns:dc="http://purl.org/dc/elements/1.1/"
-              xmlns:lr="http://ns.adobe.com/lightroom/1.0/"
-              xmp:Rating="4"
-              xmp:PickStatus="0">
+              xmlns:lr="http://ns.adobe.com/lightroom/1.0/">
               <dc:subject>
                 <rdf:Bag>
                   <rdf:li>Portfolio</rdf:li>

--- a/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
+++ b/app/SuperPickyTests/Core/AppStateBatchMutationTests.swift
@@ -813,6 +813,52 @@ struct AppStateBatchMutationTests {
         #expect(app.speciesXMPFlushToken > flushTokenBefore)
     }
 
+    @Test func removingSpeciesCleansLegacySidecarAndPreservesUserKeywords() async throws {
+        let folder = try makeTempFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let eagle = match("eagle")
+        let photo = try seedPhoto(filename: "legacy.CR3", species: eagle, into: folder)
+        let sidecar = XMPWriter.sidecarURL(for: photo)
+        let legacy = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <rdf:Description
+              xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+              xmlns:dc="http://purl.org/dc/elements/1.1/"
+              xmlns:lr="http://ns.adobe.com/lightroom/1.0/"
+              xmp:Rating="4"
+              xmp:PickStatus="0">
+              <dc:subject>
+                <rdf:Bag>
+                  <rdf:li>Portfolio</rdf:li>
+                  <rdf:li>Eagle</rdf:li>
+                  <rdf:li>Genus eagle</rdf:li>
+                </rdf:Bag>
+              </dc:subject>
+              <lr:hierarchicalSubject>
+                <rdf:Bag>
+                  <rdf:li>Bird|Eagle</rdf:li>
+                </rdf:Bag>
+              </lr:hierarchicalSubject>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+        """
+        try Data(legacy.utf8).write(to: sidecar)
+        let app = AppState()
+        app.loadPhotos(for: folder)
+
+        await app.removeSpecies(ids: [photo.id], species: eagle).value
+        await app.flushPendingPersistence()
+
+        let content = try String(contentsOf: sidecar, encoding: .utf8)
+        #expect(content.contains("<rdf:li>Portfolio</rdf:li>"))
+        #expect(!content.contains("<rdf:li>Eagle</rdf:li>"))
+        #expect(!content.contains("<rdf:li>Genus eagle</rdf:li>"))
+        #expect(!content.contains("<rdf:li>Bird|Eagle</rdf:li>"))
+    }
+
     // MARK: - Retryable XMP failure
 
     @Test func xmpWriteFailureIsRetryableAndKeepsOptimisticState() async throws {

--- a/app/SuperPickyTests/Core/XMPWriterTests.swift
+++ b/app/SuperPickyTests/Core/XMPWriterTests.swift
@@ -241,7 +241,7 @@ import Foundation
         }
     }
 
-    @Test func existingMatchingKeywordRemainsUserOwned() throws {
+    @Test func existingMatchingSpeciesKeywordBecomesSuperPickyManaged() throws {
         try withTempDir { tempDir in
             let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
             let sidecarURL = tempDir.appendingPathComponent("IMG_5678.xmp")
@@ -252,6 +252,7 @@ import Foundation
                 <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
                   <dc:subject>
                     <rdf:Bag>
+                      <rdf:li>Portfolio</rdf:li>
                       <rdf:li>Robin</rdf:li>
                     </rdf:Bag>
                   </dc:subject>
@@ -275,13 +276,14 @@ import Foundation
             _ = try XMPWriter.write(photo: photo)
 
             let content = try String(contentsOf: sidecarURL, encoding: .utf8)
-            #expect(content.contains("<rdf:li>Robin</rdf:li>"))
+            #expect(content.contains("<rdf:li>Portfolio</rdf:li>"))
+            #expect(!content.contains("<rdf:li>Robin</rdf:li>"))
             #expect(content.contains("<rdf:li>Osprey</rdf:li>"))
             #expect(!content.contains("<rdf:li>Turdus migratorius</rdf:li>"))
         }
     }
 
-    @Test func removingSpeciesCleansKeywordsFromLegacySuperPickySidecar() throws {
+    @Test func removingSpeciesDeletesAllMatchingKeywordsFromExistingSidecar() throws {
         try withTempDir { tempDir in
             let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
             let sidecarURL = tempDir.appendingPathComponent("IMG_5678.xmp")
@@ -290,13 +292,12 @@ import Foundation
             <x:xmpmeta xmlns:x="adobe:ns:meta/">
               <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
                 <rdf:Description
-                  xmlns:xmp="http://ns.adobe.com/xap/1.0/"
                   xmlns:dc="http://purl.org/dc/elements/1.1/"
-                  xmlns:lr="http://ns.adobe.com/lightroom/1.0/"
-                  xmp:Rating="4"
-                  xmp:PickStatus="0">
+                  xmlns:lr="http://ns.adobe.com/lightroom/1.0/">
                   <dc:subject>
                     <rdf:Bag>
+                      <rdf:li>Portfolio</rdf:li>
+                      <rdf:li>Robin</rdf:li>
                       <rdf:li>Robin</rdf:li>
                       <rdf:li>Turdus migratorius</rdf:li>
                     </rdf:Bag>
@@ -312,7 +313,7 @@ import Foundation
             """
             try Data(legacy.utf8).write(to: sidecarURL)
 
-            let legacySpecies = SpeciesMatch(
+            let removedSpecies = SpeciesMatch(
                 scientificName: "Turdus migratorius",
                 commonName: "Robin",
                 confidence: 0.9,
@@ -328,10 +329,11 @@ import Foundation
             )
             _ = try XMPWriter.write(
                 photo: photo,
-                legacyManagedSpecies: [legacySpecies]
+                replacingSpecies: [removedSpecies]
             )
 
             let content = try String(contentsOf: sidecarURL, encoding: .utf8)
+            #expect(content.contains("<rdf:li>Portfolio</rdf:li>"))
             #expect(!content.contains("<rdf:li>Robin</rdf:li>"))
             #expect(!content.contains("<rdf:li>Turdus migratorius</rdf:li>"))
             #expect(!content.contains("<rdf:li>Bird|Robin</rdf:li>"))

--- a/app/SuperPickyTests/Core/XMPWriterTests.swift
+++ b/app/SuperPickyTests/Core/XMPWriterTests.swift
@@ -281,6 +281,63 @@ import Foundation
         }
     }
 
+    @Test func removingSpeciesCleansKeywordsFromLegacySuperPickySidecar() throws {
+        try withTempDir { tempDir in
+            let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path
+            let sidecarURL = tempDir.appendingPathComponent("IMG_5678.xmp")
+            let legacy = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <x:xmpmeta xmlns:x="adobe:ns:meta/">
+              <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description
+                  xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+                  xmlns:dc="http://purl.org/dc/elements/1.1/"
+                  xmlns:lr="http://ns.adobe.com/lightroom/1.0/"
+                  xmp:Rating="4"
+                  xmp:PickStatus="0">
+                  <dc:subject>
+                    <rdf:Bag>
+                      <rdf:li>Robin</rdf:li>
+                      <rdf:li>Turdus migratorius</rdf:li>
+                    </rdf:Bag>
+                  </dc:subject>
+                  <lr:hierarchicalSubject>
+                    <rdf:Bag>
+                      <rdf:li>Bird|Robin</rdf:li>
+                    </rdf:Bag>
+                  </lr:hierarchicalSubject>
+                </rdf:Description>
+              </rdf:RDF>
+            </x:xmpmeta>
+            """
+            try Data(legacy.utf8).write(to: sidecarURL)
+
+            let legacySpecies = SpeciesMatch(
+                scientificName: "Turdus migratorius",
+                commonName: "Robin",
+                confidence: 0.9,
+                cnName: nil,
+                pinyin: nil,
+                thresholdUsed: nil,
+                ebirdCode: "amerob"
+            )
+            let photo = makePhoto(
+                filename: "IMG_5678.CR3",
+                filePath: filePath,
+                starRating: 4
+            )
+            _ = try XMPWriter.write(
+                photo: photo,
+                legacyManagedSpecies: [legacySpecies]
+            )
+
+            let content = try String(contentsOf: sidecarURL, encoding: .utf8)
+            #expect(!content.contains("<rdf:li>Robin</rdf:li>"))
+            #expect(!content.contains("<rdf:li>Turdus migratorius</rdf:li>"))
+            #expect(!content.contains("<rdf:li>Bird|Robin</rdf:li>"))
+        }
+    }
+
     @Test func writeUpdatesLocationWithoutRemovingDevelopSettings() throws {
         try withTempDir { tempDir in
             let filePath = tempDir.appendingPathComponent("IMG_5678.CR3").path


### PR DESCRIPTION
SuperPicky should fully own species metadata. Removing or replacing a species must remove every corresponding XMP keyword, regardless of whether that exact keyword already existed in the sidecar.

## What changed

- Remove all flat and hierarchical keyword variants for replaced species, including duplicate entries.
- Mark every currently assigned species keyword as SuperPicky-managed, even when the value was already present.
- Carry replaced species through write-behind coalescing, persistence failures, and retries so rapid edits cannot leave stale keywords.
- Preserve unrelated keywords such as `Portfolio`.
- Add writer-level and end-to-end regression coverage.

## Tests

- `XMPWriterTests`
- `AppStateBatchMutationTests`
- SwiftLint strict checks