### PR TITLE
Keep last image selected after rejection

### DIFF
--- a/app/SuperPickyApp/ContentView.swift
+++ b/app/SuperPickyApp/ContentView.swift
@@ -430,7 +430,7 @@ struct ContentView: View {
             return true
         case "x":
             guard !ids.isEmpty else { return false }
-            if !isMulti { navigatePhoto(direction: 1, fallbackToPrevious: true) }
+            if !isMulti { navigatePhoto(direction: 1) }
             appState.setPickStatus(ids: ids, status: .rejected)
             return true
         case "0", "1", "2", "3", "4", "5":

--- a/app/SuperPickyUITests/BatchSelectionUITests.swift
+++ b/app/SuperPickyUITests/BatchSelectionUITests.swift
@@ -140,6 +140,30 @@ final class BatchSelectionUITests: SuperPickyUITestCase {
         XCTAssertEqual(a11ySelection(of: names[2]), "active")
     }
 
+    func testRejectingLastThumbnailKeepsItActive() {
+        let names = fixtureFilenames()
+        guard let last = names.last else {
+            XCTFail("Need at least one fixture")
+            return
+        }
+        clickThumbnail(last)
+
+        app.typeKey("x", modifierFlags: [])
+
+        let remainsActive = XCTNSPredicateExpectation(
+            predicate: NSPredicate(
+                format: "value == %@",
+                A11y.ThumbnailSelection.active.rawValue
+            ),
+            object: thumbnail(last)
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [remainsActive], timeout: 2),
+            .completed,
+            "Rejecting the last thumbnail should leave it active"
+        )
+    }
+
     func testBatchPickSetsAllSelectedPhotos() throws {
         let names = fixtureFilenames()
         guard names.count >= 3 else { return }


### PR DESCRIPTION
Rejecting the final image in the filmstrip moved selection backward to the second-to-last image, disrupting culling at the end of the strip.

## Changes
- Keep the current image selected when rejection has no next image.
- Preserve normal forward advancement when another image follows.
- Add UI regression coverage for rejecting the final thumbnail.

## Testing
- `BatchSelectionUITests`
- G1 static checks and L1 unit tests